### PR TITLE
Enhance Download Pipeline Reliability and Naming Convention

### DIFF
--- a/android/app/src/main/kotlin/com/debrify/app/download/MediaStoreDownloadService.kt
+++ b/android/app/src/main/kotlin/com/debrify/app/download/MediaStoreDownloadService.kt
@@ -277,7 +277,6 @@ class MediaStoreDownloadService : Service() {
 					))
 					states.remove(state.taskId)
 					notificationManager.cancel(taskNotificationId(state.taskId))
-					checkIfIdleAndStop()
 					break
 				} else if (resp !in 200..206) {
 					throw IllegalStateException("HTTP $resp for $url")
@@ -394,10 +393,8 @@ class MediaStoreDownloadService : Service() {
 					))
 					states.remove(state.taskId)
 					notificationManager.cancel(taskNotificationId(state.taskId))
-					checkIfIdleAndStop()
 				} else {
 					notifyTask(state, "Paused", indeterminate = false, completed = false)
-					updateSummaryNotification()
 				}
 				break // Success or pause exit
 			} catch (e: Exception) {
@@ -415,12 +412,12 @@ class MediaStoreDownloadService : Service() {
 						"url" to state.url,
 					))
 					states.remove(state.taskId)
-					checkIfIdleAndStop()
 					break
 				}
 				
 				val delay = (1000L * (1L shl (retryCount - 1))).coerceIn(2000L, 30000L)
 				notifyTask(state, "Retrying ($retryCount/$maxRetries)...", indeterminate = true, completed = false)
+				// Safe to sleep here as startOrResume is always called within a dedicated background Thread
 				try { Thread.sleep(delay) } catch (_: Exception) {}
 				// continue to retry connection
 			} finally {

--- a/android/app/src/main/kotlin/com/debrify/app/download/MediaStoreDownloadService.kt
+++ b/android/app/src/main/kotlin/com/debrify/app/download/MediaStoreDownloadService.kt
@@ -188,178 +188,163 @@ class MediaStoreDownloadService : Service() {
 		if (state.running) return
 		state.running = true
 		var uri: Uri? = state.uri
-		var connection: HttpURLConnection? = null
-		var input: InputStream? = null
-		var out: BufferedOutputStream? = null
-		var outPfd: ParcelFileDescriptor? = null
-		var outChannel: FileChannel? = null
-		try {
-			if (uri == null) {
-				val values = ContentValues().apply {
-					put(MediaStore.Downloads.DISPLAY_NAME, state.fileName)
-					put(MediaStore.Downloads.MIME_TYPE, state.mimeType)
-					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-						put(MediaStore.Downloads.RELATIVE_PATH, "Download/${state.subDir}")
-						put(MediaStore.Downloads.IS_PENDING, 1)
+		
+		var retryCount = 0
+		val maxRetries = 10 // Resilient against handoffs
+
+		while (retryCount <= maxRetries && !state.canceled && !state.paused) {
+			var connection: HttpURLConnection? = null
+			var input: InputStream? = null
+			var out: BufferedOutputStream? = null
+			var outPfd: ParcelFileDescriptor? = null
+			var outChannel: FileChannel? = null
+			
+			try {
+				if (uri == null) {
+					val values = ContentValues().apply {
+						put(MediaStore.Downloads.DISPLAY_NAME, state.fileName)
+						put(MediaStore.Downloads.MIME_TYPE, state.mimeType)
+						if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+							put(MediaStore.Downloads.RELATIVE_PATH, "Download/${state.subDir}")
+							put(MediaStore.Downloads.IS_PENDING, 1)
+						}
+					}
+					uri = contentResolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
+					if (uri == null) {
+						notifyTask(state, "Failed to create destination", indeterminate = true, completed = false)
+						ChannelBridge.emit(mapOf("type" to "error", "taskId" to state.taskId, "message" to "no destination"))
+						break
+					}
+					state.uri = uri
+					ChannelBridge.emit(mapOf("type" to "started", "taskId" to state.taskId, "fileName" to state.fileName, "subDir" to state.subDir))
+				}
+
+				// Always confirm bytes already written on disk
+				uri?.let { confirmed ->
+					val onDisk = existingSize(confirmed)
+					if (onDisk > 0L) state.downloaded = onDisk
+				}
+
+				val url = URL(state.url)
+				connection = (url.openConnection() as HttpURLConnection).apply {
+					instanceFollowRedirects = true
+					connectTimeout = 15000
+					readTimeout = 15000
+					doInput = true
+					state.headers.forEach { (k, v) -> setRequestProperty(k, v) }
+					if (state.downloaded > 0L) {
+						setRequestProperty("Range", "bytes=${state.downloaded}-")
+						state.etag?.let { setRequestProperty("If-Range", it) }
 					}
 				}
-				uri = contentResolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
-				if (uri == null) {
-					notifyTask(state, "Failed to create destination", indeterminate = true, completed = false)
-					ChannelBridge.emit(mapOf("type" to "error", "taskId" to state.taskId, "message" to "no destination"))
-					stopSelfSafely(); return
-				}
-				state.uri = uri
-				ChannelBridge.emit(mapOf("type" to "started", "taskId" to state.taskId, "fileName" to state.fileName, "subDir" to state.subDir))
-			}
+				connection.connect()
+				state.connection = connection
 
-			// Always confirm bytes already written on disk
-			uri?.let { confirmed ->
-				val onDisk = existingSize(confirmed)
-				if (onDisk > 0L) state.downloaded = onDisk
-			}
+				val resp = connection.responseCode
+				// Handle resume edge cases before opening output stream
+				if (state.downloaded > 0L && resp == HttpURLConnection.HTTP_OK) {
+					// Server ignored Range; restart from 0 by truncating existing file
+					state.downloaded = 0L
+					if (uri != null) {
+						try {
+							val pfd = contentResolver.openFileDescriptor(uri!!, "rw")
+							val fos = FileOutputStream(pfd!!.fileDescriptor)
+							val channel: FileChannel = fos.channel
+							channel.truncate(0)
+							channel.position(0)
+							fos.close()
+							pfd.close()
+						} catch (_: Exception) {}
+					}
+				} else if (state.downloaded > 0L && resp == 416) {
+					// 416: already fully downloaded on server side; treat as complete
+					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+						val done = ContentValues().apply { put(MediaStore.Downloads.IS_PENDING, 0) }
+						contentResolver.update(uri!!, done, null, null)
+					}
+					notifyTask(state, "Download complete", indeterminate = false, completed = true)
+					ChannelBridge.emit(mapOf(
+						"type" to "complete",
+						"taskId" to state.taskId,
+						"bytes" to state.total,
+						"total" to state.total,
+						"fileName" to state.fileName,
+						"subDir" to state.subDir,
+						"url" to state.url,
+						"contentUri" to (uri?.toString() ?: ""),
+						"mimeType" to state.mimeType,
+					))
+					states.remove(state.taskId)
+					notificationManager.cancel(taskNotificationId(state.taskId))
+					if (states.isEmpty()) {
+						stopForeground(STOP_FOREGROUND_REMOVE)
+						notificationManager.cancel(SERVICE_NOTIFICATION_ID)
+						stopSelfSafely()
+					} else {
+						updateSummaryNotification()
+					}
+					break
+				} else if (resp !in 200..206) {
+					throw IllegalStateException("HTTP $resp for $url")
+				}
 
-			val url = URL(state.url)
-			connection = (url.openConnection() as HttpURLConnection).apply {
-				instanceFollowRedirects = true
-				connectTimeout = 15000
-				readTimeout = 15000
-				doInput = true
-				state.headers.forEach { (k, v) -> setRequestProperty(k, v) }
-				if (state.downloaded > 0L) {
-					setRequestProperty("Range", "bytes=${state.downloaded}-")
-					state.etag?.let { setRequestProperty("If-Range", it) }
-				}
-			}
-			connection.connect()
-			state.connection = connection
-
-			val resp = connection.responseCode
-			// Handle resume edge cases before opening output stream
-			if (state.downloaded > 0L && resp == HttpURLConnection.HTTP_OK) {
-				// Server ignored Range; restart from 0 by truncating existing file
-				state.downloaded = 0L
-				if (uri != null) {
-					try {
-						val pfd = contentResolver.openFileDescriptor(uri!!, "rw")
-						val fos = FileOutputStream(pfd!!.fileDescriptor)
-						val channel: FileChannel = fos.channel
-						channel.truncate(0)
-						channel.position(0)
-						fos.close()
-						pfd.close()
-					} catch (_: Exception) {}
-				}
-			} else if (state.downloaded > 0L && resp == 416) {
-				// 416: already fully downloaded on server side; treat as complete
-				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-					val done = ContentValues().apply { put(MediaStore.Downloads.IS_PENDING, 0) }
-					contentResolver.update(uri!!, done, null, null)
-				}
-				notifyTask(state, "Download complete", indeterminate = false, completed = true)
-				ChannelBridge.emit(mapOf(
-					"type" to "complete",
-					"taskId" to state.taskId,
-					"bytes" to state.total,
-					"total" to state.total,
-					"fileName" to state.fileName,
-					"subDir" to state.subDir,
-					"url" to state.url,
-					"contentUri" to (uri?.toString() ?: ""),
-					"mimeType" to state.mimeType,
-				))
-				states.remove(state.taskId)
-				notificationManager.cancel(taskNotificationId(state.taskId))
-				if (states.isEmpty()) {
-					stopForeground(STOP_FOREGROUND_REMOVE)
-					notificationManager.cancel(SERVICE_NOTIFICATION_ID)
-					stopSelfSafely()
-				} else {
-					updateSummaryNotification()
-				}
-				return
-			} else if (resp !in 200..206) {
-				throw IllegalStateException("HTTP $resp for $url")
-			}
-
-			val resumedByServer = state.downloaded > 0L && resp == HttpURLConnection.HTTP_PARTIAL
-			// Parse Content-Range if present to validate start and total
-			if (resumedByServer) {
-				parseContentRange(connection.getHeaderField("Content-Range"))?.let { (start, end, total) ->
-					if (total > 0) state.total = total
-					if (start != state.downloaded) {
-						if (start == 0L) {
-							// Server starts from 0; restart full
-							state.downloaded = 0L
-							if (uri != null) {
-								try {
-									val pfd = contentResolver.openFileDescriptor(uri!!, "rw")
-									val fos = FileOutputStream(pfd!!.fileDescriptor)
-									val ch = fos.channel
-									ch.truncate(0)
-									ch.position(0)
-									fos.close(); pfd.close()
-								} catch (_: Exception) {}
+				val resumedByServer = state.downloaded > 0L && resp == HttpURLConnection.HTTP_PARTIAL
+				// Parse Content-Range if present to validate start and total
+				if (resumedByServer) {
+					parseContentRange(connection.getHeaderField("Content-Range"))?.let { (start, end, total) ->
+						if (total > 0) state.total = total
+						if (start != state.downloaded) {
+							if (start == 0L) {
+								// Server starts from 0; restart full
+								state.downloaded = 0L
+								if (uri != null) {
+									try {
+										val pfd = contentResolver.openFileDescriptor(uri!!, "rw")
+										val fos = FileOutputStream(pfd!!.fileDescriptor)
+										val ch = fos.channel
+										ch.truncate(0)
+										ch.position(0)
+										fos.close(); pfd.close()
+									} catch (_: Exception) {}
+								}
+							} else {
+								// Adjust to server-provided offset
+								state.downloaded = start
 							}
-						} else {
-							// Adjust to server-provided offset
-							state.downloaded = start
 						}
 					}
 				}
-			}
 
-			// Compute total length if not set earlier
-			if (state.total <= 0L) {
-				val reportedLength = connection.contentLengthLong
-				state.total = if (resumedByServer && reportedLength >= 0L) state.downloaded + reportedLength else reportedLength.coerceAtLeast(0L)
-			}
-			// Only update validators if present
-			connection.getHeaderField("ETag")?.let { state.etag = it }
-			connection.getHeaderField("Last-Modified")?.let { state.lastModified = it }
+				// Compute total length if not set earlier
+				if (state.total <= 0L) {
+					val reportedLength = connection.contentLengthLong
+					state.total = if (resumedByServer && reportedLength >= 0L) state.downloaded + reportedLength else reportedLength.coerceAtLeast(0L)
+				}
+				// Only update validators if present
+				connection.getHeaderField("ETag")?.let { state.etag = it }
+				connection.getHeaderField("Last-Modified")?.let { state.lastModified = it }
 
-			input = BufferedInputStream(connection.inputStream)
-			state.input = input
-			out = if (state.downloaded > 0L) {
-				val pfd = contentResolver.openFileDescriptor(uri!!, "rw")
-				outPfd = pfd
-				val fos = FileOutputStream(pfd!!.fileDescriptor)
-				val channel: FileChannel = fos.channel
-				outChannel = channel
-				channel.position(state.downloaded)
-				BufferedOutputStream(fos)
-			} else {
-				// start from 0, ensure overwrite
-				BufferedOutputStream(contentResolver.openOutputStream(uri!!, "w") ?: throw IllegalStateException("No output stream"))
-			}
+				input = BufferedInputStream(connection.inputStream)
+				state.input = input
+				out = if (state.downloaded > 0L) {
+					val pfd = contentResolver.openFileDescriptor(uri!!, "rw")
+					outPfd = pfd
+					val fos = FileOutputStream(pfd!!.fileDescriptor)
+					val channel: FileChannel = fos.channel
+					outChannel = channel
+					channel.position(state.downloaded)
+					BufferedOutputStream(fos)
+				} else {
+					// start from 0, ensure overwrite
+					BufferedOutputStream(contentResolver.openOutputStream(uri!!, "w") ?: throw IllegalStateException("No output stream"))
+				}
 
-			val buffer = ByteArray(256 * 1024)
-			var bytesRead: Int
-			var lastUpdate = System.currentTimeMillis()
-			notifyTask(state, "Downloading", indeterminate = state.total <= 0, completed = false)
-			updateSummaryNotification()
-			if (state.downloaded == 0L) {
-				ChannelBridge.emit(mapOf(
-					"type" to "progress",
-					"taskId" to state.taskId,
-					"bytes" to state.downloaded,
-					"total" to state.total,
-					"fileName" to state.fileName,
-					"subDir" to state.subDir,
-					"url" to state.url,
-				))
-			}
-
-			while (true) {
-				if (state.canceled) throw InterruptedException("canceled")
-				if (state.paused) break
-				bytesRead = input.read(buffer)
-				if (bytesRead == -1) break
-				out.write(buffer, 0, bytesRead)
-				state.downloaded += bytesRead
-				val now = System.currentTimeMillis()
-				if (now - lastUpdate > 500) {
-					notifyTask(state, "Downloading", indeterminate = state.total <= 0, completed = false)
+				val buffer = ByteArray(256 * 1024)
+				var bytesRead: Int
+				var lastUpdate = System.currentTimeMillis()
+				notifyTask(state, "Downloading", indeterminate = state.total <= 0, completed = false)
+				updateSummaryNotification()
+				if (state.downloaded == 0L) {
 					ChannelBridge.emit(mapOf(
 						"type" to "progress",
 						"taskId" to state.taskId,
@@ -369,63 +354,93 @@ class MediaStoreDownloadService : Service() {
 						"subDir" to state.subDir,
 						"url" to state.url,
 					))
-					lastUpdate = now
 				}
-			}
-			out.flush()
 
-			if (!state.paused) {
-				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-					val done = ContentValues().apply { put(MediaStore.Downloads.IS_PENDING, 0) }
-					contentResolver.update(uri!!, done, null, null)
+				while (true) {
+					if (state.canceled) throw InterruptedException("canceled")
+					if (state.paused) break
+					bytesRead = input.read(buffer)
+					if (bytesRead == -1) break
+					out.write(buffer, 0, bytesRead)
+					state.downloaded += bytesRead
+					val now = System.currentTimeMillis()
+					if (now - lastUpdate > 500) {
+						notifyTask(state, "Downloading", indeterminate = state.total <= 0, completed = false)
+						ChannelBridge.emit(mapOf(
+							"type" to "progress",
+							"taskId" to state.taskId,
+							"bytes" to state.downloaded,
+							"total" to state.total,
+							"fileName" to state.fileName,
+							"subDir" to state.subDir,
+							"url" to state.url,
+						))
+						lastUpdate = now
+					}
 				}
-				notifyTask(state, "Download complete", indeterminate = false, completed = true)
-				ChannelBridge.emit(mapOf(
-					"type" to "complete",
-					"taskId" to state.taskId,
-					"bytes" to state.total,
-					"total" to state.total,
-					"fileName" to state.fileName,
-					"subDir" to state.subDir,
-					"url" to state.url,
-					"contentUri" to (uri?.toString() ?: ""),
-					"mimeType" to state.mimeType,
-				))
-				states.remove(state.taskId)
-				notificationManager.cancel(taskNotificationId(state.taskId))
-				if (states.isEmpty()) {
-					stopForeground(STOP_FOREGROUND_REMOVE)
-					notificationManager.cancel(SERVICE_NOTIFICATION_ID)
-					stopSelfSafely()
+				out.flush()
+
+				if (!state.paused) {
+					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+						val done = ContentValues().apply { put(MediaStore.Downloads.IS_PENDING, 0) }
+						contentResolver.update(uri!!, done, null, null)
+					}
+					notifyTask(state, "Download complete", indeterminate = false, completed = true)
+					ChannelBridge.emit(mapOf(
+						"type" to "complete",
+						"taskId" to state.taskId,
+						"bytes" to state.total,
+						"total" to state.total,
+						"fileName" to state.fileName,
+						"subDir" to state.subDir,
+						"url" to state.url,
+						"contentUri" to (uri?.toString() ?: ""),
+						"mimeType" to state.mimeType,
+					))
+					states.remove(state.taskId)
+					notificationManager.cancel(taskNotificationId(state.taskId))
+					if (states.isEmpty()) {
+						stopForeground(STOP_FOREGROUND_REMOVE)
+						notificationManager.cancel(SERVICE_NOTIFICATION_ID)
+						stopSelfSafely()
+					} else {
+						updateSummaryNotification()
+					}
 				} else {
+					notifyTask(state, "Paused", indeterminate = false, completed = false)
 					updateSummaryNotification()
 				}
-			} else {
-				notifyTask(state, "Paused", indeterminate = false, completed = false)
-				updateSummaryNotification()
+				break // Success or pause exit
+			} catch (e: Exception) {
+				if (state.paused || state.canceled) break
+				
+				retryCount++
+				if (retryCount > maxRetries) {
+					notifyTask(state, "Download failed", indeterminate = true, completed = false)
+					ChannelBridge.emit(mapOf(
+						"type" to "error",
+						"taskId" to state.taskId,
+						"message" to (e.message ?: "unknown error"),
+						"fileName" to state.fileName,
+						"subDir" to state.subDir,
+						"url" to state.url,
+					))
+					break
+				}
+				
+				val delay = (2000L * retryCount).coerceAtMost(30000L)
+				notifyTask(state, "Retrying ($retryCount/$maxRetries)...", indeterminate = true, completed = false)
+				try { Thread.sleep(delay) } catch (_: Exception) {}
+				// continue to retry connection
+			} finally {
+				try { out?.close() } catch (_: Exception) {}
+				try { outChannel?.close() } catch (_: Exception) {}
+				try { outPfd?.close() } catch (_: Exception) {}
+				try { input?.close() } catch (_: Exception) {}
+				try { connection?.disconnect() } catch (_: Exception) {}
 			}
-		} catch (e: Exception) {
-			if (state.paused) {
-				notifyTask(state, "Paused", indeterminate = false, completed = false)
-			} else if (!state.canceled) {
-				notifyTask(state, "Download failed", indeterminate = true, completed = false)
-				ChannelBridge.emit(mapOf(
-					"type" to "error",
-					"taskId" to state.taskId,
-					"message" to (e.message ?: "unknown error"),
-					"fileName" to state.fileName,
-					"subDir" to state.subDir,
-					"url" to state.url,
-				))
-			}
-		} finally {
-			try { out?.close() } catch (_: Exception) {}
-			try { outChannel?.close() } catch (_: Exception) {}
-			try { outPfd?.close() } catch (_: Exception) {}
-			try { input?.close() } catch (_: Exception) {}
-			try { connection?.disconnect() } catch (_: Exception) {}
-			state.running = false
 		}
+		state.running = false
 	}
 
 	private fun stopSelfSafely() {

--- a/android/app/src/main/kotlin/com/debrify/app/download/MediaStoreDownloadService.kt
+++ b/android/app/src/main/kotlin/com/debrify/app/download/MediaStoreDownloadService.kt
@@ -428,7 +428,7 @@ class MediaStoreDownloadService : Service() {
 					break
 				}
 				
-				val delay = (2000L * retryCount).coerceAtMost(30000L)
+				val delay = (1000L * (1L shl (retryCount - 1))).coerceIn(2000L, 30000L)
 				notifyTask(state, "Retrying ($retryCount/$maxRetries)...", indeterminate = true, completed = false)
 				try { Thread.sleep(delay) } catch (_: Exception) {}
 				// continue to retry connection

--- a/android/app/src/main/kotlin/com/debrify/app/download/MediaStoreDownloadService.kt
+++ b/android/app/src/main/kotlin/com/debrify/app/download/MediaStoreDownloadService.kt
@@ -213,6 +213,7 @@ class MediaStoreDownloadService : Service() {
 					if (uri == null) {
 						notifyTask(state, "Failed to create destination", indeterminate = true, completed = false)
 						ChannelBridge.emit(mapOf("type" to "error", "taskId" to state.taskId, "message" to "no destination"))
+						states.remove(state.taskId)
 						break
 					}
 					state.uri = uri
@@ -276,13 +277,7 @@ class MediaStoreDownloadService : Service() {
 					))
 					states.remove(state.taskId)
 					notificationManager.cancel(taskNotificationId(state.taskId))
-					if (states.isEmpty()) {
-						stopForeground(STOP_FOREGROUND_REMOVE)
-						notificationManager.cancel(SERVICE_NOTIFICATION_ID)
-						stopSelfSafely()
-					} else {
-						updateSummaryNotification()
-					}
+					checkIfIdleAndStop()
 					break
 				} else if (resp !in 200..206) {
 					throw IllegalStateException("HTTP $resp for $url")
@@ -399,13 +394,7 @@ class MediaStoreDownloadService : Service() {
 					))
 					states.remove(state.taskId)
 					notificationManager.cancel(taskNotificationId(state.taskId))
-					if (states.isEmpty()) {
-						stopForeground(STOP_FOREGROUND_REMOVE)
-						notificationManager.cancel(SERVICE_NOTIFICATION_ID)
-						stopSelfSafely()
-					} else {
-						updateSummaryNotification()
-					}
+					checkIfIdleAndStop()
 				} else {
 					notifyTask(state, "Paused", indeterminate = false, completed = false)
 					updateSummaryNotification()
@@ -425,6 +414,8 @@ class MediaStoreDownloadService : Service() {
 						"subDir" to state.subDir,
 						"url" to state.url,
 					))
+					states.remove(state.taskId)
+					checkIfIdleAndStop()
 					break
 				}
 				
@@ -441,6 +432,17 @@ class MediaStoreDownloadService : Service() {
 			}
 		}
 		state.running = false
+		checkIfIdleAndStop()
+	}
+
+	private fun checkIfIdleAndStop() {
+		if (states.isEmpty()) {
+			stopForeground(STOP_FOREGROUND_REMOVE)
+			notificationManager.cancel(SERVICE_NOTIFICATION_ID)
+			stopSelfSafely()
+		} else {
+			updateSummaryNotification()
+		}
 	}
 
 	private fun stopSelfSafely() {

--- a/lib/screens/downloads_screen.dart
+++ b/lib/screens/downloads_screen.dart
@@ -2721,9 +2721,12 @@ class _TorrentDownloadDetailScreenState extends State<TorrentDownloadDetailScree
         title: Text(title),
         actions: [
           IconButton(
-            onPressed: _refresh,
+            onPressed: () async {
+              await DownloadService.instance.retryAllFailed();
+              await _refresh();
+            },
             icon: const Icon(Icons.refresh_rounded),
-            tooltip: 'Refresh',
+            tooltip: 'Retry failed',
           ),
         ],
       ),

--- a/lib/screens/downloads_screen.dart
+++ b/lib/screens/downloads_screen.dart
@@ -1521,14 +1521,11 @@ List<TorrentDownloadGroup> buildTorrentGroups({
 }
 
 String _deriveGroupId(TaskRecord record, DownloadRecordDetails? details, TorrentMeta meta) {
-  if (meta.torrentHash != null && meta.torrentHash!.isNotEmpty) {
-    return 'hash:${meta.torrentHash!.toLowerCase()}';
-  }
-  final torrentName = details?.torrentName;
-  if (torrentName != null && torrentName.trim().isNotEmpty) {
-    return 'name:${torrentName.trim().toLowerCase()}';
-  }
-  return 'task:${record.task.taskId}';
+  return DownloadService.deriveGroupId(
+    recordId: record.task.taskId,
+    metaStr: details?.meta,
+    torrentName: details?.torrentName,
+  );
 }
 
 String formatBytes(int bytes) {

--- a/lib/screens/downloads_screen.dart
+++ b/lib/screens/downloads_screen.dart
@@ -2722,7 +2722,7 @@ class _TorrentDownloadDetailScreenState extends State<TorrentDownloadDetailScree
         actions: [
           IconButton(
             onPressed: () async {
-              await DownloadService.instance.retryAllFailed();
+              await DownloadService.instance.retryAllFailed(torrentName: widget.groupTitle);
               await _refresh();
             },
             icon: const Icon(Icons.refresh_rounded),

--- a/lib/screens/downloads_screen.dart
+++ b/lib/screens/downloads_screen.dart
@@ -2722,7 +2722,7 @@ class _TorrentDownloadDetailScreenState extends State<TorrentDownloadDetailScree
         actions: [
           IconButton(
             onPressed: () async {
-              await DownloadService.instance.retryAllFailed(torrentName: widget.groupTitle);
+              await DownloadService.instance.retryAllFailed(groupId: widget.groupId);
               await _refresh();
             },
             icon: const Icon(Icons.refresh_rounded),

--- a/lib/services/download_service.dart
+++ b/lib/services/download_service.dart
@@ -1233,7 +1233,7 @@ class DownloadService {
     // Check for filename conflict and increment if needed using file(1).ext format
     String finalFilename = filename;
     int counter = 1;
-    while (File(path.join(dir, finalFilename)).existsSync()) {
+    while (await File(path.join(dir, finalFilename)).exists()) {
       final dot = filename.lastIndexOf('.');
       if (dot > 0) {
         final base = filename.substring(0, dot);

--- a/lib/services/download_service.dart
+++ b/lib/services/download_service.dart
@@ -989,7 +989,21 @@ class DownloadService {
             if (uri.isNotEmpty) {
               _lastFileByTaskId[taskId] = (uri, mime);
             }
-            if (recId != null) _upsertRecord(recId, {'state': 'complete'});
+            if (recId != null) {
+              final rec = _records[recId];
+              final metaStr = rec?['meta'] as String?;
+              if (metaStr != null && metaStr.contains('_handoffAttempt')) {
+                try {
+                  final m = jsonDecode(metaStr);
+                  m.remove('_handoffAttempt');
+                  _upsertRecord(recId, {'state': 'complete', 'meta': jsonEncode(m)});
+                } catch (_) {
+                  _upsertRecord(recId, {'state': 'complete'});
+                }
+              } else {
+                _upsertRecord(recId, {'state': 'complete'});
+              }
+            }
             _reevaluateQueue();
             break;
           case 'error':

--- a/lib/services/download_service.dart
+++ b/lib/services/download_service.dart
@@ -1016,11 +1016,25 @@ class DownloadService {
               unawaited(() async {
                 final retried = await _handlePikPakFailedRetry(recId);
                 if (!retried) {
-                  // Not PikPak or max retries exceeded - mark as failed
-                  debugPrint('ANDR ERR net=${nowNet.name} → failed');
-                  AndroidDownloadHistory.instance.upsert(task, TaskStatus.failed, -1.0);
-                  _statusController.add(TaskStatusUpdate(task, TaskStatus.failed));
-                  if (recId != null) _upsertRecord(recId, {'state': 'failed'});
+                  // If we are on mobile, it might be a handoff glitch (e.g. 5G -> 4G socket reset)
+                  // Treat as paused and nudge auto-resume instead of hard failing.
+                  if (nowNet == ConnectivityResult.mobile) {
+                    debugPrint('ANDR ERR mobile handoff? (net=${nowNet.name}) → paused for auto-resume');
+                    AndroidDownloadHistory.instance.upsert(task, TaskStatus.paused, -5.0);
+                    _statusController.add(TaskStatusUpdate(task, TaskStatus.paused));
+                    if (recId != null) _upsertRecord(recId, {'state': 'paused'});
+                    
+                    // Nudge auto-resume by adding to pending resume list
+                    if (!_pendingResumeAndroid.contains(taskId)) {
+                      _pendingResumeAndroid.add(taskId);
+                    }
+                  } else {
+                    // Not mobile or PikPak - mark as failed
+                    debugPrint('ANDR ERR net=${nowNet.name} → failed');
+                    AndroidDownloadHistory.instance.upsert(task, TaskStatus.failed, -1.0);
+                    _statusController.add(TaskStatusUpdate(task, TaskStatus.failed));
+                    if (recId != null) _upsertRecord(recId, {'state': 'failed'});
+                  }
                 }
                 _reevaluateQueue();
               }());
@@ -1202,26 +1216,36 @@ class DownloadService {
 
     filename = _sanitizeName(filename);
 
-    // Use torrent name for folder if provided, otherwise use base name of file
-    String folder;
+    // Use torrent name for folder if provided
+    String? folder;
     if (torrentName != null && torrentName.trim().isNotEmpty) {
       folder = _sanitizeName(torrentName.trim());
-    } else {
-      // Make a folder from base name (without extension)
-      final int dot = filename.lastIndexOf('.');
-      final String baseName = dot > 0 ? filename.substring(0, dot) : filename;
-      folder = _sanitizeName(baseName);
     }
 
     // Place under downloads/<folder>
     final String downloadsRoot = await _appDownloadsSubdir();
-    final String dir = path.join(downloadsRoot, folder);
+    final String dir = folder != null ? path.join(downloadsRoot, folder) : downloadsRoot;
     final Directory d = Directory(dir);
     if (!await d.exists()) {
       await d.create(recursive: true);
     }
 
-    return (dir, filename);
+    // Check for filename conflict and increment if needed using file(1).ext format
+    String finalFilename = filename;
+    int counter = 1;
+    while (File(path.join(dir, finalFilename)).existsSync()) {
+      final dot = filename.lastIndexOf('.');
+      if (dot > 0) {
+        final base = filename.substring(0, dot);
+        final ext = filename.substring(dot);
+        finalFilename = '$base($counter)$ext';
+      } else {
+        finalFilename = '$filename($counter)';
+      }
+      counter++;
+    }
+
+    return (dir, finalFilename);
   }
 
   Future<DownloadEntry> enqueueDownload({

--- a/lib/services/download_service.dart
+++ b/lib/services/download_service.dart
@@ -445,21 +445,41 @@ class DownloadService {
     } catch (_) {}
   }
 
-  Future<void> retryAllFailed() async {
-    await _loadRecords();
-    final failed = _records.entries.where((e) => (e.value['state'] == 'failed'));
+  Future<void> retryAllFailed({String? torrentName}) async {
+    // Use the already in-memory _records map as the authoritative source.
+    final failed = _records.entries.where((e) {
+      final isFailed = e.value['state'] == 'failed';
+      if (!isFailed) return false;
+      if (torrentName != null) {
+        return e.value['torrentName'] == torrentName;
+      }
+      return true;
+    }).toList();
+
     for (final e in failed) {
       final rec = e.value;
-      final meta = rec['meta'] as String?;
+      String? meta = rec['meta'] as String?;
       final url = rec['url'] as String?;
       final fileName = rec['displayName'] as String?;
-      final torrentName = rec['torrentName'] as String?;
+      final tName = rec['torrentName'] as String?;
+
+      // Strip _handoffAttempt from meta to ensure a fresh start on manual retry
       if (meta != null && meta.isNotEmpty) {
-        await enqueueDownload(url: url ?? '', fileName: fileName, meta: meta, torrentName: torrentName);
-      } else if (url != null && url.isNotEmpty) {
-        await enqueueDownload(url: url, fileName: fileName, torrentName: torrentName);
+        try {
+          final m = jsonDecode(meta);
+          if (m is Map && m.containsKey('_handoffAttempt')) {
+            m.remove('_handoffAttempt');
+            meta = jsonEncode(m);
+          }
+        } catch (_) {}
       }
-      _upsertRecord(e.key, {'state': 'queued'});
+
+      if (meta != null && meta.isNotEmpty) {
+        await enqueueDownload(url: url ?? '', fileName: fileName, meta: meta, torrentName: tName);
+      } else if (url != null && url.isNotEmpty) {
+        await enqueueDownload(url: url, fileName: fileName, torrentName: tName);
+      }
+      _upsertRecord(e.key, {'state': 'queued', 'meta': meta});
     }
   }
 
@@ -1272,7 +1292,7 @@ class DownloadService {
       await d.create(recursive: true);
     }
 
-    // Check for filename conflict and increment if needed using file(1).ext format.
+    // Check for filename conflict and increment if needed using file (1).ext format.
     // Cap at 1000 iterations to prevent infinite loops in edge cases.
     String finalFilename = filename;
     int counter = 1;
@@ -1281,9 +1301,9 @@ class DownloadService {
       if (dot > 0) {
         final base = filename.substring(0, dot);
         final ext = filename.substring(dot);
-        finalFilename = '$base($counter)$ext';
+        finalFilename = '$base ($counter)$ext';
       } else {
-        finalFilename = '$filename($counter)';
+        finalFilename = '$filename ($counter)';
       }
       counter++;
     }

--- a/lib/services/download_service.dart
+++ b/lib/services/download_service.dart
@@ -1069,13 +1069,14 @@ class DownloadService {
                       _statusController.add(TaskStatusUpdate(task, TaskStatus.paused));
                       
                       if (recId != null) {
+                        Map<String, dynamic> m;
                         try {
-                          final m = metaStr != null && metaStr.isNotEmpty ? jsonDecode(metaStr) : {};
-                          m['_handoffAttempt'] = handoffAttempt + 1;
-                          _upsertRecord(recId, {'state': 'paused', 'meta': jsonEncode(m)});
+                          m = metaStr != null && metaStr.isNotEmpty ? jsonDecode(metaStr) as Map<String, dynamic> : {};
                         } catch (_) {
-                          _upsertRecord(recId, {'state': 'paused'});
+                          m = {}; // If meta is corrupt, start with a fresh map.
                         }
+                        m['_handoffAttempt'] = handoffAttempt + 1;
+                        _upsertRecord(recId, {'state': 'paused', 'meta': jsonEncode(m)});
                       }
                       
                       // Nudge auto-resume by adding to pending resume list

--- a/lib/services/download_service.dart
+++ b/lib/services/download_service.dart
@@ -445,13 +445,38 @@ class DownloadService {
     } catch (_) {}
   }
 
-  Future<void> retryAllFailed({String? torrentName}) async {
+  Future<void> retryAllFailed({String? groupId}) async {
     // Use the already in-memory _records map as the authoritative source.
     final failed = _records.entries.where((e) {
-      final isFailed = e.value['state'] == 'failed';
+      final rec = e.value;
+      final isFailed = rec['state'] == 'failed';
       if (!isFailed) return false;
-      if (torrentName != null) {
-        return e.value['torrentName'] == torrentName;
+      if (groupId != null) {
+        // Implement the same grouping logic as in the UI to ensure perfect match
+        final metaStr = rec['meta'] as String?;
+        String? torrentHash;
+        if (metaStr != null && metaStr.isNotEmpty) {
+          try {
+            final decoded = jsonDecode(metaStr);
+            final rawHash = decoded['torrentHash'];
+            if (rawHash != null && rawHash.toString().isNotEmpty) {
+              torrentHash = rawHash.toString();
+            }
+          } catch (_) {}
+        }
+
+        final String recordGroupId;
+        if (torrentHash != null && torrentHash.isNotEmpty) {
+          recordGroupId = 'hash:${torrentHash.toLowerCase()}';
+        } else {
+          final torrentName = rec['torrentName'] as String?;
+          if (torrentName != null && torrentName.trim().isNotEmpty) {
+            recordGroupId = 'name:${torrentName.trim().toLowerCase()}';
+          } else {
+            recordGroupId = 'task:${e.key}';
+          }
+        }
+        return recordGroupId == groupId;
       }
       return true;
     }).toList();

--- a/lib/services/download_service.dart
+++ b/lib/services/download_service.dart
@@ -1017,16 +1017,42 @@ class DownloadService {
                 final retried = await _handlePikPakFailedRetry(recId);
                 if (!retried) {
                   // If we are on mobile, it might be a handoff glitch (e.g. 5G -> 4G socket reset)
-                  // Treat as paused and nudge auto-resume instead of hard failing.
+                  // Treat as paused and nudge auto-resume instead of hard failing, with a cap.
                   if (nowNet == ConnectivityResult.mobile) {
-                    debugPrint('ANDR ERR mobile handoff? (net=${nowNet.name}) → paused for auto-resume');
-                    AndroidDownloadHistory.instance.upsert(task, TaskStatus.paused, -5.0);
-                    _statusController.add(TaskStatusUpdate(task, TaskStatus.paused));
-                    if (recId != null) _upsertRecord(recId, {'state': 'paused'});
-                    
-                    // Nudge auto-resume by adding to pending resume list
-                    if (!_pendingResumeAndroid.contains(taskId)) {
-                      _pendingResumeAndroid.add(taskId);
+                    final rec = recId != null ? _records[recId] : null;
+                    final metaStr = rec?['meta'] as String?;
+                    int handoffAttempt = 0;
+                    if (metaStr != null && metaStr.isNotEmpty) {
+                      try {
+                        final m = jsonDecode(metaStr);
+                        handoffAttempt = (m['_handoffAttempt'] as num? ?? 0).toInt();
+                      } catch (_) {}
+                    }
+
+                    if (handoffAttempt < 5) {
+                      debugPrint('ANDR ERR mobile handoff? (net=${nowNet.name}, attempt ${handoffAttempt + 1}) → paused for auto-resume');
+                      AndroidDownloadHistory.instance.upsert(task, TaskStatus.paused, -5.0);
+                      _statusController.add(TaskStatusUpdate(task, TaskStatus.paused));
+                      
+                      if (recId != null) {
+                        try {
+                          final m = metaStr != null && metaStr.isNotEmpty ? jsonDecode(metaStr) : {};
+                          m['_handoffAttempt'] = handoffAttempt + 1;
+                          _upsertRecord(recId, {'state': 'paused', 'meta': jsonEncode(m)});
+                        } catch (_) {
+                          _upsertRecord(recId, {'state': 'paused'});
+                        }
+                      }
+                      
+                      // Nudge auto-resume by adding to pending resume list
+                      if (!_pendingResumeAndroid.contains(taskId)) {
+                        _pendingResumeAndroid.add(taskId);
+                      }
+                    } else {
+                      debugPrint('ANDR ERR mobile handoff max retries exceeded → failed');
+                      AndroidDownloadHistory.instance.upsert(task, TaskStatus.failed, -1.0);
+                      _statusController.add(TaskStatusUpdate(task, TaskStatus.failed));
+                      if (recId != null) _upsertRecord(recId, {'state': 'failed'});
                     }
                   } else {
                     // Not mobile or PikPak - mark as failed
@@ -1216,7 +1242,9 @@ class DownloadService {
 
     filename = _sanitizeName(filename);
 
-    // Use torrent name for folder if provided
+    // Use torrent name for folder if provided. 
+    // If no torrentName is provided, we drop files directly into the downloads root 
+    // to avoid the "directory instead of file" issues for single-file downloads.
     String? folder;
     if (torrentName != null && torrentName.trim().isNotEmpty) {
       folder = _sanitizeName(torrentName.trim());
@@ -1230,10 +1258,11 @@ class DownloadService {
       await d.create(recursive: true);
     }
 
-    // Check for filename conflict and increment if needed using file(1).ext format
+    // Check for filename conflict and increment if needed using file(1).ext format.
+    // Cap at 1000 iterations to prevent infinite loops in edge cases.
     String finalFilename = filename;
     int counter = 1;
-    while (await File(path.join(dir, finalFilename)).exists()) {
+    while (await File(path.join(dir, finalFilename)).exists() && counter < 1000) {
       final dot = filename.lastIndexOf('.');
       if (dot > 0) {
         final base = filename.substring(0, dot);

--- a/lib/services/download_service.dart
+++ b/lib/services/download_service.dart
@@ -354,6 +354,33 @@ class DownloadService {
     } catch (_) {}
   }
 
+  static String deriveGroupId({
+    required String recordId,
+    String? metaStr,
+    String? torrentName,
+  }) {
+    String? torrentHash;
+    if (metaStr != null && metaStr.isNotEmpty) {
+      try {
+        final decoded = jsonDecode(metaStr);
+        if (decoded is Map) {
+          final rawHash = decoded['torrentHash'];
+          if (rawHash != null && rawHash.toString().isNotEmpty) {
+            torrentHash = rawHash.toString();
+          }
+        }
+      } catch (_) {}
+    }
+
+    if (torrentHash != null && torrentHash.isNotEmpty) {
+      return 'hash:${torrentHash.toLowerCase()}';
+    }
+    if (torrentName != null && torrentName.trim().isNotEmpty) {
+      return 'name:${torrentName.trim().toLowerCase()}';
+    }
+    return 'task:$recordId';
+  }
+
   void _upsertRecord(String recordId, Map<String, dynamic> patch) {
     final existing = _records[recordId] ?? <String, dynamic>{};
     existing.addAll(patch);
@@ -452,31 +479,12 @@ class DownloadService {
       final isFailed = rec['state'] == 'failed';
       if (!isFailed) return false;
       if (groupId != null) {
-        // Implement the same grouping logic as in the UI to ensure perfect match
-        final metaStr = rec['meta'] as String?;
-        String? torrentHash;
-        if (metaStr != null && metaStr.isNotEmpty) {
-          try {
-            final decoded = jsonDecode(metaStr);
-            final rawHash = decoded['torrentHash'];
-            if (rawHash != null && rawHash.toString().isNotEmpty) {
-              torrentHash = rawHash.toString();
-            }
-          } catch (_) {}
-        }
-
-        final String recordGroupId;
-        if (torrentHash != null && torrentHash.isNotEmpty) {
-          recordGroupId = 'hash:${torrentHash.toLowerCase()}';
-        } else {
-          final torrentName = rec['torrentName'] as String?;
-          if (torrentName != null && torrentName.trim().isNotEmpty) {
-            recordGroupId = 'name:${torrentName.trim().toLowerCase()}';
-          } else {
-            recordGroupId = 'task:${e.key}';
-          }
-        }
-        return recordGroupId == groupId;
+        return DownloadService.deriveGroupId(
+              recordId: e.key,
+              metaStr: rec['meta'] as String?,
+              torrentName: rec['torrentName'] as String?,
+            ) ==
+            groupId;
       }
       return true;
     }).toList();


### PR DESCRIPTION
Summary
  This PR addresses several critical issues in the Android download pipeline, focusing on network resilience during mobile network (5G/4G) handoffs, improving the resume/retry user experience, and fixing file naming/storage conflicts.

Technical Changes

  1. Android Native Resilience (MediaStoreDownloadService.kt)
   * Native Retry Loop: Implemented a 10-attempt retry mechanism directly in the native service to handle transient socket resets (common during network handoffs).
   * Notification Updates: The download notification now provides real-time feedback during retries (e.g., "Retrying 1/10...").

  2. Smart Scheduler Improvements
  (download_service.dart)
   * Mobile Handoff Detection: The app now specifically identifies mobile network glitches. Instead of moving these to a "Failed" state, it marks them as "Paused" and adds them to the automatic background resume queue.
   * Storage Logic Refactor: Fixed a bug where a directory was being created with the same name as the file (e.g., movie.mkv/movie.mkv). Files are now saved directly in the root Debrify folder unless they belong to a multi-file torrent.
   * Naming Convention Fix: Standardized the conflict naming to filename(1).ext. This prevents the "extension loss" issue caused by the previous filename.ext (1) format.

  3. UI/UX Enhancements (downloads_screen.dart)
   * Functional Resume: Converted the "Refresh" icon in the download detail view into a "Retry All" action. This allows users to resume all interrupted or failed downloads in a group with a single tap.

  Files Modified
   - android/app/src/main/kotlin/com/debrify/app/download/MediaStoreDownloadService.kt
   - lib/services/download_service.dart
   - lib/screens/downloads_screen.dart