### PR TITLE
Add collections: import Nuvio-style folder collections as Home rows

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -101,7 +101,9 @@ right code instead of re-discovering it. Flutter app; code under `lib/{screens,s
 - Collections (imported Nuvio/Xperience-style folder groups → Home rows of folder tiles):
   `models/home_collection.dart` (schema + parser + `collection:<id>` row ids),
   `services/home_collections_store.dart` (`home_collections_v1`, file/URL/paste import, addon
-  resolution), `services/collection_folder_loader.dart` (merged multi-catalog paging),
+  resolution), `models/home_collection_inventory.dart` (atomic inventory and durable
+  deletions), `services/collection_catalog_pager.dart` (raw cursor and retry state),
+  `services/collection_folder_loader.dart` (merged multi-catalog paging),
   `services/home_collection_rows.dart` (`HomeCollectionSection`), browser
   `screens/collections/collection_folder_screen.dart` (+ `widgets/collections/rail_see_all_pill.dart`),
   settings `screens/settings/collections_settings_page.dart` (+ `widgets/text_prompt_dialog.dart`).

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -98,6 +98,15 @@ right code instead of re-discovering it. Flutter app; code under `lib/{screens,s
 ## Settings · storage · misc infra
 - Settings: `screens/settings/*` (+ `home_sections_filter_page.dart` = show/hide home rows,
   `home_page_settings_page.dart`). Metrics/format helpers: `utils/*`.
+- Collections (imported Nuvio/Xperience-style folder groups → Home rows of folder tiles):
+  `models/home_collection.dart` (schema + parser + `collection:<id>` row ids),
+  `services/home_collections_store.dart` (`home_collections_v1`, file/URL/paste import, addon
+  resolution), `services/collection_folder_loader.dart` (merged multi-catalog paging),
+  `services/home_collection_rows.dart` (`HomeCollectionSection`), browser
+  `screens/collections/collection_folder_screen.dart` (+ `widgets/collections/rail_see_all_pill.dart`),
+  settings `screens/settings/collections_settings_page.dart` (+ `widgets/text_prompt_dialog.dart`).
+  Board wiring lives in `search_screen.dart` (`_buildCollectionSections`, `_openCollectionFolder`,
+  `_openCollectionScreen`). Docs: `docs/collections.md`.
 - Backup/transfer/sync: `services/backup_restore_service.dart` (full config snapshot),
   `widgets/remote/*` + `services/remote_control/*` (device-to-device over LAN, no server).
 - Onboarding: `widgets/initial_setup_flow.dart` 🔴. Migration: `services/app_migration_service.dart`.

--- a/docs/collections-review.md
+++ b/docs/collections-review.md
@@ -185,3 +185,23 @@ profile, Home and Spotlight suites used in Part 2. Full debug Dart bundle
 build succeeded. Analysis of all PR-touched Dart files found no errors or
 warnings and the same 27 existing informational diagnostics. Hardware TV
 validation remains outstanding.
+
+## Final whole-branch review (2026-09-07)
+
+Reviewed the full feature at `697ab9bf` against `webdav-sync` (`93b92caf`),
+including imports, inventory persistence, Home and TV layouts, Rows/Tabs/All,
+source resolution, backup, sync replay and shared widget changes. No new P1/P2
+blocker was confirmed; the earlier blocking fixes retained their behavior.
+
+All **841 regression tests passed**. Analysis of every PR-touched Dart file
+reported no errors or warnings and 27 existing informational diagnostics. An
+additional widget probe traversed 12 folder rails with DPAD Down at 1280×720.
+
+A direct legacy collection-helper probe found an export/restore size-limit
+mismatch for an oversized synced union. Call-site review established that synced
+profiles use the native profile archive path instead, so this is not evidence
+of a normal Backup & Restore failure and was not treated as a merge blocker.
+
+The partial addon-signature and live See All settings behavior and documented
+P3s remain follow-up work. Physical Android TV checks of rapid folder focus,
+focus GIFs and transitions from active trailers are still outstanding.

--- a/docs/collections-review.md
+++ b/docs/collections-review.md
@@ -157,3 +157,31 @@ shape/caption rendering, Home Rows persistence and See All propagation have
 widget tests. This does not substitute for an Android TV hardware pass through
 all six layouts, focus GIFs and active trailer transitions. Remaining Part 2
 P3s are deferred, apart from the adjacent fixes explicitly listed above.
+
+## Replay and All-view follow-up (Part 3, 2026-09-07)
+
+Starting at `06290656`, the new regression tests reproduced both reported
+All-view failures (an overlapping source and a client-filtered window) and a
+collection deletion lost during pending-apply replay.
+
+- All ignores individual no-progress windows while sibling sources advance.
+  Genuine transport errors still surface, and exhausting the shared eight-window
+  budget still produces a resumable retry state.
+- Replay journals converted collection tombstones in the adapter's `beforeWrite`
+  hook, inside the preference mutation fence, before local markers disappear.
+  The successful replay state update also retains those tombstones with the
+  baseline. The regression interrupts a normal apply, deletes a collection,
+  crashes again after replay materialization, restarts and verifies convergence
+  on a peer still holding the live record.
+- Empty-object and null-`metas` catalog responses are accepted as exhaustion,
+  matching Home/See All. Wrongly typed `metas` remains an uncached retryable
+  failure. This supersedes the earlier missing-array strictness.
+
+The low-impact addon-signature and live See All preference limitations, and
+remaining P3 findings, are not addressed in this pass.
+
+Validation: **841 tests passed** across the same collections, WebDAV, backup,
+profile, Home and Spotlight suites used in Part 2. Full debug Dart bundle
+build succeeded. Analysis of all PR-touched Dart files found no errors or
+warnings and the same 27 existing informational diagnostics. Hardware TV
+validation remains outstanding.

--- a/docs/collections-review.md
+++ b/docs/collections-review.md
@@ -77,9 +77,47 @@ claim of universally bug-free playback, addon behavior, animated-art performance
 or every possible device size is made.
 
 Concurrent edits to the same collection retain the existing last-writer stamp
-semantics. Different collections merge independently. The 128 KiB/1,024-identity
-local growth bounds retain deletion records; the existing shared 1 MiB WebDAV
+semantics. Different collections merge independently. The 128 KiB/1,024-live-collection
+definition bounds exclude pending deletion records; the existing shared 1 MiB WebDAV
 hot-document ceiling still applies after aggregation with other profile data.
 Legacy array preferences upgrade on mutation, so devices editing this feature
 should run the repaired implementation. The import UI remains an importer and
 manager, not a collection authoring editor.
+
+
+## Follow-up review — 2026-09-07
+
+The review of `519454cf` identified additional P2 issues. They are addressed by:
+
+- Salvaging valid records for Home, Home Rows and backup; settings offers an
+  explicit reset, and restore can repair a damaged inventory. Ordinary imports
+  still protect damaged data from accidental overwrite.
+- Tolerant hot build/materialization, including malformed record values and
+  encoded identities. A multi-profile engine test verifies corrupt collection
+  data does not abort the cycle.
+- Moving null deletion markers into WebDAV's native tombstone tier. The engine
+  journals converted deletions before local apply, then removes local markers.
+  Retention starts at publication and uses the existing 90-day horizon and
+  dormant-peer suppression. Tests cover crash-after-apply recovery, expiry,
+  dormant peers, explicit reimport, and 1,100 pending deletion identities without
+  blocking a new live collection.
+- Claiming catalogs only when collection rows are visible in Home. Hidden rows,
+  Search and Discover do not suppress their catalogs.
+- Comparing folder configuration before rebuilding. Unrelated notifications
+  preserve the grid state and focused poster; actual configuration changes
+  restore a usable focus target.
+
+Additional checks cover a one-request retry cache bypass, HTTP 200 without
+`metas`, a shared eight-request paging budget, fallback source deduplication,
+visibility changes on oversized synced definitions, and the reset UI. Settings
+no longer labels action dialogs as imports, and its layout toggle is visibly
+inactive while an operation is pending. Same-collection edit/delete stamp
+semantics are documented in `collections.md`.
+
+
+Follow-up validation: **772 tests passed** in the combined command above plus
+`test/profiles/profile_stremio_isolation_test.dart`,
+`test/catalog_ingest_spike_test.dart`, `test/stremio_addon_import_test.dart` and
+`test/stremio_metadata_provider_test.dart`. Full PR analysis reports no errors
+or warnings and the same 25 informational notices. The application Dart bundle
+build succeeds. Physical-device playback/live-server limits remain as stated.

--- a/docs/collections-review.md
+++ b/docs/collections-review.md
@@ -121,3 +121,39 @@ Follow-up validation: **772 tests passed** in the combined command above plus
 `test/stremio_metadata_provider_test.dart`. Full PR analysis reports no errors
 or warnings and the same 25 informational notices. The application Dart bundle
 build succeeds. Physical-device playback/live-server limits remain as stated.
+
+## Whole-feature follow-up (Part 2, 2026-09-07)
+
+This pass starts at `38a60e6f` and supersedes the earlier permissive catalog
+fallback behavior described above. The Part 1 inventory/sync repairs remain.
+
+- Canvas, Atrium, Mosaic, Deck, Tonight and Promenade now size collection
+  cells using collection geometry and pass cover art, focus GIF and hidden-title
+  preferences to the shared card. Folder focus replaces the stage identity/art,
+  retires pending title enrichment and trailers, and clears live IPTV. Route
+  returns cannot schedule a folder trailer.
+- Sources require their declared addon identity and requested browsable catalog.
+  A matching catalog id on another provider cannot silently supply or claim a
+  row. Different manifest identities need an explicit source-id correction.
+- The common import parser accepts a leading BOM for file, URL and pasted JSON.
+- Newly discovered pinned rows lead existing saved orders. Canvas/Classic and
+  Home Rows use the same pin seeding; already saved manual positions survive.
+- Spotlight supports square covers and per-card hidden captions. Focus GIFs
+  have bounded decode width; failed Spotlight previews reveal the cover.
+- Rail See All carries the current Discover card preferences across the route
+  boundary and only passes genres supported by the catalog. Folder detail/play
+  uses the actual serving addon object, preserving its configuration.
+- TV poster focus uses the grid's scroll behavior; only rail-pill focus also
+  invokes rail alignment, removing the competing outer scroll request.
+
+Validation: **834 tests passed**, including collections recovery/storage/paging,
+WebDAV engine/runtime, backup/profile isolation, Home ordering/filtering, shared
+Spotlight rendering, BOM/identity regressions and See All scope propagation.
+The full debug Dart bundle builds. Analysis across PR Dart files and the shared
+Spotlight widget reports **no errors or warnings**, with 27 existing infos
+(the wider file set adds the Spotlight widget's two pre-existing infos).
+Stage-private wiring and hero retirement have source guards; shared Spotlight
+shape/caption rendering, Home Rows persistence and See All propagation have
+widget tests. This does not substitute for an Android TV hardware pass through
+all six layouts, focus GIFs and active trailer transitions. Remaining Part 2
+P3s are deferred, apart from the adjacent fixes explicitly listed above.

--- a/docs/collections-review.md
+++ b/docs/collections-review.md
@@ -1,0 +1,85 @@
+# Collections hardening review — PR #54
+
+Reviewed against `webdav-sync` at `93b92cafcf3b8e71d7333fa28ae84848ab7e4226`,
+after the contributor branch incorporated the conflict resolution at
+`27992115e6db2886fe3fcf7faf1c188631332e46`. The repair retains the import format
+and Home/folder integration and replaces the unsafe persistence and paging
+behavior. The PR remains based on `webdav-sync`; it is not merged into that
+branch by this work.
+
+## Five review rounds
+
+1. **Profile storage and import integrity.** Reproduced the original failures,
+   then verified profile-switch cancellation, concurrent imports, imports racing
+   a sync apply, refused device-budget writes, corrupt data protection, legacy
+   array migration, backup round trips, retained deletions, explicit reorder,
+   reimport visibility, full-content signatures, and storage/identity bounds.
+   Imports now use the profile mutation barrier for the entire read/update/write.
+2. **Recurring sync and deletion.** Replaced the collection-list scalar with
+   individual stamped records and an order record. Tests cover independent
+   device imports, durable deletion, Home refresh dispatch, and a two-engine
+   encrypted publish/merge/apply scenario, including an engine restart and an
+   intentional later reimport. Existing WebDAV engine, codec, profile, graph,
+   tombstone, adoption and runtime tests were included in broad verification.
+3. **Catalog browsing and navigation.** Verified fallback resolution against the
+   requested browsable catalog, filtered-empty pages, overlapping catalog pages,
+   same-ID movie/series separation, serving-addon propagation, transport failure
+   and retry, raw exhaustion, bounded no-progress behavior and concurrency.
+   TV Tabs now uses the attached grid key. Retry retains tab B, successfully
+   loads its results and moves TV focus from Retry into content. Folder requests
+   are retired on configuration/folder changes; All gets a fresh grid key.
+4. **Responsive UI and live changes.** Rows and Tabs were exercised at 320×568,
+   568×320, 768×1024, 1280×720 and 1920×1080 with long names and unavailable
+   artwork. Tests open the phone Filters sheet and select All, check merged
+   deduplication/source identity, and remove the collection while the folder is
+   open. Settings dialogs use 1.5× text at phone portrait/landscape and TV sizes.
+   Paste import is exercised with a landscape keyboard inset. This round found
+   and fixed narrow-sheet dropdown overflow, scrollability gaps, and stale open
+   settings. Initial and retry rail batches are bounded to four requests.
+5. **Integration and final audit.** Ran the combined collections, WebDAV, Home,
+   backup, sorting and shared filter/dropdown suites. An existing source guard
+   expected four Home browser routes; its expectation now includes the fifth
+   collection route, which also applies the existing expanded-card settings.
+   Analyzed every Dart file changed by the PR or repairs and built the complete
+   application Dart bundle. Reviewed the final diff and documentation for the
+   inventory migration, retained deletions and practical size limits.
+
+## Reproduction commands
+
+```sh
+flutter test --no-pub \
+  test/home_collections_test.dart \
+  test/home_collections_regression_test.dart \
+  test/home_collections_storage_test.dart \
+  test/home_collections_responsive_test.dart \
+  test/collection_catalog_pager_test.dart \
+  test/services/webdav_sync \
+  test/home_row_focus_test.dart test/home_row_order_test.dart \
+  test/home_sections_filter_page_test.dart test/home_layout_policy_test.dart \
+  test/home_catalog_refresh_test.dart test/home_extra_rows_test.dart \
+  test/home_expanded_card_settings_test.dart test/home_hero_source_test.dart \
+  test/backup_encryption_test.dart test/profile_backup_migrate_source_guard_test.dart \
+  test/see_all_added_sort_test.dart test/see_all_filter_bar_test.dart \
+  test/stremio_dropdown_sections_test.dart
+flutter build bundle --debug --no-pub
+```
+
+Static analysis of the PR and repair files reports no errors or warnings and
+25 informational notices already recorded on the pre-repair branch. The Dart
+bundle build succeeds. The final combined command above passes **736 tests**.
+
+## Verification limits
+
+These are unit/widget tests and an encrypted in-memory WebDAV transport; they
+are not a physical-TV playback session or a live WebDAV-server soak test. The
+bundle build compiles application Dart, not each native release package. No
+claim of universally bug-free playback, addon behavior, animated-art performance
+or every possible device size is made.
+
+Concurrent edits to the same collection retain the existing last-writer stamp
+semantics. Different collections merge independently. The 128 KiB/1,024-identity
+local growth bounds retain deletion records; the existing shared 1 MiB WebDAV
+hot-document ceiling still applies after aggregation with other profile data.
+Legacy array preferences upgrade on mutation, so devices editing this feature
+should run the repaired implementation. The import UI remains an importer and
+manager, not a collection authoring editor.

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -19,9 +19,10 @@ Imports **merge**: a collection whose `id` already exists is replaced in place
 (keeping its show/hide state); new ids are appended. Tapping a collection
 offers hide-from-Home and delete; "Remove all" is under Danger Zone. Documents
 over 8 MiB are refused. Persisted collection definitions have a 128 KiB
-aggregate limit per profile, including retained deletion records, and a maximum
-of 1,024 collection identities. An import that would grow beyond either limit
-fails before saving. This leaves space for the profile's other sync data.
+aggregate limit per profile and a maximum of 1,024 live collections. Pending
+deletion records do not consume these definition limits, and changing visibility
+does not grow the measured definition size. An import that would grow beyond
+either limit fails before saving. This leaves space for the profile's other sync data.
 Profile changes during a picker or download cancel the import; failed storage
 writes are reported as failures.
 
@@ -130,10 +131,12 @@ detail page and Quick Play of the addon that served them.
   never arranged, since they live inside the folder.
 - The collection's own Home row (its folder tiles) is a normal row in the
   Collections group there: it can be hidden or dragged anywhere.
-- A catalog claimed by an enabled collection folder is **folder-only**: it no
+- A catalog claimed by a visible, enabled collection folder is **folder-only**: it no
   longer appears as a plain Home row, and it is listed under its folder rather
   than under its addon in Home Rows. Hiding the collection (Settings → Home
-  Screen → Collections) returns those catalogs to the board.
+  Screen → Collections), or hiding its row in Home Rows, returns those catalogs
+  to the board unless they were independently hidden. Search and Discover keep
+  their normal catalog access because those modes do not show collection rows.
 
 ## Persistence and WebDAV sync
 
@@ -146,11 +149,24 @@ Mutations read and write within the profile preference mutation barrier. WebDAV
 sync stores one stamped record per collection ID, with a separate order record.
 Independent imports on different devices merge; simultaneous edits to the same
 collection use the existing sync stamp ordering. Deleting a collection retains
-a null record, so an offline peer cannot restore it accidentally. A deliberate
-later reimport may restore it. Deletion identities are retained rather than
-expired by time; they count toward the inventory limits.
+a local null marker until sync moves the deletion into its normal tombstone
+tier. The engine journals that tombstone before clearing the marker, including
+across an interrupted apply or publication. Published deletions follow the
+shared 90-day retention policy and dormant-device protection. A deliberate later
+reimport may restore a collection; a newer edit on another device, including a
+visibility change, may also win over an older deletion under the stamp rules.
+
+Reads salvage valid collection records if another record is damaged. Settings
+shows a recovery notice with **Reset damaged collections**; explicit backup
+restore can also repair the inventory. Ordinary imports refuse to overwrite
+damaged local data until it is reset or restored. Backup exports include the
+valid records. Malformed collection entries are skipped during sync, and a wholly
+undecodable local inventory is treated as empty for that sync build, so it cannot
+stop unrelated profiles from syncing.
 
 Incoming sync changes refresh Home, an open folder, and collection settings.
+Unrelated settings notifications preserve loaded folder pages and TV focus;
+actual folder configuration changes restore focus to the folder control.
 The limit on local growth also allows an older or merged oversized inventory
 to be reduced. The shared WebDAV hot-document limit still applies to the whole
 profile; this feature does not remove that existing aggregate limit. Use the
@@ -159,7 +175,10 @@ array-only store cannot read the upgraded inventory.
 
 Catalog paging advances by the raw response count, including filtered-out or
 overlapping results. Only an empty raw catalog response means the end. Failed
-requests and addons that make no progress show a retryable state. Initial rail
+requests, responses without a `metas` array, and addons that make no progress
+show a retryable state. All shares an eight-request-per-source budget for each
+page attempt, including filtered and duplicate-only windows. Retry bypasses the
+cache for the retried rail request, then normal cache use resumes. Initial rail
 loads and the merged view use bounded concurrency; retries retain the selected
 list and TV focus returns to content when it becomes available.
 

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -80,7 +80,8 @@ Field notes:
 - `heroBackdropUrl`, `titleLogoUrl`: the backdrop and logo shown above the
   folder's lists when it is opened; the cover stands in for a missing
   backdrop, the title for a missing logo.
-- `pinToTop`: the row leads the Home board; otherwise collection rows sit
+- `pinToTop`: a newly imported row leads the Home board, including when a
+  saved Home Rows order already exists; otherwise collection rows sit
   after the tracker list rows and before addon catalog rows. Rows can be
   re-arranged or hidden under **Home Screen → Home Rows** like any other row
   (row id `collection:<id>`).
@@ -96,11 +97,11 @@ Each source names an addon by its Stremio manifest id (`addonId`) plus a
 catalog `type` and `catalogId`. On the device the source is resolved against
 the installed catalog addons:
 
-1. an addon whose manifest id equals `addonId` and serves the requested
-   browsable catalog, else
-2. any installed addon that serves a catalog with the same `type` and
-   `catalogId` (a file made against a different deployment of the same addon
-   still works).
+Only an addon whose manifest id equals `addonId` and serves the requested
+browsable catalog is used. Catalog ids are provider-local: another addon's
+`top` or `popular` is not a compatible substitute. A file from a deployment
+with a different manifest id needs its source ids updated to the installed
+provider before those sources can resolve.
 
 Sources that resolve to nothing are skipped. The settings page and the import
 result dialog list the missing addon ids, and a folder whose sources all fail

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -175,9 +175,11 @@ updated implementation on each device that edits collections; the original PR's
 array-only store cannot read the upgraded inventory.
 
 Catalog paging advances by the raw response count, including filtered-out or
-overlapping results. Only an empty raw catalog response means the end. Failed
-requests, responses without a `metas` array, and addons that make no progress
-show a retryable state. All shares an eight-request-per-source budget for each
+overlapping results. An empty raw catalog response means the end, including
+`{}` and `{"metas": null}`, consistent with Home and See All. Failed requests
+and wrongly typed `metas` values show a retryable state. In All, one source's
+filtered or overlapping window does not interrupt another source's progress;
+no-progress becomes retryable only when the shared attempt budget is exhausted. All shares an eight-request-per-source budget for each
 page attempt, including filtered and duplicate-only windows. Retry bypasses the
 cache for the retried rail request, then normal cache use resumes. Initial rail
 loads and the merged view use bounded concurrency; retries retain the selected

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -18,7 +18,12 @@ Settings → **Home Screen** → **Collections**:
 Imports **merge**: a collection whose `id` already exists is replaced in place
 (keeping its show/hide state); new ids are appended. Tapping a collection
 offers hide-from-Home and delete; "Remove all" is under Danger Zone. Documents
-over 8 MB are refused.
+over 8 MiB are refused. Persisted collection definitions have a 128 KiB
+aggregate limit per profile, including retained deletion records, and a maximum
+of 1,024 collection identities. An import that would grow beyond either limit
+fails before saving. This leaves space for the profile's other sync data.
+Profile changes during a picker or download cancel the import; failed storage
+writes are reported as failures.
 
 Collections are per profile and are included in **Backup & Restore**
 (`homeCollections` in the backup payload).
@@ -90,7 +95,8 @@ Each source names an addon by its Stremio manifest id (`addonId`) plus a
 catalog `type` and `catalogId`. On the device the source is resolved against
 the installed catalog addons:
 
-1. an addon whose manifest id equals `addonId`, else
+1. an addon whose manifest id equals `addonId` and serves the requested
+   browsable catalog, else
 2. any installed addon that serves a catalog with the same `type` and
    `catalogId` (a file made against a different deployment of the same addon
    still works).
@@ -129,12 +135,42 @@ detail page and Quick Play of the addon that served them.
   than under its addon in Home Rows. Hiding the collection (Settings → Home
   Screen → Collections) returns those catalogs to the board.
 
+## Persistence and WebDAV sync
+
+The local `home_collections_v1` preference now contains a version-2 inventory:
+`{ "version": 2, "records": { "collection-id": { … } }, "order": [ … ] }`.
+Existing array preferences are read and upgraded on the next mutation. Legacy
+backup exports remain Nuvio-compatible arrays of present collections.
+
+Mutations read and write within the profile preference mutation barrier. WebDAV
+sync stores one stamped record per collection ID, with a separate order record.
+Independent imports on different devices merge; simultaneous edits to the same
+collection use the existing sync stamp ordering. Deleting a collection retains
+a null record, so an offline peer cannot restore it accidentally. A deliberate
+later reimport may restore it. Deletion identities are retained rather than
+expired by time; they count toward the inventory limits.
+
+Incoming sync changes refresh Home, an open folder, and collection settings.
+The limit on local growth also allows an older or merged oversized inventory
+to be reduced. The shared WebDAV hot-document limit still applies to the whole
+profile; this feature does not remove that existing aggregate limit. Use the
+updated implementation on each device that edits collections; the original PR's
+array-only store cannot read the upgraded inventory.
+
+Catalog paging advances by the raw response count, including filtered-out or
+overlapping results. Only an empty raw catalog response means the end. Failed
+requests and addons that make no progress show a retryable state. Initial rail
+loads and the merged view use bounded concurrency; retries retain the selected
+list and TV focus returns to content when it becomes available.
+
 ## Code map
 
 | Piece | File |
 |---|---|
 | Schema, parser, row-id grammar | `lib/models/home_collection.dart` |
 | Store (`home_collections_v1`), import (file/URL/paste), addon resolution | `lib/services/home_collections_store.dart` |
+| Atomic inventory and durable deletions | `lib/models/home_collection_inventory.dart` |
+| Per-catalog raw cursor and retry state | `lib/services/collection_catalog_pager.dart` |
 | Merged multi-catalog paging | `lib/services/collection_folder_loader.dart` |
 | Home row section (`HomeCollectionSection`) | `lib/services/home_collection_rows.dart` |
 | Folder browser screen | `lib/screens/collections/collection_folder_screen.dart` |
@@ -144,4 +180,4 @@ detail page and Quick Play of the addon that served them.
 | Board wiring | `lib/screens/search_screen.dart` — `_buildCollectionSections`, `_openCollectionFolder`, `_openCollectionScreen` |
 | Home Rows manager group | `lib/screens/settings/home_sections_filter_page.dart` |
 | Backup / restore | `lib/services/backup_restore_service.dart` (`homeCollections`) |
-| Tests | `test/home_collections_test.dart` |
+| Tests | `test/home_collections*_test.dart`, `test/collection_catalog_pager_test.dart`, WebDAV engine tests |

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -68,10 +68,12 @@ Field notes:
   de-duplicated. Only `provider: "addon"` sources are used.
 - `tileShape`: `LANDSCAPE` (16:9, default), `PORTRAIT` (2:3) or `SQUARE`.
 - `hideTitle`: draw no text over the cover (the art carries the brand).
-- `focusGifUrl` + `focusGifEnabled`: animated art played over the tile while
-  it is focused or hovered.
+- `focusGifUrl`: animated art played over the tile while it is focused or
+  hovered (`focusGifEnabled` is ignored; community files set the URL without
+  the flag).
 - `heroBackdropUrl`, `titleLogoUrl`: the backdrop and logo shown above the
-  folder's lists when it is opened.
+  folder's lists when it is opened; the cover stands in for a missing
+  backdrop, the title for a missing logo.
 - `pinToTop`: the row leads the Home board; otherwise collection rows sit
   after the tracker list rows and before addon catalog rows. Rows can be
   re-arranged or hidden under **Home Screen → Home Rows** like any other row

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -1,0 +1,141 @@
+# Collections (Nuvio / Xperience-style folder imports)
+
+Debrify imports **collections JSON** files — the format Nuvio and Xperience
+use to describe named groups of "folders", where each folder bundles one or
+more Stremio addon catalogs. Every imported collection becomes a row of folder
+tiles on the Home screen; opening a folder browses its catalogs.
+
+## Importing
+
+Settings → **Home Screen** → **Collections**:
+
+| Action | Behaviour |
+|---|---|
+| Import from file | Pick a `.json` on the device |
+| Import from link | Download the JSON from an http(s) URL |
+| Paste JSON | Paste the file contents into a text box |
+
+Imports **merge**: a collection whose `id` already exists is replaced in place
+(keeping its show/hide state); new ids are appended. Tapping a collection
+offers hide-from-Home and delete; "Remove all" is under Danger Zone. Documents
+over 8 MB are refused.
+
+Collections are per profile and are included in **Backup & Restore**
+(`homeCollections` in the backup payload).
+
+## File format
+
+The parser accepts:
+
+- a bare list of collections (the Nuvio / Xperience export — see below),
+- `{ "collections": [ … ] }`,
+- a single collection object,
+- a bare list of folders (imported as one collection named "Imported").
+
+```json
+[
+  {
+    "id": "ee8e31f3-…",
+    "title": "Streaming",
+    "pinToTop": false,
+    "showAllTab": true,
+    "backdropImageUrl": null,
+    "folders": [
+      {
+        "id": "dd534772-…",
+        "title": "Netflix",
+        "hideTitle": true,
+        "coverImageUrl": "https://…/netflix.webp",
+        "heroBackdropUrl": "https://…/netflix.backdrop.webp",
+        "titleLogoUrl": "https://…/netflix.logo.webp",
+        "tileShape": "LANDSCAPE",
+        "catalogSources": [
+          { "addonId": "app.xperience.…", "type": "movie",  "catalogId": "streaming_netflix_movies", "genre": null },
+          { "addonId": "app.xperience.…", "type": "series", "catalogId": "streaming_netflix_series", "genre": null }
+        ],
+        "sources": [
+          { "provider": "addon", "addonId": "app.xperience.…", "type": "movie", "catalogId": "streaming_netflix_movies", "genre": null }
+        ]
+      }
+    ]
+  }
+]
+```
+
+Field notes:
+
+- `catalogSources` and `sources` describe the same catalogs; both are read and
+  de-duplicated. Only `provider: "addon"` sources are used.
+- `tileShape`: `LANDSCAPE` (16:9, default), `PORTRAIT` (2:3) or `SQUARE`.
+- `hideTitle`: draw no text over the cover (the art carries the brand).
+- `pinToTop`: the row leads the Home board; otherwise collection rows sit
+  after the tracker list rows and before addon catalog rows. Rows can be
+  re-arranged or hidden under **Home Screen → Home Rows** like any other row
+  (row id `collection:<id>`).
+- `showAllTab`: the folder browser offers an "All" view merging every list.
+- Records without an `id` get a stable one derived from their title, so
+  re-importing the same file updates rather than duplicates.
+- Unknown fields (`viewMode`, `focusGlowEnabled`, focus GIF/video URLs, …) are
+  ignored.
+
+## Addon resolution
+
+Each source names an addon by its Stremio manifest id (`addonId`) plus a
+catalog `type` and `catalogId`. On the device the source is resolved against
+the installed catalog addons:
+
+1. an addon whose manifest id equals `addonId`, else
+2. any installed addon that serves a catalog with the same `type` and
+   `catalogId` (a file made against a different deployment of the same addon
+   still works).
+
+Sources that resolve to nothing are skipped. The settings page and the import
+result dialog list the missing addon ids, and a folder whose sources all fail
+shows an explanatory empty state. Installing the addon is enough; no re-import
+is needed.
+
+## Browsing a folder
+
+Each catalog in a folder is its own **list**. The folder browser has two
+layouts, chosen by the per-profile "Tabbed folders" switch under Settings →
+Home Screen → Collections:
+
+- **Rows** (default): one horizontal rail per list, each with a See All into
+  the regular catalog browser (opened on the source's `genre`). Collections
+  with `showAllTab` also offer an "All" view.
+- **Tabs**: one list at a time as a full poster grid, chosen from a List chip,
+  with the same "All" entry when the collection enables it.
+
+The "All" view pages every list together into one merged, de-duplicated grid
+(round-robin interleaved, bounded fan-out). Items open through the normal
+detail page and Quick Play of the addon that served them.
+
+## Lists, Home rows and the Home Rows manager
+
+- Every folder appears in **Home Screen → Home Rows** as a group
+  ("Streaming › Netflix") with one switch per list. Switched-off lists are
+  left out of every folder view. These switches only hide or show; lists are
+  never arranged, since they live inside the folder.
+- The collection's own Home row (its folder tiles) is a normal row in the
+  Collections group there: it can be hidden or dragged anywhere.
+- A catalog claimed by an enabled collection folder is **folder-only**: it no
+  longer appears as a plain Home row, and it is listed under its folder rather
+  than under its addon in Home Rows. Hiding the collection (Settings → Home
+  Screen → Collections) returns those catalogs to the board.
+
+## Code map
+
+| Piece | File |
+|---|---|
+| Schema, parser, row-id grammar | `lib/models/home_collection.dart` |
+| Store (`home_collections_v1`), import (file/URL/paste), addon resolution | `lib/services/home_collections_store.dart` |
+| Merged multi-catalog paging | `lib/services/collection_folder_loader.dart` |
+| Home row section (`HomeCollectionSection`) | `lib/services/home_collection_rows.dart` |
+| Folder browser screen | `lib/screens/collections/collection_folder_screen.dart` |
+| Rail "See all" pill (TV focus rung) | `lib/widgets/collections/rail_see_all_pill.dart` |
+| Settings page | `lib/screens/settings/collections_settings_page.dart` |
+| Single-field prompt dialog (link / paste import) | `lib/widgets/text_prompt_dialog.dart` |
+| Board wiring | `lib/screens/search_screen.dart` — `_buildCollectionSections`, `_openCollectionFolder`, `_openCollectionScreen` |
+| Home Rows manager group | `lib/screens/settings/home_sections_filter_page.dart` |
+| Backup / restore | `lib/services/backup_restore_service.dart` (`homeCollections`) |
+| Tests | `test/home_collections_test.dart` |

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -68,6 +68,10 @@ Field notes:
   de-duplicated. Only `provider: "addon"` sources are used.
 - `tileShape`: `LANDSCAPE` (16:9, default), `PORTRAIT` (2:3) or `SQUARE`.
 - `hideTitle`: draw no text over the cover (the art carries the brand).
+- `focusGifUrl` + `focusGifEnabled`: animated art played over the tile while
+  it is focused or hovered.
+- `heroBackdropUrl`, `titleLogoUrl`: the backdrop and logo shown above the
+  folder's lists when it is opened.
 - `pinToTop`: the row leads the Home board; otherwise collection rows sit
   after the tracker list rows and before addon catalog rows. Rows can be
   re-arranged or hidden under **Home Screen → Home Rows** like any other row
@@ -75,7 +79,7 @@ Field notes:
 - `showAllTab`: the folder browser offers an "All" view merging every list.
 - Records without an `id` get a stable one derived from their title, so
   re-importing the same file updates rather than duplicates.
-- Unknown fields (`viewMode`, `focusGlowEnabled`, focus GIF/video URLs, …) are
+- Unknown fields (`viewMode`, `focusGlowEnabled`, focus video URLs, …) are
   ignored.
 
 ## Addon resolution

--- a/lib/models/home_collection.dart
+++ b/lib/models/home_collection.dart
@@ -351,7 +351,9 @@ class HomeCollectionParser {
   static List<HomeCollection> parse(String jsonText) {
     final Object? decoded;
     try {
-      decoded = jsonDecode(jsonText);
+      decoded = jsonDecode(
+        jsonText.trimLeft().replaceFirst(RegExp(r'^\uFEFF'), ''),
+      );
     } catch (_) {
       throw const FormatException('The file is not valid JSON.');
     }

--- a/lib/models/home_collection.dart
+++ b/lib/models/home_collection.dart
@@ -1,0 +1,423 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+
+/// Row-id grammar for imported collections on the Home board. Kept next to
+/// the model so the board, the Home Rows manager and the settings page
+/// cannot drift on what an id means.
+class HomeCollectionRowIds {
+  HomeCollectionRowIds._();
+
+  /// `collection:<collectionId>` — one board row per collection, its folders
+  /// as tiles.
+  static const String prefix = 'collection:';
+
+  static String collection(String collectionId) => '$prefix$collectionId';
+
+  static bool isCollection(String id) => id.startsWith(prefix);
+
+  /// The `<collectionId>` of a `collection:` id (null for anything else).
+  static String? collectionId(String id) =>
+      isCollection(id) ? id.substring(prefix.length) : null;
+
+  /// Synthetic meta id for a folder tile on the board (`StremioMeta.id`).
+  static String folderMetaId(String collectionId, String folderId) =>
+      'collection:$collectionId:$folderId';
+
+  /// `collectionlist:…` — one catalog list inside a folder. Toggleable in the
+  /// Home Rows manager (off = present in the disabled set) but never a board
+  /// row itself.
+  static const String folderListPrefix = 'collectionlist:';
+
+  static String folderList(
+    String collectionId,
+    String folderId,
+    CollectionCatalogSource source,
+  ) =>
+      '$folderListPrefix$collectionId:$folderId:'
+      '${source.addonId}:${source.type}:${source.catalogId}'
+      '${source.genre == null ? '' : ':${source.genre}'}';
+
+  static bool isFolderList(String id) => id.startsWith(folderListPrefix);
+}
+
+/// How an opened folder presents its lists: stacked horizontal rows, or one
+/// list at a time behind a selector. A per-profile preference, not part of
+/// the collections file.
+enum CollectionFolderLayout {
+  rows,
+  tabs;
+
+  static CollectionFolderLayout parse(Object? raw) =>
+      raw is String && raw.trim().toLowerCase() == 'tabs'
+      ? CollectionFolderLayout.tabs
+      : CollectionFolderLayout.rows;
+
+  String get storageValue => name;
+}
+
+/// How a folder's cover tile is shaped on the Home board.
+enum CollectionTileShape {
+  landscape(16 / 9),
+  portrait(2 / 3),
+  square(1);
+
+  const CollectionTileShape(this.aspectRatio);
+
+  /// Width / height.
+  final double aspectRatio;
+
+  /// Lenient: unknown or missing values fall back to landscape.
+  static CollectionTileShape parse(Object? raw) {
+    switch ((raw is String ? raw : '').trim().toUpperCase()) {
+      case 'PORTRAIT':
+      case 'POSTER':
+        return CollectionTileShape.portrait;
+      case 'SQUARE':
+        return CollectionTileShape.square;
+      default:
+        return CollectionTileShape.landscape;
+    }
+  }
+
+  String get storageValue => name.toUpperCase();
+}
+
+/// One addon catalog a folder pulls from.
+class CollectionCatalogSource {
+  /// Stremio manifest id of the addon (`StremioAddon.id`).
+  final String addonId;
+
+  /// `movie` / `series` / … — the catalog's type.
+  final String type;
+
+  /// `StremioAddonCatalog.id`.
+  final String catalogId;
+
+  /// Optional `genre` extra applied to the catalog request.
+  final String? genre;
+
+  const CollectionCatalogSource({
+    required this.addonId,
+    required this.type,
+    required this.catalogId,
+    this.genre,
+  });
+
+  /// De-duplication identity (a Nuvio file lists each source twice: under
+  /// `catalogSources` and again under `sources`).
+  String get key => '$addonId|$type|$catalogId|${genre ?? ''}';
+
+  static CollectionCatalogSource? fromJson(Object? json) {
+    if (json is! Map) return null;
+    // `sources` entries carry a `provider`; a non-addon provider (a future
+    // "url"/"trakt" source) is skipped rather than mis-read as an addon.
+    final provider = json['provider'];
+    if (provider is String && provider.isNotEmpty && provider != 'addon') {
+      return null;
+    }
+    final addonId = _str(json['addonId']) ?? _str(json['addon']);
+    final catalogId = _str(json['catalogId']) ?? _str(json['id']);
+    if (addonId == null || catalogId == null) return null;
+    final type = _str(json['type']) ?? 'movie';
+    final genre = _str(json['genre']);
+    return CollectionCatalogSource(
+      addonId: addonId,
+      type: type,
+      catalogId: catalogId,
+      genre: genre,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'addonId': addonId,
+    'type': type,
+    'catalogId': catalogId,
+    'genre': genre,
+  };
+}
+
+/// A folder: a titled, cover-art tile whose contents are the merged catalogs
+/// in [sources].
+class HomeCollectionFolder {
+  final String id;
+  final String title;
+
+  /// Draw no text over the cover — the art already carries the brand (e.g. a
+  /// Netflix logo tile).
+  final bool hideTitle;
+  final String? coverImageUrl;
+  final String? coverEmoji;
+  final String? heroBackdropUrl;
+  final String? titleLogoUrl;
+  final String? focusGifUrl;
+  final bool focusGifEnabled;
+  final CollectionTileShape tileShape;
+  final List<CollectionCatalogSource> sources;
+
+  const HomeCollectionFolder({
+    required this.id,
+    required this.title,
+    this.hideTitle = false,
+    this.coverImageUrl,
+    this.coverEmoji,
+    this.heroBackdropUrl,
+    this.titleLogoUrl,
+    this.focusGifUrl,
+    this.focusGifEnabled = false,
+    this.tileShape = CollectionTileShape.landscape,
+    this.sources = const [],
+  });
+
+  HomeCollectionFolder copyWith({List<CollectionCatalogSource>? sources}) =>
+      HomeCollectionFolder(
+        id: id,
+        title: title,
+        hideTitle: hideTitle,
+        coverImageUrl: coverImageUrl,
+        coverEmoji: coverEmoji,
+        heroBackdropUrl: heroBackdropUrl,
+        titleLogoUrl: titleLogoUrl,
+        focusGifUrl: focusGifUrl,
+        focusGifEnabled: focusGifEnabled,
+        tileShape: tileShape,
+        sources: sources ?? this.sources,
+      );
+
+  static HomeCollectionFolder? fromJson(
+    Object? json, {
+    required String collectionId,
+  }) {
+    if (json is! Map) return null;
+    final title = _str(json['title']) ?? _str(json['name']) ?? '';
+    final id =
+        _str(json['id']) ?? HomeCollection.stableId('$collectionId/$title');
+
+    final seen = <String>{};
+    final sources = <CollectionCatalogSource>[];
+    void addAll(Object? list) {
+      if (list is! List) return;
+      for (final raw in list) {
+        final s = CollectionCatalogSource.fromJson(raw);
+        if (s != null && seen.add(s.key)) sources.add(s);
+      }
+    }
+
+    // `catalogSources` is canonical; `sources` duplicates it with a
+    // `provider` field. Reading both tolerates files that carry only one.
+    addAll(json['catalogSources']);
+    addAll(json['sources']);
+
+    return HomeCollectionFolder(
+      id: id,
+      title: title,
+      hideTitle: json['hideTitle'] == true,
+      coverImageUrl: _str(json['coverImageUrl']) ?? _str(json['cover']),
+      coverEmoji: _str(json['coverEmoji']),
+      heroBackdropUrl:
+          _str(json['heroBackdropUrl']) ?? _str(json['backdropImageUrl']),
+      titleLogoUrl: _str(json['titleLogoUrl']),
+      focusGifUrl: _str(json['focusGifUrl']),
+      focusGifEnabled: json['focusGifEnabled'] == true,
+      tileShape: CollectionTileShape.parse(json['tileShape']),
+      sources: sources,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'title': title,
+    'hideTitle': hideTitle,
+    'coverImageUrl': coverImageUrl,
+    'coverEmoji': coverEmoji,
+    'heroBackdropUrl': heroBackdropUrl,
+    'titleLogoUrl': titleLogoUrl,
+    'focusGifUrl': focusGifUrl,
+    'focusGifEnabled': focusGifEnabled,
+    'tileShape': tileShape.storageValue,
+    'catalogSources': [for (final s in sources) s.toJson()],
+  };
+}
+
+/// A collection: a titled group of folders that becomes one Home row.
+///
+/// Storage and import share the Nuvio / Xperience JSON shape, so a backup
+/// round-trips and a third-party file parses without conversion. Every field
+/// is optional — third-party files drift, and a folder with no art is still
+/// a folder.
+class HomeCollection {
+  final String id;
+  final String title;
+
+  /// The row leads the board, ahead of the tracker list rows.
+  final bool pinToTop;
+
+  /// Whether the folder browser offers an "All" view merging every list.
+  final bool showAllTab;
+  final String? backdropImageUrl;
+  final List<HomeCollectionFolder> folders;
+
+  /// Local state (not in the Nuvio file): switched off without deleting.
+  final bool enabled;
+
+  /// Local state: when this collection was last imported, epoch ms.
+  final int? importedAtMs;
+
+  const HomeCollection({
+    required this.id,
+    required this.title,
+    this.pinToTop = false,
+    this.showAllTab = true,
+    this.backdropImageUrl,
+    this.folders = const [],
+    this.enabled = true,
+    this.importedAtMs,
+  });
+
+  String get rowId => HomeCollectionRowIds.collection(id);
+
+  int get sourceCount => folders.fold(0, (sum, f) => sum + f.sources.length);
+
+  HomeCollection copyWith({bool? enabled, int? importedAtMs}) => HomeCollection(
+    id: id,
+    title: title,
+    pinToTop: pinToTop,
+    showAllTab: showAllTab,
+    backdropImageUrl: backdropImageUrl,
+    folders: folders,
+    enabled: enabled ?? this.enabled,
+    importedAtMs: importedAtMs ?? this.importedAtMs,
+  );
+
+  static HomeCollection? fromJson(Object? json) {
+    if (json is! Map) return null;
+    final title = _str(json['title']) ?? _str(json['name']) ?? '';
+    final rawFolders = json['folders'];
+    if (title.isEmpty && rawFolders is! List) return null;
+    final id = _str(json['id']) ?? stableId(title);
+    final folders = <HomeCollectionFolder>[];
+    final seen = <String>{};
+    if (rawFolders is List) {
+      for (final raw in rawFolders) {
+        final f = HomeCollectionFolder.fromJson(raw, collectionId: id);
+        if (f != null && seen.add(f.id)) folders.add(f);
+      }
+    }
+    final importedAt = json['importedAt'];
+    return HomeCollection(
+      id: id,
+      title: title.isEmpty ? 'Collection' : title,
+      pinToTop: json['pinToTop'] == true,
+      showAllTab: json['showAllTab'] != false,
+      backdropImageUrl: _str(json['backdropImageUrl']),
+      folders: folders,
+      enabled: json['enabled'] != false,
+      importedAtMs: importedAt is num ? importedAt.toInt() : null,
+    );
+  }
+
+  /// Nuvio-compatible shape plus the local `enabled` / `importedAt` fields
+  /// (which a Nuvio import ignores).
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'title': title,
+    'pinToTop': pinToTop,
+    'showAllTab': showAllTab,
+    'backdropImageUrl': backdropImageUrl,
+    'folders': [for (final f in folders) f.toJson()],
+    'enabled': enabled,
+    if (importedAtMs != null) 'importedAt': importedAtMs,
+  };
+
+  /// Deterministic id for a record that came without one, so re-importing
+  /// the same file replaces rather than duplicates.
+  static String stableId(String seed) =>
+      sha1.convert(utf8.encode(seed)).toString().substring(0, 16);
+}
+
+/// Parses a collections JSON document into [HomeCollection]s.
+///
+/// Accepts:
+///   - a bare list of collections (the Nuvio / Xperience export),
+///   - `{ "collections": [ … ] }` (a wrapped export or a Debrify backup),
+///   - a single collection object,
+///   - a bare list of folders (wrapped into one "Imported" collection).
+///
+/// Throws [FormatException] with a user-readable message when the text is
+/// not JSON or holds no collection.
+class HomeCollectionParser {
+  HomeCollectionParser._();
+
+  static List<HomeCollection> parse(String jsonText) {
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(jsonText);
+    } catch (_) {
+      throw const FormatException('The file is not valid JSON.');
+    }
+    return parseDecoded(decoded);
+  }
+
+  static List<HomeCollection> parseDecoded(Object? decoded) {
+    Object? root = decoded;
+    if (root is Map) {
+      final wrapped =
+          root['collections'] ?? root['homeCollections'] ?? root['data'];
+      if (wrapped is List) {
+        root = wrapped;
+      } else if (root.containsKey('folders') ||
+          root.containsKey('title') ||
+          root.containsKey('name')) {
+        root = [root];
+      } else {
+        throw const FormatException(
+          'No collections found — expected a list of collections '
+          'with "title" and "folders".',
+        );
+      }
+    }
+    if (root is! List) {
+      throw const FormatException(
+        'Unexpected JSON shape — expected a list of collections.',
+      );
+    }
+    if (root.isEmpty) {
+      throw const FormatException('The file contains no collections.');
+    }
+
+    // A bare list of folders (catalog sources but no `folders`) imports as
+    // one collection.
+    final looksLikeFolders = root.every(
+      (e) =>
+          e is Map &&
+          !e.containsKey('folders') &&
+          (e.containsKey('catalogSources') || e.containsKey('sources')),
+    );
+    if (looksLikeFolders) {
+      root = [
+        {'title': 'Imported', 'folders': root},
+      ];
+    }
+
+    final out = <HomeCollection>[];
+    final seen = <String>{};
+    for (final raw in root) {
+      final c = HomeCollection.fromJson(raw);
+      if (c == null || !seen.add(c.id)) continue;
+      out.add(c);
+    }
+    if (out.isEmpty) {
+      throw const FormatException(
+        'No collections found — expected a list of collections '
+        'with "title" and "folders".',
+      );
+    }
+    return out;
+  }
+}
+
+String? _str(Object? v) {
+  if (v is! String) return null;
+  final t = v.trim();
+  return t.isEmpty ? null : t;
+}

--- a/lib/models/home_collection_inventory.dart
+++ b/lib/models/home_collection_inventory.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+
+import 'home_collection.dart';
+
+/// Atomic local inventory. Null records are durable, per-collection deletions:
+/// an absent record on an offline peer must never resurrect a deleted folder.
+/// Legacy list preferences are accepted and upgraded on the next mutation.
+class HomeCollectionInventory {
+  static const String prefsKey = 'home_collections_v1';
+  static const int maxStoredBytes = 128 * 1024;
+  static const int maxRecords = 1024;
+
+  final Map<String, HomeCollection?> records;
+  final List<String> order;
+
+  HomeCollectionInventory({
+    Map<String, HomeCollection?>? records,
+    List<String>? order,
+  }) : records = records ?? {},
+       order = order ?? [];
+
+  factory HomeCollectionInventory.decode(Object? encoded) {
+    if (encoded == null || encoded == '') return HomeCollectionInventory();
+    final raw = encoded is String ? jsonDecode(encoded) : encoded;
+    final out = HomeCollectionInventory();
+    if (raw is List) {
+      for (final item in raw) {
+        final c = HomeCollection.fromJson(item);
+        if (c == null) throw const FormatException('Invalid saved collection.');
+        out.put(c);
+      }
+      return out;
+    }
+    if (raw is! Map ||
+        raw['version'] != 2 ||
+        raw['records'] is! Map ||
+        raw['order'] is! List) {
+      throw const FormatException(
+        'Invalid saved collections. Restore a backup or remove them before importing.',
+      );
+    }
+    for (final entry in (raw['records'] as Map).entries) {
+      if (entry.key is! String || (entry.key as String).isEmpty) {
+        throw const FormatException('Invalid collection identity.');
+      }
+      final value = entry.value;
+      final c = value == null ? null : HomeCollection.fromJson(value);
+      if (value != null && (c == null || c.id != entry.key)) {
+        throw const FormatException('Invalid saved collection.');
+      }
+      out.records[entry.key as String] = c;
+    }
+    for (final id in raw['order'] as List) {
+      if (id is! String) {
+        throw const FormatException('Invalid collection order.');
+      }
+      if (out.records.containsKey(id) && !out.order.contains(id)) {
+        out.order.add(id);
+      }
+    }
+    for (final id in out.records.keys) {
+      if (!out.order.contains(id)) out.order.add(id);
+    }
+    return out;
+  }
+
+  List<HomeCollection> get collections => [
+    for (final id in order)
+      if (records[id] case final c?) c,
+  ];
+
+  void put(HomeCollection c) {
+    records[c.id] = c;
+    if (!order.contains(c.id)) order.add(c.id);
+  }
+
+  void remove(String id) {
+    if (records.containsKey(id)) records[id] = null;
+  }
+
+  Map<String, Object?> toJson() => {
+    'version': 2,
+    'records': {for (final e in records.entries) e.key: e.value?.toJson()},
+    'order': order,
+  };
+
+  /// IDs become WebDAV record keys and Home row identities. Reject oversized
+  /// identities before they can create an inventory that cannot be synced.
+  void validate() {
+    void bounded(String value, int limit, String label) {
+      if (value.contains('\u0000')) {
+        throw FormatException('$label contains an invalid character.');
+      }
+      if (utf8.encode(value).length > limit) {
+        throw FormatException(
+          '$label is too long. Import a smaller collection file.',
+        );
+      }
+    }
+
+    for (final entry in records.entries) {
+      if (entry.key.isEmpty) {
+        throw const FormatException('Collection ID must not be empty.');
+      }
+      bounded(entry.key, 256, 'Collection ID');
+      final c = entry.value;
+      if (c == null) continue;
+      for (final f in c.folders) {
+        bounded(f.id, 256, 'Folder ID');
+        for (final source in f.sources) {
+          bounded(source.addonId, 256, 'Addon ID');
+          bounded(source.catalogId, 256, 'Catalog ID');
+          bounded(source.type, 64, 'Catalog type');
+          bounded(source.genre ?? '', 256, 'Genre');
+        }
+      }
+    }
+  }
+
+  String encode() => jsonEncode(toJson());
+}

--- a/lib/models/home_collection_inventory.dart
+++ b/lib/models/home_collection_inventory.dart
@@ -2,8 +2,8 @@ import 'dart:convert';
 
 import 'home_collection.dart';
 
-/// Atomic local inventory. Null records are durable, per-collection deletions:
-/// an absent record on an offline peer must never resurrect a deleted folder.
+/// Atomic local inventory. Null records are pending per-collection deletions;
+/// sync journals them in its retained tombstone tier before removing them here.
 /// Legacy list preferences are accepted and upgraded on the next mutation.
 class HomeCollectionInventory {
   static const String prefsKey = 'home_collections_v1';
@@ -12,6 +12,7 @@ class HomeCollectionInventory {
 
   final Map<String, HomeCollection?> records;
   final List<String> order;
+  bool hadCorruption = false;
 
   HomeCollectionInventory({
     Map<String, HomeCollection?>? records,
@@ -63,6 +64,93 @@ class HomeCollectionInventory {
     }
     return out;
   }
+
+  /// Read usable records without allowing one damaged entry to disable Home,
+  /// backup or the rest of a sync circle. Strict decoding remains available
+  /// for writes until the user explicitly resets or restores damaged data.
+  factory HomeCollectionInventory.recover(Object? encoded) {
+    final out = HomeCollectionInventory();
+    if (encoded == null || encoded == '') return out;
+    Object? raw;
+    try {
+      raw = encoded is String ? jsonDecode(encoded) : encoded;
+    } catch (_) {
+      out.hadCorruption = true;
+      return out;
+    }
+    void read(Object? value, {String? id}) {
+      try {
+        if (value == null && id != null) {
+          final single = HomeCollectionInventory(
+            records: {id: null},
+            order: [id],
+          );
+          single.validate();
+          out.records[id] = null;
+          out.order.add(id);
+          return;
+        }
+        final c = HomeCollection.fromJson(value);
+        if (c == null || (id != null && c.id != id)) {
+          throw const FormatException('Invalid saved collection.');
+        }
+        HomeCollectionInventory(records: {c.id: c}, order: [c.id]).validate();
+        out.put(c);
+      } catch (_) {
+        out.hadCorruption = true;
+      }
+    }
+
+    if (raw is List) {
+      for (final value in raw) {
+        read(value);
+      }
+      return out;
+    }
+    if (raw is! Map || raw['version'] != 2 || raw['records'] is! Map) {
+      out.hadCorruption = true;
+      return out;
+    }
+    for (final e in (raw['records'] as Map).entries) {
+      if (e.key is! String) {
+        out.hadCorruption = true;
+        continue;
+      }
+      read(e.value, id: e.key as String);
+    }
+    final preferred = raw['order'];
+    if (preferred is List) {
+      final ordered = <String>[];
+      for (final id in preferred) {
+        if (id is! String) {
+          out.hadCorruption = true;
+          continue;
+        }
+        if (out.records.containsKey(id) && !ordered.contains(id)) {
+          ordered.add(id);
+        }
+      }
+      for (final id in out.order) {
+        if (!ordered.contains(id)) ordered.add(id);
+      }
+      out.order
+        ..clear()
+        ..addAll(ordered);
+    } else {
+      out.hadCorruption = true;
+    }
+    return out;
+  }
+
+  /// Import capacity concerns live definitions, not pending sync deletions.
+  int get liveCount => records.values.where((c) => c != null).length;
+  int get definitionBytes => utf8
+      .encode(
+        jsonEncode([
+          for (final c in collections) c.copyWith(enabled: true).toJson(),
+        ]),
+      )
+      .length;
 
   List<HomeCollection> get collections => [
     for (final id in order)

--- a/lib/screens/collections/collection_folder_screen.dart
+++ b/lib/screens/collections/collection_folder_screen.dart
@@ -7,6 +7,8 @@ import '../../models/home_collection.dart';
 import '../../models/stremio_addon.dart';
 import '../../services/analytics_service.dart';
 import '../../services/collection_folder_loader.dart';
+import '../../services/collection_catalog_pager.dart';
+import '../../services/main_page_bridge.dart';
 import '../../services/home_collections_store.dart';
 import '../../services/storage_service.dart';
 import '../../services/stremio_service.dart';
@@ -76,7 +78,28 @@ const int _kAllTab = -1;
 /// One catalog list inside the folder: its resolved addon/catalog, the pages
 /// loaded so far, and the focus plumbing for its rail.
 class _Rail {
-  _Rail({required this.source, required this.addon, required this.catalog});
+  _Rail({
+    required this.source,
+    required this.addon,
+    required this.catalog,
+    required StremioService stremio,
+  }) {
+    pager = CollectionCatalogPager(
+      addon: addon,
+      catalog: catalog,
+      genre: source.genre,
+      fetch: (a, c, {skip = 0, genre, onRawCount}) => stremio.fetchCatalog(
+        a,
+        c,
+        skip: skip,
+        genre: genre,
+        onRawCount: onRawCount,
+        forceRefresh: forceRefresh,
+      ),
+    );
+  }
+  late final CollectionCatalogPager pager;
+  bool forceRefresh = false;
 
   final CollectionCatalogSource source;
   final StremioAddon addon;
@@ -85,10 +108,11 @@ class _Rail {
   final GlobalKey containerKey = GlobalKey();
   final FocusNode seeAllNode = FocusNode(debugLabel: 'collection_rail_seeall');
   final List<StremioMeta> items = [];
-  int nextSkip = 0;
+  int get nextSkip => pager.skip;
   bool loadingInitial = true;
   bool loadingMore = false;
-  bool exhausted = false;
+  bool get exhausted => pager.exhausted;
+  String? get error => pager.error;
 
   /// "Popular Movies · Action" — the Home row title plus the source's genre.
   String get title {
@@ -123,10 +147,10 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
   List<_Rail> _rails = const [];
   List<String> _unresolved = const [];
   final ScrollController _railsScroll = ScrollController();
-  final GlobalKey<SeeAllPosterGridState> _tabGridKey = GlobalKey();
+  GlobalKey<SeeAllPosterGridState> _tabGridKey = GlobalKey();
 
   // The All (merged grid) view, shared by both layouts.
-  final GlobalKey<SeeAllPosterGridState> _allGridKey = GlobalKey();
+  GlobalKey<SeeAllPosterGridState> _allGridKey = GlobalKey();
   CollectionFolderLoader? _loader;
   final List<StremioMeta> _allItems = [];
   bool _allStarted = false;
@@ -145,7 +169,9 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
   final FocusNode _sortNode = FocusNode(debugLabel: 'collection_sort');
   final FocusNode _retryNode = FocusNode(debugLabel: 'collection_retry');
 
-  HomeCollection get _collection => widget.collection;
+  late HomeCollection _collection;
+  int _configurationToken = 0;
+  String? _configurationError;
   bool get _hasFolders => _collection.folders.isNotEmpty;
   HomeCollectionFolder get _folder => _collection.folders[_folderIndex];
   bool get _tabs => _layout == CollectionFolderLayout.tabs;
@@ -168,6 +194,9 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
   void initState() {
     super.initState();
     AnalyticsService.screenView('collection_folder');
+    _collection = widget.collection;
+    MainPageBridge.addHomeSettingsListener(_onConfigurationChanged);
+    _stremio.addAddonsChangedListener(_onConfigurationChanged);
     final count = _collection.folders.length;
     _folderIndex = count == 0
         ? 0
@@ -175,25 +204,57 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
     unawaited(_boot());
   }
 
-  Future<void> _boot() async {
+  void _onConfigurationChanged() => unawaited(_boot(refreshCollection: true));
+
+  Future<void> _boot({bool refreshCollection = false}) async {
+    final generation = ++_configurationToken;
+    ++_reqToken;
+    final session = HomeCollectionsStore.captureSession();
     try {
-      _addons = await _stremio.getCatalogAddons();
-    } catch (_) {
-      _addons = const [];
+      final addons = await _stremio.getCatalogAddons();
+      final disabled = await StorageService.getHomeDisabledSections();
+      final layout = await HomeCollectionsStore.instance.getFolderLayout();
+      HomeCollection? updated;
+      if (refreshCollection) {
+        final collections = await HomeCollectionsStore.instance
+            .getCollections();
+        for (final c in collections) {
+          if (c.id == _collection.id && c.enabled) updated = c;
+        }
+      }
+      if (!mounted || generation != _configurationToken) return;
+      HomeCollectionsStore.checkSession(session);
+      final folderId = _hasFolders ? _folder.id : null;
+      _addons = addons;
+      _disabled = disabled;
+      _layout = layout;
+      if (refreshCollection) {
+        _collection =
+            updated ??
+            HomeCollection(id: _collection.id, title: _collection.title);
+        final index = _collection.folders.indexWhere((f) => f.id == folderId);
+        _folderIndex = index < 0 ? 0 : index;
+      }
+      _configurationError = null;
+      _booted = true;
+      _rebuildFolder(
+        autoFocus: !refreshCollection,
+        preserveSelection: refreshCollection,
+      );
+    } catch (e) {
+      if (!mounted || generation != _configurationToken) return;
+      setState(() {
+        _configurationError =
+            'Could not load this collection. Retry to continue.';
+        _booted = true;
+      });
     }
-    try {
-      _disabled = await StorageService.getHomeDisabledSections();
-    } catch (_) {
-      _disabled = const {};
-    }
-    _layout = await HomeCollectionsStore.instance.getFolderLayout();
-    if (!mounted) return;
-    _booted = true;
-    _rebuildFolder(autoFocus: true);
   }
 
   @override
   void dispose() {
+    MainPageBridge.removeHomeSettingsListener(_onConfigurationChanged);
+    _stremio.removeAddonsChangedListener(_onConfigurationChanged);
     for (final r in _rails) {
       r.dispose();
     }
@@ -211,7 +272,12 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
 
   /// Resolve the current folder's enabled lists into rails and fetch their
   /// first pages. The All view is built lazily on first switch.
-  void _rebuildFolder({bool autoFocus = false}) {
+  void _rebuildFolder({
+    bool autoFocus = false,
+    bool preserveSelection = false,
+  }) {
+    final oldSource = preserveSelection ? _tabRail?.source.key : null;
+    final wasAll = preserveSelection && _showingAll;
     final token = ++_reqToken;
     for (final r in _rails) {
       r.dispose();
@@ -232,7 +298,9 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
           );
           continue;
         }
-        rails.add(_Rail(source: s, addon: addon, catalog: catalog));
+        rails.add(
+          _Rail(source: s, addon: addon, catalog: catalog, stremio: _stremio),
+        );
       }
     }
     setState(() {
@@ -244,85 +312,143 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
       _allLoadingInitial = false;
       _allLoadingMore = false;
       _allExhausted = false;
-      _tab = 0;
+      final index = rails.indexWhere((r) => r.source.key == oldSource);
+      _tab = wasAll && _collection.showAllTab && rails.length > 1
+          ? _kAllTab
+          : (index < 0 ? 0 : index);
+      _tabGridKey = GlobalKey();
+      _allGridKey = GlobalKey();
       if (!_collection.showAllTab || rails.length < 2) _view = _View.lists;
     });
-    for (final r in rails) {
-      unawaited(_loadRail(r, token));
-    }
+    unawaited(_loadInitialRails(rails, token));
     if (_showingAll) unawaited(_startAll(token));
     if (autoFocus && widget.isTelevision) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted || token != _reqToken) return;
-        _enterContent();
+        _folderNode.requestFocus();
       });
+    }
+  }
+
+  Future<void> _loadInitialRails(List<_Rail> rails, int token) async {
+    for (
+      var start = 0;
+      start < rails.length;
+      start += CollectionFolderLoader.maxConcurrent
+    ) {
+      if (!mounted || token != _reqToken) return;
+      await Future.wait(
+        rails
+            .skip(start)
+            .take(CollectionFolderLoader.maxConcurrent)
+            .map((rail) => _loadRail(rail, token)),
+      );
     }
   }
 
   Future<void> _loadRail(_Rail r, int token) async {
-    try {
-      var rawCount = 0;
-      final items = await _stremio.fetchCatalog(
-        r.addon,
-        r.catalog,
-        genre: r.source.genre,
-        onRawCount: (c) => rawCount = c,
-      );
-      if (!mounted || token != _reqToken) return;
-      setState(() {
-        r.items.addAll(items);
-        r.nextSkip = rawCount > 0 ? rawCount : items.length;
-        r.exhausted = items.isEmpty;
-        r.loadingInitial = false;
-      });
-    } catch (_) {
-      if (!mounted || token != _reqToken) return;
-      setState(() {
-        r.loadingInitial = false;
-        r.exhausted = true;
-      });
-    }
+    final page = await r.pager.nextPage();
+    if (!mounted || token != _reqToken) return;
+    setState(() {
+      r.items.addAll(page);
+      r.loadingInitial = false;
+    });
   }
 
   Future<void> _loadMoreRail(_Rail r) async {
-    if (r.loadingInitial || r.loadingMore || r.exhausted) return;
+    if (r.loadingInitial || r.loadingMore || r.exhausted || r.error != null) {
+      return;
+    }
     final token = _reqToken;
     setState(() => r.loadingMore = true);
-    try {
-      var rawCount = 0;
-      final page = await _stremio.fetchCatalog(
-        r.addon,
-        r.catalog,
-        skip: r.nextSkip,
-        genre: r.source.genre,
-        onRawCount: (c) => rawCount = c,
+    final page = await r.pager.nextPage();
+    if (!mounted || token != _reqToken) return;
+    setState(() {
+      r.items.addAll(page);
+      r.loadingMore = false;
+    });
+  }
+
+  Future<void> _retryRail(_Rail r) async {
+    if (r.loadingInitial || r.loadingMore) return;
+    if (r.items.isEmpty && r.exhausted) r.pager.reset();
+    r.forceRefresh = true;
+    final restoreFocus = _retryNode.hasFocus;
+    final token = _reqToken;
+    setState(() => r.loadingMore = true);
+    final page = await r.pager.nextPage();
+    if (!mounted || token != _reqToken) return;
+    setState(() {
+      r.items.addAll(page);
+      r.loadingMore = false;
+    });
+    _restoreRetryFocus(restoreFocus, token);
+  }
+
+  void _restoreRetryFocus(bool restore, int token) {
+    if (!restore || !widget.isTelevision) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted &&
+          token == _reqToken &&
+          !_showingEmpty &&
+          ModalRoute.of(context)?.isCurrent == true) {
+        _enterContent();
+      }
+    });
+  }
+
+  Future<void> _retryRails() async {
+    final token = _reqToken;
+    final retry = _rails
+        .where((r) => r.error != null || r.items.isEmpty)
+        .toList();
+    for (
+      var start = 0;
+      start < retry.length;
+      start += CollectionFolderLoader.maxConcurrent
+    ) {
+      if (!mounted || token != _reqToken) return;
+      await Future.wait(
+        retry
+            .skip(start)
+            .take(CollectionFolderLoader.maxConcurrent)
+            .map(_retryRail),
       );
-      if (!mounted || token != _reqToken) return;
-      final seen = r.items.map((m) => m.id).toSet();
-      final fresh = page.where((m) => seen.add(m.id)).toList();
-      setState(() {
-        r.nextSkip += rawCount > 0 ? rawCount : page.length;
-        if (fresh.isEmpty) {
-          r.exhausted = true;
-        } else {
-          r.items.addAll(fresh);
-        }
-        r.loadingMore = false;
-      });
-    } catch (_) {
-      if (!mounted || token != _reqToken) return;
-      setState(() => r.loadingMore = false);
+    }
+  }
+
+  void _retryCurrent() {
+    if (_configurationError != null || _rails.isEmpty) {
+      unawaited(_boot());
+      return;
+    }
+    if (_showingAll) {
+      if (_allLoadingInitial || _allLoadingMore) return;
+      if (_loader == null || _allExhausted) {
+        _allStarted = false;
+        _allItems.clear();
+        unawaited(_startAll(_reqToken, forceRefresh: true));
+      } else {
+        unawaited(_loadMoreAll(retry: true));
+      }
+    } else if (_tabs) {
+      final r = _tabRail;
+      if (r != null) unawaited(_retryRail(r));
+    } else {
+      unawaited(_retryRails());
     }
   }
 
   // ── All (merged grid) ──────────────────────────────────────────────────
 
-  Future<void> _startAll(int token) async {
+  Future<void> _startAll(int token, {bool forceRefresh = false}) async {
     if (_allStarted) return;
     _allStarted = true;
+    final restoreFocus = _retryNode.hasFocus;
     final loader = CollectionFolderLoader(
       folder: _folder.copyWith(sources: _enabledSources),
       installedAddons: _addons,
+      forceRefresh: forceRefresh,
     );
     setState(() {
       _loader = loader;
@@ -336,6 +462,7 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
         _allExhausted = loader.exhausted;
         _allLoadingInitial = false;
       });
+      _restoreRetryFocus(restoreFocus, token);
     } catch (_) {
       if (!mounted || token != _reqToken) return;
       setState(() {
@@ -345,15 +472,17 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
     }
   }
 
-  Future<void> _loadMoreAll() async {
+  Future<void> _loadMoreAll({bool retry = false}) async {
     final loader = _loader;
     if (loader == null ||
         _allLoadingInitial ||
         _allLoadingMore ||
-        _allExhausted) {
+        _allExhausted ||
+        (!retry && loader.hasErrors)) {
       return;
     }
     final token = _reqToken;
+    final restoreFocus = retry && _retryNode.hasFocus;
     setState(() => _allLoadingMore = true);
     try {
       final page = await loader.nextPage();
@@ -363,6 +492,7 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
         _allExhausted = loader.exhausted;
         _allLoadingMore = false;
       });
+      _restoreRetryFocus(restoreFocus, token);
     } catch (_) {
       if (!mounted || token != _reqToken) return;
       setState(() {
@@ -409,7 +539,10 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
 
   void _onTabChanged(int tab) {
     if (tab == _tab) return;
-    setState(() => _tab = tab);
+    setState(() {
+      _tab = tab;
+      _tabGridKey = GlobalKey();
+    });
     if (tab == _kAllTab) unawaited(_startAll(_reqToken));
   }
 
@@ -459,6 +592,7 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
       if (_offersAll) _viewNode,
       if (_view == _View.all) _sortNode,
     ],
+    if (_hasVisibleLoadError) _retryNode,
   ];
 
   bool get _showingEmpty {
@@ -564,6 +698,17 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
                 isTelevision: widget.isTelevision,
               ),
             _buildFilterBar(),
+            if (_hasVisibleLoadError)
+              Focus(
+                canRequestFocus: false,
+                onKeyEvent: _handleFilterKeys,
+                child: TextButton.icon(
+                  focusNode: _retryNode,
+                  onPressed: _retryCurrent,
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('Some lists could not load · Retry'),
+                ),
+              ),
             Expanded(child: _buildBody()),
           ],
         ),
@@ -655,10 +800,23 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
     return DiscoverShelfMetrics(cardHeight: posterW * 1.5, hPad: 24);
   }
 
+  bool get _hasVisibleLoadError {
+    if (_configurationError != null) return false;
+    if (_showingAll) {
+      return _allItems.isNotEmpty && (_loader?.hasErrors ?? false);
+    }
+    if (_tabs) {
+      return (_tabRail?.items.isNotEmpty ?? false) && _tabRail?.error != null;
+    }
+    return _rails.any((r) => r.items.isNotEmpty) &&
+        _rails.any((r) => r.error != null);
+  }
+
   Widget _buildBody() {
     if (!_booted) {
       return SkeletonPosterGrid(isTelevision: widget.isTelevision);
     }
+    if (_configurationError != null) return _buildEmpty();
     if (_showingAll) return _buildAll();
     if (_tabs) return _buildTab();
     return _buildLists();
@@ -702,7 +860,7 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
                 ),
               ),
               const SizedBox(width: 10),
-              RowTagPill(r.addon.name),
+              Flexible(child: RowTagPill(r.addon.name)),
               const Spacer(),
               RailSeeAllPill(
                 node: r.seeAllNode,
@@ -755,7 +913,7 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
     return SeeAllPosterGrid(
       // Keyed per list so switching tabs remounts the grid (fresh scroll and
       // focus memory) instead of morphing one list into another.
-      key: ValueKey('collection-tab-${r.source.key}'),
+      key: _tabGridKey,
       items: _sorted(r.items),
       isTelevision: widget.isTelevision,
       loadingMore: r.loadingMore,
@@ -797,7 +955,10 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
     final app = AppThemeScope.of(context);
     final String title;
     final String detail;
-    if (!_hasFolders) {
+    if (_configurationError != null) {
+      title = 'Could not load collection';
+      detail = _configurationError!;
+    } else if (!_hasFolders) {
       title = 'This collection has no folders';
       detail = 'Import a file that lists folders with catalog sources.';
     } else if (_folder.sources.isEmpty) {
@@ -823,68 +984,70 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
                 'missing an addon:\n${_unresolved.toSet().join('\n')}'
           : 'The catalogs may be empty, or the addon failed to respond.';
     }
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(40),
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 520),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                Icons.folder_open_rounded,
-                size: 44,
-                color: app.fade(app.core.tx, 0.25),
-              ),
-              const SizedBox(height: 14),
-              Text(
-                title,
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: app.fade(app.core.tx, 0.7),
-                  fontSize: 15,
-                  fontWeight: FontWeight.w700,
+    return SingleChildScrollView(
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 520),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.folder_open_rounded,
+                  size: 44,
+                  color: app.fade(app.core.tx, 0.25),
                 ),
-              ),
-              const SizedBox(height: 6),
-              Text(
-                detail,
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: app.fade(app.core.tx, 0.4),
-                  fontSize: 13,
+                const SizedBox(height: 14),
+                Text(
+                  title,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: app.fade(app.core.tx, 0.7),
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
-              ),
-              const SizedBox(height: 18),
-              Focus(
-                onKeyEvent: (_, event) {
-                  if (widget.isTelevision &&
-                      event is KeyDownEvent &&
-                      event.logicalKey == LogicalKeyboardKey.arrowUp) {
-                    _gridExitNode.requestFocus();
-                    return KeyEventResult.handled;
-                  }
-                  return KeyEventResult.ignored;
-                },
-                child: OutlinedButton.icon(
-                  focusNode: _retryNode,
-                  onPressed: () => _rebuildFolder(autoFocus: true),
-                  icon: const Icon(Icons.refresh_rounded, size: 18),
-                  label: const Text('Retry'),
-                  style: OutlinedButton.styleFrom(
-                    foregroundColor: app.core.tx,
-                    side: BorderSide(color: app.seeAll.accentBorder),
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 20,
-                      vertical: 12,
-                    ),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: app.shape.br(11),
+                const SizedBox(height: 6),
+                Text(
+                  detail,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: app.fade(app.core.tx, 0.4),
+                    fontSize: 13,
+                  ),
+                ),
+                const SizedBox(height: 18),
+                Focus(
+                  onKeyEvent: (_, event) {
+                    if (widget.isTelevision &&
+                        event is KeyDownEvent &&
+                        event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                      _gridExitNode.requestFocus();
+                      return KeyEventResult.handled;
+                    }
+                    return KeyEventResult.ignored;
+                  },
+                  child: OutlinedButton.icon(
+                    focusNode: _retryNode,
+                    onPressed: _retryCurrent,
+                    icon: const Icon(Icons.refresh_rounded, size: 18),
+                    label: const Text('Retry'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: app.core.tx,
+                      side: BorderSide(color: app.seeAll.accentBorder),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 20,
+                        vertical: 12,
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: app.shape.br(11),
+                      ),
                     ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/screens/collections/collection_folder_screen.dart
+++ b/lib/screens/collections/collection_folder_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -88,14 +89,18 @@ class _Rail {
       addon: addon,
       catalog: catalog,
       genre: source.genre,
-      fetch: (a, c, {skip = 0, genre, onRawCount}) => stremio.fetchCatalog(
-        a,
-        c,
-        skip: skip,
-        genre: genre,
-        onRawCount: onRawCount,
-        forceRefresh: forceRefresh,
-      ),
+      fetch: (a, c, {skip = 0, genre, onRawCount}) {
+        final refresh = forceRefresh;
+        forceRefresh = false;
+        return stremio.fetchCatalog(
+          a,
+          c,
+          skip: skip,
+          genre: genre,
+          onRawCount: onRawCount,
+          forceRefresh: refresh,
+        );
+      },
     );
   }
   late final CollectionCatalogPager pager;
@@ -172,6 +177,7 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
   late HomeCollection _collection;
   int _configurationToken = 0;
   String? _configurationError;
+  String? _configurationSignature;
   bool get _hasFolders => _collection.folders.isNotEmpty;
   HomeCollectionFolder get _folder => _collection.folders[_folderIndex];
   bool get _tabs => _layout == CollectionFolderLayout.tabs;
@@ -208,7 +214,6 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
 
   Future<void> _boot({bool refreshCollection = false}) async {
     final generation = ++_configurationToken;
-    ++_reqToken;
     final session = HomeCollectionsStore.captureSession();
     try {
       final addons = await _stremio.getCatalogAddons();
@@ -224,6 +229,34 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
       }
       if (!mounted || generation != _configurationToken) return;
       HomeCollectionsStore.checkSession(session);
+      final candidate = refreshCollection
+          ? updated ??
+                HomeCollection(id: _collection.id, title: _collection.title)
+          : _collection;
+      final relevantDisabled =
+          disabled
+              .where(
+                (id) => id.startsWith(
+                  '${HomeCollectionRowIds.folderListPrefix}${candidate.id}:',
+                ),
+              )
+              .toList()
+            ..sort();
+      final signature = jsonEncode({
+        'collection': candidate.toJson()..remove('importedAt'),
+        'addons': [for (final addon in addons) addon.toJson()],
+        'disabled': relevantDisabled,
+        'layout': layout.name,
+      });
+      if (_configurationError == null && signature == _configurationSignature) {
+        return;
+      }
+      _configurationSignature = signature;
+      final restoreFocus =
+          refreshCollection &&
+          widget.isTelevision &&
+          ModalRoute.of(context)?.isCurrent == true &&
+          FocusScope.of(context).hasFocus;
       final folderId = _hasFolders ? _folder.id : null;
       _addons = addons;
       _disabled = disabled;
@@ -238,7 +271,7 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
       _configurationError = null;
       _booted = true;
       _rebuildFolder(
-        autoFocus: !refreshCollection,
+        autoFocus: !refreshCollection || restoreFocus,
         preserveSelection: refreshCollection,
       );
     } catch (e) {
@@ -284,6 +317,7 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
     }
     final rails = <_Rail>[];
     final unresolved = <String>[];
+    final resolved = <String>{};
     if (_hasFolders) {
       for (final s in _enabledSources) {
         final addon = HomeCollectionsStore.resolveAddon(s, _addons);
@@ -298,6 +332,13 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
           );
           continue;
         }
+        final resolvedKey = jsonEncode([
+          addon.manifestUrl,
+          catalog.type,
+          catalog.id,
+          s.genre,
+        ]);
+        if (!resolved.add(resolvedKey)) continue;
         rails.add(
           _Rail(source: s, addon: addon, catalog: catalog, stremio: _stremio),
         );

--- a/lib/screens/collections/collection_folder_screen.dart
+++ b/lib/screens/collections/collection_folder_screen.dart
@@ -19,6 +19,7 @@ import '../../widgets/collections/folder_hero_band.dart';
 import '../../widgets/collections/rail_see_all_pill.dart';
 import '../../widgets/home/row_tag_pill.dart';
 import '../../widgets/see_all/discover_shelf_scope.dart';
+import '../../widgets/see_all/discover_card_settings_scope.dart';
 import '../../widgets/see_all/see_all_filter_bar.dart';
 import '../../widgets/see_all/see_all_filter_focus.dart';
 import '../../widgets/see_all/see_all_header.dart';
@@ -596,20 +597,31 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
   /// rail already loaded (paging continues rather than restarts) and opened
   /// on the source's genre.
   void _openRailSeeAll(_Rail r) {
+    final settings = DiscoverCardSettingsScope.maybeOf(context);
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (_) => CatalogSeeAllScreen(
-          addon: r.addon,
-          initialCatalog: r.catalog,
-          initialGenre: r.source.genre,
-          seedItems: List<StremioMeta>.of(r.items),
-          seedNextSkip: r.nextSkip,
-          isTelevision: widget.isTelevision,
-          onOpenItem: widget.onOpenItem,
-          onQuickPlay: widget.onQuickPlay,
-          onItemFocused: widget.onItemFocused,
-          isBound: widget.isBound,
-        ),
+        builder: (_) {
+          final screen = CatalogSeeAllScreen(
+            addon: r.addon,
+            initialCatalog: r.catalog,
+            initialGenre: r.catalog.supportsGenre ? r.source.genre : null,
+            seedItems: List<StremioMeta>.of(r.items),
+            seedNextSkip: r.nextSkip,
+            isTelevision: widget.isTelevision,
+            onOpenItem: widget.onOpenItem,
+            onQuickPlay: widget.onQuickPlay,
+            onItemFocused: widget.onItemFocused,
+            isBound: widget.isBound,
+          );
+          return settings == null
+              ? screen
+              : DiscoverCardSettingsScope(
+                  showTitles: settings.showTitles,
+                  showRatings: settings.showRatings,
+                  showTypeTags: settings.showTypeTags,
+                  child: screen,
+                );
+        },
       ),
     );
   }
@@ -929,7 +941,6 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
                     onOpen: widget.onOpenItem,
                     onQuickPlay: widget.onQuickPlay,
                     onItemFocused: (item) {
-                      _ensureRailVisible(r);
                       widget.onItemFocused?.call(item);
                     },
                     isBound: widget.isBound,

--- a/lib/screens/collections/collection_folder_screen.dart
+++ b/lib/screens/collections/collection_folder_screen.dart
@@ -11,6 +11,7 @@ import '../../services/home_collections_store.dart';
 import '../../services/storage_service.dart';
 import '../../services/stremio_service.dart';
 import '../../theme/app_theme_scope.dart';
+import '../../utils/home_rail_metrics.dart';
 import '../../widgets/collections/folder_hero_band.dart';
 import '../../widgets/collections/rail_see_all_pill.dart';
 import '../../widgets/home/row_tag_pill.dart';
@@ -644,12 +645,14 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
     );
   }
 
+  /// Same poster geometry as a Home board rail, so a folder reads as Home
+  /// with different lists.
   DiscoverShelfMetrics _railMetrics(BuildContext context) {
-    final w = MediaQuery.sizeOf(context).width;
-    final cardH = widget.isTelevision
-        ? (w * 0.10).clamp(140.0, 200.0)
-        : (w * 0.14).clamp(120.0, 190.0);
-    return DiscoverShelfMetrics(cardHeight: cardH, hPad: 24);
+    final posterW = homeRailPosterWidth(
+      context,
+      isTelevision: widget.isTelevision,
+    );
+    return DiscoverShelfMetrics(cardHeight: posterW * 1.5, hPad: 24);
   }
 
   Widget _buildBody() {

--- a/lib/screens/collections/collection_folder_screen.dart
+++ b/lib/screens/collections/collection_folder_screen.dart
@@ -1,0 +1,883 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../models/home_collection.dart';
+import '../../models/stremio_addon.dart';
+import '../../services/analytics_service.dart';
+import '../../services/collection_folder_loader.dart';
+import '../../services/home_collections_store.dart';
+import '../../services/storage_service.dart';
+import '../../services/stremio_service.dart';
+import '../../theme/app_theme_scope.dart';
+import '../../widgets/collections/rail_see_all_pill.dart';
+import '../../widgets/home/row_tag_pill.dart';
+import '../../widgets/see_all/discover_shelf_scope.dart';
+import '../../widgets/see_all/see_all_filter_bar.dart';
+import '../../widgets/see_all/see_all_filter_focus.dart';
+import '../../widgets/see_all/see_all_header.dart';
+import '../../widgets/see_all/see_all_poster_grid.dart';
+import '../../widgets/see_all/stremio_dropdown.dart';
+import '../../widgets/skeleton_poster.dart';
+import '../see_all/catalog_see_all_screen.dart';
+
+/// Full-screen browser for one folder of an imported collection — where a
+/// folder tile on the Home board and the collection row's "See All" land.
+///
+/// Each catalog in a folder is its own list. Two layouts, chosen in
+/// Settings › Home Screen › Collections:
+///
+///  * **Rows** — one horizontal rail per list, each with its own See All
+///    into the regular catalog browser; a collection with `showAllTab` also
+///    offers an "All" view that pages every list into one merged grid.
+///  * **Tabs** — one list at a time as a full poster grid, picked from a
+///    List chip (plus "All" when the collection enables it).
+///
+/// Lists switched off in the Home Rows manager (`collectionlist:` ids in the
+/// disabled set) are left out of every view.
+///
+/// Rails reuse [SeeAllPosterGrid] in shelf mode (under a
+/// [DiscoverShelfScope]), so focus walking, paging and card chrome are the
+/// Discover stage's own; this screen only adds the vertical DPAD ladder
+/// between rails (See-All pill → cards → next rail's pill).
+class CollectionFolderScreen extends StatefulWidget {
+  final HomeCollection collection;
+  final int initialFolderIndex;
+  final void Function(StremioMeta item) onOpenItem;
+  final void Function(StremioMeta item)? onQuickPlay;
+  final void Function(StremioMeta item)? onItemFocused;
+  final bool Function(StremioMeta item)? isBound;
+  final bool isTelevision;
+
+  const CollectionFolderScreen({
+    super.key,
+    required this.collection,
+    required this.onOpenItem,
+    this.initialFolderIndex = 0,
+    this.onQuickPlay,
+    this.onItemFocused,
+    this.isBound,
+    this.isTelevision = false,
+  });
+
+  @override
+  State<CollectionFolderScreen> createState() => _CollectionFolderScreenState();
+}
+
+/// Rows layout: stacked rails, or the merged grid.
+enum _View { lists, all }
+
+/// Tabs layout: the merged grid's value in the List chip.
+const int _kAllTab = -1;
+
+/// One catalog list inside the folder: its resolved addon/catalog, the pages
+/// loaded so far, and the focus plumbing for its rail.
+class _Rail {
+  _Rail({required this.source, required this.addon, required this.catalog});
+
+  final CollectionCatalogSource source;
+  final StremioAddon addon;
+  final StremioAddonCatalog catalog;
+  final GlobalKey<SeeAllPosterGridState> gridKey = GlobalKey();
+  final GlobalKey containerKey = GlobalKey();
+  final FocusNode seeAllNode = FocusNode(debugLabel: 'collection_rail_seeall');
+  final List<StremioMeta> items = [];
+  int nextSkip = 0;
+  bool loadingInitial = true;
+  bool loadingMore = false;
+  bool exhausted = false;
+
+  /// "Popular Movies · Action" — the Home row title plus the source's genre.
+  String get title {
+    final base = CatalogSection.rowTitle(catalog);
+    final genre = source.genre;
+    return genre == null ? base : '$base · $genre';
+  }
+
+  /// Hidden once loaded empty — an empty rail is noise, like on Home.
+  bool get visible => loadingInitial || items.isNotEmpty;
+
+  void dispose() => seeAllNode.dispose();
+}
+
+class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
+  final StremioService _stremio = StremioService.instance;
+
+  static const String _sortDefault = 'default';
+  static const String _sortImdbDesc = 'imdbDesc';
+  static const String _sortImdbAsc = 'imdbAsc';
+  static const String _sortTitle = 'title';
+  String _sort = _sortDefault;
+
+  late int _folderIndex;
+  CollectionFolderLayout _layout = CollectionFolderLayout.rows;
+  _View _view = _View.lists;
+  int _tab = 0;
+  List<StremioAddon> _addons = const [];
+  Set<String> _disabled = const {};
+  bool _booted = false;
+
+  List<_Rail> _rails = const [];
+  List<String> _unresolved = const [];
+  final ScrollController _railsScroll = ScrollController();
+  final GlobalKey<SeeAllPosterGridState> _tabGridKey = GlobalKey();
+
+  // The All (merged grid) view, shared by both layouts.
+  final GlobalKey<SeeAllPosterGridState> _allGridKey = GlobalKey();
+  CollectionFolderLoader? _loader;
+  final List<StremioMeta> _allItems = [];
+  bool _allStarted = false;
+  bool _allLoadingInitial = false;
+  bool _allLoadingMore = false;
+  bool _allExhausted = false;
+
+  // Bumped on every folder change so in-flight pages from the previous
+  // folder are discarded when they land.
+  int _reqToken = 0;
+
+  final FocusNode _backNode = FocusNode(debugLabel: 'collection_back');
+  final FocusNode _folderNode = FocusNode(debugLabel: 'collection_folder');
+  final FocusNode _viewNode = FocusNode(debugLabel: 'collection_view');
+  final FocusNode _listNode = FocusNode(debugLabel: 'collection_list');
+  final FocusNode _sortNode = FocusNode(debugLabel: 'collection_sort');
+  final FocusNode _retryNode = FocusNode(debugLabel: 'collection_retry');
+
+  HomeCollection get _collection => widget.collection;
+  bool get _hasFolders => _collection.folders.isNotEmpty;
+  HomeCollectionFolder get _folder => _collection.folders[_folderIndex];
+  bool get _tabs => _layout == CollectionFolderLayout.tabs;
+
+  /// The folder's lists minus the ones switched off in Home Rows.
+  List<CollectionCatalogSource> get _enabledSources => [
+    for (final s in _folder.sources)
+      if (!_disabled.contains(
+        HomeCollectionRowIds.folderList(_collection.id, _folder.id, s),
+      ))
+        s,
+  ];
+
+  bool get _offersAll => _collection.showAllTab && _rails.length > 1;
+
+  /// Whether the merged grid is what's on screen.
+  bool get _showingAll => _tabs ? _tab == _kAllTab : _view == _View.all;
+
+  @override
+  void initState() {
+    super.initState();
+    AnalyticsService.screenView('collection_folder');
+    final count = _collection.folders.length;
+    _folderIndex = count == 0
+        ? 0
+        : widget.initialFolderIndex.clamp(0, count - 1);
+    unawaited(_boot());
+  }
+
+  Future<void> _boot() async {
+    try {
+      _addons = await _stremio.getCatalogAddons();
+    } catch (_) {
+      _addons = const [];
+    }
+    try {
+      _disabled = await StorageService.getHomeDisabledSections();
+    } catch (_) {
+      _disabled = const {};
+    }
+    _layout = await HomeCollectionsStore.instance.getFolderLayout();
+    if (!mounted) return;
+    _booted = true;
+    _rebuildFolder(autoFocus: true);
+  }
+
+  @override
+  void dispose() {
+    for (final r in _rails) {
+      r.dispose();
+    }
+    _railsScroll.dispose();
+    _backNode.dispose();
+    _folderNode.dispose();
+    _viewNode.dispose();
+    _listNode.dispose();
+    _sortNode.dispose();
+    _retryNode.dispose();
+    super.dispose();
+  }
+
+  // ── Folder (re)build ───────────────────────────────────────────────────
+
+  /// Resolve the current folder's enabled lists into rails and fetch their
+  /// first pages. The All view is built lazily on first switch.
+  void _rebuildFolder({bool autoFocus = false}) {
+    final token = ++_reqToken;
+    for (final r in _rails) {
+      r.dispose();
+    }
+    final rails = <_Rail>[];
+    final unresolved = <String>[];
+    if (_hasFolders) {
+      for (final s in _enabledSources) {
+        final addon = HomeCollectionsStore.resolveAddon(s, _addons);
+        final catalog = addon == null
+            ? null
+            : HomeCollectionsStore.resolveCatalog(s, addon);
+        if (addon == null || catalog == null) {
+          unresolved.add(
+            addon == null
+                ? s.addonId
+                : '${s.addonId} → ${s.type}/${s.catalogId}',
+          );
+          continue;
+        }
+        rails.add(_Rail(source: s, addon: addon, catalog: catalog));
+      }
+    }
+    setState(() {
+      _rails = rails;
+      _unresolved = unresolved;
+      _loader = null;
+      _allItems.clear();
+      _allStarted = false;
+      _allLoadingInitial = false;
+      _allLoadingMore = false;
+      _allExhausted = false;
+      _tab = 0;
+      if (!_collection.showAllTab || rails.length < 2) _view = _View.lists;
+    });
+    for (final r in rails) {
+      unawaited(_loadRail(r, token));
+    }
+    if (_showingAll) unawaited(_startAll(token));
+    if (autoFocus && widget.isTelevision) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || token != _reqToken) return;
+        _enterContent();
+      });
+    }
+  }
+
+  Future<void> _loadRail(_Rail r, int token) async {
+    try {
+      var rawCount = 0;
+      final items = await _stremio.fetchCatalog(
+        r.addon,
+        r.catalog,
+        genre: r.source.genre,
+        onRawCount: (c) => rawCount = c,
+      );
+      if (!mounted || token != _reqToken) return;
+      setState(() {
+        r.items.addAll(items);
+        r.nextSkip = rawCount > 0 ? rawCount : items.length;
+        r.exhausted = items.isEmpty;
+        r.loadingInitial = false;
+      });
+    } catch (_) {
+      if (!mounted || token != _reqToken) return;
+      setState(() {
+        r.loadingInitial = false;
+        r.exhausted = true;
+      });
+    }
+  }
+
+  Future<void> _loadMoreRail(_Rail r) async {
+    if (r.loadingInitial || r.loadingMore || r.exhausted) return;
+    final token = _reqToken;
+    setState(() => r.loadingMore = true);
+    try {
+      var rawCount = 0;
+      final page = await _stremio.fetchCatalog(
+        r.addon,
+        r.catalog,
+        skip: r.nextSkip,
+        genre: r.source.genre,
+        onRawCount: (c) => rawCount = c,
+      );
+      if (!mounted || token != _reqToken) return;
+      final seen = r.items.map((m) => m.id).toSet();
+      final fresh = page.where((m) => seen.add(m.id)).toList();
+      setState(() {
+        r.nextSkip += rawCount > 0 ? rawCount : page.length;
+        if (fresh.isEmpty) {
+          r.exhausted = true;
+        } else {
+          r.items.addAll(fresh);
+        }
+        r.loadingMore = false;
+      });
+    } catch (_) {
+      if (!mounted || token != _reqToken) return;
+      setState(() => r.loadingMore = false);
+    }
+  }
+
+  // ── All (merged grid) ──────────────────────────────────────────────────
+
+  Future<void> _startAll(int token) async {
+    if (_allStarted) return;
+    _allStarted = true;
+    final loader = CollectionFolderLoader(
+      folder: _folder.copyWith(sources: _enabledSources),
+      installedAddons: _addons,
+    );
+    setState(() {
+      _loader = loader;
+      _allLoadingInitial = true;
+    });
+    try {
+      final page = await loader.nextPage();
+      if (!mounted || token != _reqToken) return;
+      setState(() {
+        _allItems.addAll(page);
+        _allExhausted = loader.exhausted;
+        _allLoadingInitial = false;
+      });
+    } catch (_) {
+      if (!mounted || token != _reqToken) return;
+      setState(() {
+        _allLoadingInitial = false;
+        _allExhausted = true;
+      });
+    }
+  }
+
+  Future<void> _loadMoreAll() async {
+    final loader = _loader;
+    if (loader == null ||
+        _allLoadingInitial ||
+        _allLoadingMore ||
+        _allExhausted) {
+      return;
+    }
+    final token = _reqToken;
+    setState(() => _allLoadingMore = true);
+    try {
+      final page = await loader.nextPage();
+      if (!mounted || token != _reqToken) return;
+      setState(() {
+        _allItems.addAll(page);
+        _allExhausted = loader.exhausted;
+        _allLoadingMore = false;
+      });
+    } catch (_) {
+      if (!mounted || token != _reqToken) return;
+      setState(() {
+        _allLoadingMore = false;
+        _allExhausted = true;
+      });
+    }
+  }
+
+  /// Client-side sort over whatever is loaded. Default keeps addon order.
+  List<StremioMeta> _sorted(List<StremioMeta> items) {
+    if (_sort == _sortDefault) return items;
+    final sorted = List<StremioMeta>.of(items);
+    if (_sort == _sortTitle) {
+      sorted.sort(
+        (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
+      );
+      return sorted;
+    }
+    final asc = _sort == _sortImdbAsc;
+    sorted.sort((a, b) {
+      final ra = a.imdbRating, rb = b.imdbRating;
+      if (ra == null && rb == null) return 0;
+      if (ra == null) return 1;
+      if (rb == null) return -1;
+      return asc ? ra.compareTo(rb) : rb.compareTo(ra);
+    });
+    return sorted;
+  }
+
+  // ── Handlers ───────────────────────────────────────────────────────────
+
+  void _onFolderChanged(int index) {
+    if (index == _folderIndex) return;
+    setState(() => _folderIndex = index);
+    _rebuildFolder();
+  }
+
+  void _onViewChanged(_View view) {
+    if (view == _view) return;
+    setState(() => _view = view);
+    if (view == _View.all) unawaited(_startAll(_reqToken));
+  }
+
+  void _onTabChanged(int tab) {
+    if (tab == _tab) return;
+    setState(() => _tab = tab);
+    if (tab == _kAllTab) unawaited(_startAll(_reqToken));
+  }
+
+  void _onSortChanged(String sort) {
+    if (sort == _sort) return;
+    setState(() => _sort = sort);
+  }
+
+  /// The regular catalog browser on this rail's catalog, seeded with what the
+  /// rail already loaded (paging continues rather than restarts) and opened
+  /// on the source's genre.
+  void _openRailSeeAll(_Rail r) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => CatalogSeeAllScreen(
+          addon: r.addon,
+          initialCatalog: r.catalog,
+          initialGenre: r.source.genre,
+          seedItems: List<StremioMeta>.of(r.items),
+          seedNextSkip: r.nextSkip,
+          isTelevision: widget.isTelevision,
+          onOpenItem: widget.onOpenItem,
+          onQuickPlay: widget.onQuickPlay,
+          onItemFocused: widget.onItemFocused,
+          isBound: widget.isBound,
+        ),
+      ),
+    );
+  }
+
+  // ── TV focus ladder ────────────────────────────────────────────────────
+
+  List<_Rail> get _visibleRails => [
+    for (final r in _rails)
+      if (r.visible) r,
+  ];
+
+  _Rail? get _tabRail =>
+      _tab >= 0 && _tab < _rails.length ? _rails[_tab] : null;
+
+  List<FocusNode> get _filterNodes => [
+    _folderNode,
+    if (_tabs) ...[
+      if (_rails.isNotEmpty) _listNode,
+      _sortNode,
+    ] else ...[
+      if (_offersAll) _viewNode,
+      if (_view == _View.all) _sortNode,
+    ],
+  ];
+
+  bool get _showingEmpty {
+    if (!_booted) return false;
+    if (_showingAll) return !_allLoadingInitial && _allItems.isEmpty;
+    if (_tabs) {
+      final r = _tabRail;
+      return r == null || (!r.loadingInitial && r.items.isEmpty);
+    }
+    return _visibleRails.isEmpty;
+  }
+
+  /// DPAD-down from the filter line: the first rail's See-All pill (Rows) or
+  /// the grid on screen (Tabs / All); the Retry button when there's nothing.
+  void _enterContent() {
+    if (_showingEmpty) {
+      _retryNode.requestFocus();
+      return;
+    }
+    if (_showingAll) {
+      _allGridKey.currentState?.focusFirst();
+      return;
+    }
+    if (_tabs) {
+      _tabGridKey.currentState?.focusFirst();
+      return;
+    }
+    final rails = _visibleRails;
+    if (rails.isEmpty) {
+      _retryNode.requestFocus();
+      return;
+    }
+    rails.first.seeAllNode.requestFocus();
+  }
+
+  /// The chip the grid hands focus back to on DPAD-up.
+  FocusNode get _gridExitNode =>
+      _tabs && _rails.isNotEmpty ? _listNode : _folderNode;
+
+  void _focusRailAbove(_Rail r) {
+    final rails = _visibleRails;
+    final i = rails.indexOf(r);
+    if (i <= 0) {
+      _folderNode.requestFocus();
+      return;
+    }
+    rails[i - 1].gridKey.currentState?.focusFirst();
+  }
+
+  void _focusRailBelow(_Rail r) {
+    final rails = _visibleRails;
+    final i = rails.indexOf(r);
+    if (i < 0 || i + 1 >= rails.length) return;
+    rails[i + 1].seeAllNode.requestFocus();
+  }
+
+  void _ensureRailVisible(_Rail r) {
+    final ctx = r.containerKey.currentContext;
+    if (ctx == null) return;
+    Scrollable.ensureVisible(
+      ctx,
+      alignment: 0.15,
+      duration: const Duration(milliseconds: 180),
+      curve: Curves.easeOut,
+    );
+  }
+
+  KeyEventResult _handleFilterKeys(FocusNode _, KeyEvent event) {
+    if (!widget.isTelevision) return KeyEventResult.ignored;
+    return handleSeeAllFilterArrows(
+      event,
+      _filterNodes,
+      onDown: _enterContent,
+      onUp: () => _backNode.requestFocus(),
+    );
+  }
+
+  // ── Build ──────────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    final subtitle = !_hasFolders
+        ? 'No folders'
+        : '${_folder.title} · ${_rails.length} '
+              'list${_rails.length == 1 ? '' : 's'}';
+    return Scaffold(
+      backgroundColor: AppThemeScope.of(context).seeAll.bg,
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SeeAllHeader(
+              title: _collection.title,
+              subtitle: subtitle,
+              isTelevision: widget.isTelevision,
+              backNode: _backNode,
+              onFilterDown: () => _folderNode.requestFocus(),
+            ),
+            _buildFilterBar(),
+            Expanded(child: _buildBody()),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _sortChip() => StremioDropdown<String>(
+    label: 'Sort',
+    value: _sort,
+    isTelevision: widget.isTelevision,
+    focusNode: _sortNode,
+    options: const [
+      StremioDropdownOption(_sortDefault, 'Default'),
+      StremioDropdownOption(_sortImdbDesc, 'IMDb Rating · High → Low'),
+      StremioDropdownOption(_sortImdbAsc, 'IMDb Rating · Low → High'),
+      StremioDropdownOption(_sortTitle, 'Title · A → Z'),
+    ],
+    onSelected: _onSortChanged,
+  );
+
+  Widget _buildFilterBar() {
+    final folders = _collection.folders;
+    return Focus(
+      canRequestFocus: false,
+      skipTraversal: true,
+      onKeyEvent: _handleFilterKeys,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 10, 24, 12),
+        child: SeeAllFilterBar(
+          isTelevision: widget.isTelevision,
+          activeCount: _sort != _sortDefault && (_tabs || _showingAll) ? 1 : 0,
+          buildChips: () => [
+            StremioDropdown<int>(
+              label: 'Folder',
+              value: _folderIndex,
+              isTelevision: widget.isTelevision,
+              focusNode: _folderNode,
+              options: [
+                for (var i = 0; i < folders.length; i++)
+                  StremioDropdownOption(i, folders[i].title),
+              ],
+              onSelected: _onFolderChanged,
+            ),
+            if (_tabs) ...[
+              if (_rails.isNotEmpty)
+                StremioDropdown<int>(
+                  label: 'List',
+                  value: _tab,
+                  isTelevision: widget.isTelevision,
+                  focusNode: _listNode,
+                  options: [
+                    for (var i = 0; i < _rails.length; i++)
+                      StremioDropdownOption(i, _rails[i].title),
+                    if (_offersAll)
+                      const StremioDropdownOption(_kAllTab, 'All'),
+                  ],
+                  onSelected: _onTabChanged,
+                ),
+              _sortChip(),
+            ] else ...[
+              if (_offersAll)
+                StremioDropdown<_View>(
+                  label: 'View',
+                  value: _view,
+                  isTelevision: widget.isTelevision,
+                  focusNode: _viewNode,
+                  options: const [
+                    StremioDropdownOption(_View.lists, 'Lists'),
+                    StremioDropdownOption(_View.all, 'All'),
+                  ],
+                  onSelected: _onViewChanged,
+                ),
+              if (_view == _View.all) _sortChip(),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  DiscoverShelfMetrics _railMetrics(BuildContext context) {
+    final w = MediaQuery.sizeOf(context).width;
+    final cardH = widget.isTelevision
+        ? (w * 0.10).clamp(140.0, 200.0)
+        : (w * 0.14).clamp(120.0, 190.0);
+    return DiscoverShelfMetrics(cardHeight: cardH, hPad: 24);
+  }
+
+  Widget _buildBody() {
+    if (!_booted) {
+      return SkeletonPosterGrid(isTelevision: widget.isTelevision);
+    }
+    if (_showingAll) return _buildAll();
+    if (_tabs) return _buildTab();
+    return _buildLists();
+  }
+
+  Widget _buildLists() {
+    final rails = _visibleRails;
+    if (rails.isEmpty) return _buildEmpty();
+    final m = _railMetrics(context);
+    return ListView.builder(
+      controller: _railsScroll,
+      padding: const EdgeInsets.only(bottom: 24),
+      itemCount: rails.length,
+      itemBuilder: (context, i) => _buildRail(rails[i], m),
+    );
+  }
+
+  Widget _buildRail(_Rail r, DiscoverShelfMetrics m) {
+    final app = AppThemeScope.of(context);
+    final tv = widget.isTelevision;
+    return Column(
+      key: r.containerKey,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: EdgeInsets.fromLTRB(m.hPad, 14, m.hPad, 0),
+          child: Row(
+            children: [
+              Flexible(
+                child: Text(
+                  r.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: app.core.tx,
+                    fontSize: tv ? 18 : 16,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: -0.2,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              RowTagPill(r.addon.name),
+              const Spacer(),
+              RailSeeAllPill(
+                node: r.seeAllNode,
+                isTelevision: tv,
+                onPressed: () => _openRailSeeAll(r),
+                onUp: () => _focusRailAbove(r),
+                onDown: () => r.gridKey.currentState?.focusFirst(),
+                onFocused: () => _ensureRailVisible(r),
+              ),
+            ],
+          ),
+        ),
+        SizedBox(
+          height: m.columnHeight,
+          child: DiscoverShelfScope(
+            metrics: m,
+            child: r.loadingInitial
+                ? SkeletonPosterGrid(isTelevision: tv)
+                : SeeAllPosterGrid(
+                    key: r.gridKey,
+                    items: r.items,
+                    isTelevision: tv,
+                    loadingMore: r.loadingMore,
+                    exhausted: r.exhausted,
+                    onOpen: widget.onOpenItem,
+                    onQuickPlay: widget.onQuickPlay,
+                    onItemFocused: (item) {
+                      _ensureRailVisible(r);
+                      widget.onItemFocused?.call(item);
+                    },
+                    isBound: widget.isBound,
+                    onLoadMore: () => _loadMoreRail(r),
+                    onExitTop: tv ? () => r.seeAllNode.requestFocus() : null,
+                    onExitBottom: tv ? () => _focusRailBelow(r) : null,
+                  ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Tabs layout: the selected list as a full poster grid.
+  Widget _buildTab() {
+    final r = _tabRail;
+    if (r == null) return _buildEmpty();
+    if (r.loadingInitial) {
+      return SkeletonPosterGrid(isTelevision: widget.isTelevision);
+    }
+    if (r.items.isEmpty) return _buildEmpty();
+    return SeeAllPosterGrid(
+      // Keyed per list so switching tabs remounts the grid (fresh scroll and
+      // focus memory) instead of morphing one list into another.
+      key: ValueKey('collection-tab-${r.source.key}'),
+      items: _sorted(r.items),
+      isTelevision: widget.isTelevision,
+      loadingMore: r.loadingMore,
+      exhausted: r.exhausted,
+      onOpen: widget.onOpenItem,
+      onQuickPlay: widget.onQuickPlay,
+      onItemFocused: widget.onItemFocused,
+      isBound: widget.isBound,
+      onLoadMore: () => _loadMoreRail(r),
+      onExitTop: widget.isTelevision
+          ? () => _gridExitNode.requestFocus()
+          : null,
+    );
+  }
+
+  Widget _buildAll() {
+    if (_allLoadingInitial || (!_allStarted && _rails.isNotEmpty)) {
+      return SkeletonPosterGrid(isTelevision: widget.isTelevision);
+    }
+    if (_allItems.isEmpty) return _buildEmpty();
+    return SeeAllPosterGrid(
+      key: _allGridKey,
+      items: _sorted(_allItems),
+      isTelevision: widget.isTelevision,
+      loadingMore: _allLoadingMore,
+      exhausted: _allExhausted,
+      onOpen: widget.onOpenItem,
+      onQuickPlay: widget.onQuickPlay,
+      onItemFocused: widget.onItemFocused,
+      isBound: widget.isBound,
+      onLoadMore: _loadMoreAll,
+      onExitTop: widget.isTelevision
+          ? () => _gridExitNode.requestFocus()
+          : null,
+    );
+  }
+
+  Widget _buildEmpty() {
+    final app = AppThemeScope.of(context);
+    final String title;
+    final String detail;
+    if (!_hasFolders) {
+      title = 'This collection has no folders';
+      detail = 'Import a file that lists folders with catalog sources.';
+    } else if (_folder.sources.isEmpty) {
+      title = 'This folder lists no catalogs';
+      detail = 'Nothing to browse here.';
+    } else if (_enabledSources.isEmpty) {
+      title = 'Every list in this folder is switched off';
+      detail =
+          'Turn its lists back on under Settings › Home Screen › Home Rows.';
+    } else if (_rails.isEmpty) {
+      title = 'No matching addon installed';
+      detail =
+          'This folder needs an addon that isn\'t installed:\n'
+          '${_unresolved.toSet().join('\n')}\n\n'
+          'Install it under Addons, then come back.';
+    } else if (_tabs && !_showingAll) {
+      title = 'Nothing in this list';
+      detail = 'The catalog may be empty, or the addon failed to respond.';
+    } else {
+      title = 'Nothing in this folder';
+      detail = _unresolved.isNotEmpty
+          ? 'The installed catalogs returned nothing. Some lists are '
+                'missing an addon:\n${_unresolved.toSet().join('\n')}'
+          : 'The catalogs may be empty, or the addon failed to respond.';
+    }
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(40),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 520),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.folder_open_rounded,
+                size: 44,
+                color: app.fade(app.core.tx, 0.25),
+              ),
+              const SizedBox(height: 14),
+              Text(
+                title,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: app.fade(app.core.tx, 0.7),
+                  fontSize: 15,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                detail,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: app.fade(app.core.tx, 0.4),
+                  fontSize: 13,
+                ),
+              ),
+              const SizedBox(height: 18),
+              Focus(
+                onKeyEvent: (_, event) {
+                  if (widget.isTelevision &&
+                      event is KeyDownEvent &&
+                      event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                    _gridExitNode.requestFocus();
+                    return KeyEventResult.handled;
+                  }
+                  return KeyEventResult.ignored;
+                },
+                child: OutlinedButton.icon(
+                  focusNode: _retryNode,
+                  onPressed: () => _rebuildFolder(autoFocus: true),
+                  icon: const Icon(Icons.refresh_rounded, size: 18),
+                  label: const Text('Retry'),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: app.core.tx,
+                    side: BorderSide(color: app.seeAll.accentBorder),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 20,
+                      vertical: 12,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: app.shape.br(11),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/collections/collection_folder_screen.dart
+++ b/lib/screens/collections/collection_folder_screen.dart
@@ -11,6 +11,7 @@ import '../../services/home_collections_store.dart';
 import '../../services/storage_service.dart';
 import '../../services/stremio_service.dart';
 import '../../theme/app_theme_scope.dart';
+import '../../widgets/collections/folder_hero_band.dart';
 import '../../widgets/collections/rail_see_all_pill.dart';
 import '../../widgets/home/row_tag_pill.dart';
 import '../../widgets/see_all/discover_shelf_scope.dart';
@@ -555,6 +556,12 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
               backNode: _backNode,
               onFilterDown: () => _folderNode.requestFocus(),
             ),
+            if (_hasFolders)
+              FolderHeroBand(
+                key: ValueKey('folder-hero-${_folder.id}'),
+                folder: _folder,
+                isTelevision: widget.isTelevision,
+              ),
             _buildFilterBar(),
             Expanded(child: _buildBody()),
           ],

--- a/lib/screens/search/search_card_widgets.dart
+++ b/lib/screens/search/search_card_widgets.dart
@@ -39,6 +39,11 @@ class _StremioCard extends StatefulWidget {
   /// centre-cropped poster.
   final String? artUrl;
 
+  /// Animated art shown over [artUrl] only while the card is focused or
+  /// hovered (collection folder tiles). At most one card is active, so at
+  /// most one GIF decodes at a time.
+  final String? focusArtUrl;
+
   /// Whether the card may paint local title text, either on a landscape
   /// artwork overlay or inside a loading/missing-art placeholder. Home can
   /// suppress this while Search and Discover retain their defaults.
@@ -62,6 +67,7 @@ class _StremioCard extends StatefulWidget {
     this.heroTag,
     this.aspectRatio = 2 / 3,
     this.artUrl,
+    this.focusArtUrl,
     this.showTitleOverlay = true,
     this.restVeil,
   });
@@ -164,6 +170,16 @@ class _StremioCardState extends State<_StremioCard>
         )
       else
         _placeholder(item.name),
+      if (widget.focusArtUrl != null && _active)
+        Positioned.fill(
+          child: CachedNetworkImage(
+            imageUrl: widget.focusArtUrl!,
+            fit: BoxFit.cover,
+            fadeInDuration: HomeTheme.imageFadeIn(widget.isTelevision),
+            fadeOutDuration: Duration.zero,
+            errorWidget: (_, __, ___) => const SizedBox.shrink(),
+          ),
+        ),
       // A landscape still rarely carries its title the way poster art does,
       // and off TV there is no hero identity revealing the focused card —
       // so a wide TOUCH card labels itself. TV keeps clean cards: browsing

--- a/lib/screens/search/search_card_widgets.dart
+++ b/lib/screens/search/search_card_widgets.dart
@@ -174,6 +174,7 @@ class _StremioCardState extends State<_StremioCard>
         Positioned.fill(
           child: CachedNetworkImage(
             imageUrl: widget.focusArtUrl!,
+            memCacheWidth: 640,
             fit: BoxFit.cover,
             fadeInDuration: HomeTheme.imageFadeIn(widget.isTelevision),
             fadeOutDuration: Duration.zero,

--- a/lib/screens/search/search_stage_widgets.dart
+++ b/lib/screens/search/search_stage_widgets.dart
@@ -161,6 +161,7 @@ class _BoardCell extends StatelessWidget {
   /// row uses; Promenade's strip passes 16/9 with a derived wide still.
   final double aspectRatio;
   final String? artUrl;
+  final String? focusArtUrl;
   final bool showTitleOverlay;
 
   /// Dim applied to this cell while it is NOT focused (Promenade's strip).
@@ -204,6 +205,7 @@ class _BoardCell extends StatelessWidget {
     this.onRight,
     this.aspectRatio = 2 / 3,
     this.artUrl,
+    this.focusArtUrl,
     this.showTitleOverlay = true,
     this.restVeil,
     this.onUpHold,
@@ -283,6 +285,7 @@ class _BoardCell extends StatelessWidget {
         heroTag: heroTag,
         aspectRatio: aspectRatio,
         artUrl: artUrl,
+        focusArtUrl: focusArtUrl,
         showTitleOverlay: showTitleOverlay,
         restVeil: restVeil,
       ),

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -2472,7 +2472,7 @@ class _SearchScreenState extends State<SearchScreen>
     final extras = await StorageService.getHomeExtraRows();
     final rowOrder = await StorageService.getHomeRowOrder();
     final heroSource = await StorageService.getHomeHeroSource();
-    final collections = await HomeCollectionsStore.instance.getCollections();
+    final collections = await _readHomeCollections();
     if (!mounted) return;
     final collectionsSig = HomeCollectionsStore.signatureOf(collections);
     final collectionsUnchanged = collectionsSig == _homeCollectionsSig;
@@ -2590,7 +2590,7 @@ class _SearchScreenState extends State<SearchScreen>
       final extras = await StorageService.getHomeExtraRows();
       final rowOrder = await StorageService.getHomeRowOrder();
       final heroSource = await StorageService.getHomeHeroSource();
-      final collections = await HomeCollectionsStore.instance.getCollections();
+      final collections = await _readHomeCollections();
       // Commit the prefs and (crucially) start the tracker fan-out only if
       // this load still owns the board — a superseded run kicking off its own
       // resolve would double the concurrent tracker requests beside the
@@ -4482,6 +4482,15 @@ class _SearchScreenState extends State<SearchScreen>
       return;
     }
     _onCatalogPlay(item, section.addon);
+  }
+
+  Future<List<HomeCollection>> _readHomeCollections() async {
+    try {
+      return await HomeCollectionsStore.instance.getCollections();
+    } catch (_) {
+      debugPrint('Home: saved collections could not be loaded');
+      return const [];
+    }
   }
 
   /// Every enabled imported collection as a board row (hidden rows skipped).

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -1342,10 +1342,16 @@ class _SearchScreenState extends State<SearchScreen>
   /// CW ids. Seed those new ids after the Simkl CW family instead of allowing
   /// the generic ordering projection to append them at the bottom. Any MDBList
   /// id already saved keeps its chosen position untouched.
-  List<String> get _effectiveHomeRowOrder => HomeRowOrder.insertMissingAfter(
-    _homeRowOrder,
-    additions: const ['mdblist:movies', 'mdblist:shows'],
-    anchors: const ['simkl:movies', 'simkl:shows'],
+  List<String> get _effectiveHomeRowOrder => HomeRowOrder.seedPinned(
+    HomeRowOrder.insertMissingAfter(
+      _homeRowOrder,
+      additions: const ['mdblist:movies', 'mdblist:shows'],
+      anchors: const ['simkl:movies', 'simkl:shows'],
+    ),
+    [
+      for (final c in _homeCollections)
+        if (c.pinToTop) HomeCollectionRowIds.collection(c.id),
+    ],
   );
 
   /// Whether the Trakt rows should be held open with skeleton placeholders: the
@@ -4521,12 +4527,12 @@ class _SearchScreenState extends State<SearchScreen>
                 initialFolderIndex: folderIndex,
                 isTelevision: widget.isTelevision,
                 onOpenItem: (item) =>
-                    _openItem(item, _addonForContinue(item.sourceAddon?.id)),
+                    _openItem(item, item.sourceAddon ?? _addonForContinue(null)),
                 onQuickPlay: _pikpakOnly
                     ? null
                     : (item) => _onCatalogPlay(
                         item,
-                        _addonForContinue(item.sourceAddon?.id),
+                        item.sourceAddon ?? _addonForContinue(null),
                       ),
               ),
             ),
@@ -7069,12 +7075,17 @@ class _SearchScreenState extends State<SearchScreen>
                   ? null
                   : (_) => CachedNetworkImage(
                       imageUrl: section.focusArtOf(m)!,
+                      memCacheWidth: 640,
+                      errorWidget: (_, _, _) => const SizedBox.shrink(),
                       fit: BoxFit.cover,
                     ),
               title: m.name,
-              shape: section.landscapeTiles
+              shape: section.tileAspectRatio == 1
+                  ? SpotlightCardShape.square
+                  : section.landscapeTiles
                   ? SpotlightCardShape.wide
                   : SpotlightCardShape.poster,
+              showCaption: !(section.folderOf(m)?.hideTitle ?? false),
               onOpen: () => _openCollectionFolder(section, m),
             ),
         ],
@@ -7453,7 +7464,12 @@ class _SearchScreenState extends State<SearchScreen>
       if (_sections[i].items.isEmpty || i >= _rowNodes.length) continue;
       rails.add(_CanvasRail(sectionIndex: i));
     }
-    return rails;
+    return [
+      for (final rail in rails)
+        if (_stageCollection(rail)?.collection.pinToTop ?? false) rail,
+      for (final rail in rails)
+        if (!(_stageCollection(rail)?.collection.pinToTop ?? false)) rail,
+    ];
   }
 
   /// The canonical rails, globally sorted by the user's saved row ids.
@@ -7483,7 +7499,8 @@ class _SearchScreenState extends State<SearchScreen>
       rails = HomeRowOrder.insertAfterLeadingRun(
         rails,
         skeletons,
-        (rail) => rail.cw != null,
+        (rail) => rail.cw != null ||
+            (_stageCollection(rail)?.collection.pinToTop ?? false),
       );
     }
     return _homeRowOrderActive
@@ -7727,7 +7744,7 @@ class _SearchScreenState extends State<SearchScreen>
         // Title cards follow the Home Cards orientation (full shelf height
         // either way — the same grammar as Promenade's strip); favourites
         // keep their portrait cell whatever the setting says.
-        final cardW = cardH * _titleCardAspect;
+        final cardW = cardH * _stageCardAspect(rail);
         final favCardW = cardH * 2 / 3;
         // ONE height for the whole bottom column, measured bottom-up, so the
         // identity block above can reserve exactly what the tabs and shelf
@@ -7946,8 +7963,10 @@ class _SearchScreenState extends State<SearchScreen>
                                             // Canvas focus grammar: white ring (the
                                             // violet stays with classic chrome).
                                             ringColor: Colors.white,
-                                            aspectRatio: _titleCardAspect,
-                                            artUrl: _titleArtUrl(item),
+                                            aspectRatio: _stageCardAspect(rail),
+                                            artUrl: _stageCardArt(rail, item),
+                                            focusArtUrl: _stageCollection(rail)?.focusArtOf(item),
+                                            showTitleOverlay: !(_stageCollection(rail)?.folderOf(item)?.hideTitle ?? false),
                                             progress: rail.cw?.progressOf(item),
                                             episodeLabel: rail.cw?.episodeOf(
                                               item,
@@ -8093,7 +8112,22 @@ class _SearchScreenState extends State<SearchScreen>
   String? _titleArtUrl(StremioMeta item) =>
       _homeLandscapeCards ? _wideArtUrl(item) : null;
 
-  double _stagePosterW(double boxH) => boxH * _titleCardAspect;
+  HomeCollectionSection? _stageCollection(_CanvasRail rail) {
+    final index = rail.sectionIndex;
+    if (index == null) return null;
+    final section = _sections[index];
+    return section is HomeCollectionSection ? section : null;
+  }
+
+  double _stageCardAspect(_CanvasRail rail, {double? fallback}) =>
+      _stageCollection(rail)?.tileAspectRatio ?? fallback ?? _titleCardAspect;
+
+  String? _stageCardArt(_CanvasRail rail, StremioMeta item, {bool wide = false}) =>
+      _stageCollection(rail) != null
+          ? item.poster
+          : wide
+          ? _wideArtUrl(item)
+          : _titleArtUrl(item);
 
   double _stageFavW(BuildContext context, double boxH) {
     // Poster + caption must equal the box EXACTLY. A width floor here would
@@ -8193,7 +8227,7 @@ class _SearchScreenState extends State<SearchScreen>
         );
         final double cellW = favRail
             ? _stageFavW(context, stripBoxH)
-            : stripBoxH * 16 / 9;
+            : stripBoxH * _stageCardAspect(rail, fallback: 16 / 9);
         // Measured bottom-up, exactly like Canvas's shelfColumnH, so the
         // identity's clearance is DERIVED and can never drift into the strip.
         final columnH =
@@ -8395,8 +8429,10 @@ class _SearchScreenState extends State<SearchScreen>
       rowNodes: nodes,
       hasBoundSource: _isBound(item),
       ringColor: Colors.white,
-      aspectRatio: 16 / 9,
-      artUrl: _wideArtUrl(item),
+      aspectRatio: _stageCardAspect(rail, fallback: 16 / 9),
+      artUrl: _stageCardArt(rail, item, wide: true),
+      focusArtUrl: _stageCollection(rail)?.focusArtOf(item),
+      showTitleOverlay: !(_stageCollection(rail)?.folderOf(item)?.hideTitle ?? false),
       restVeil: _kPromRestVeil,
       progress: rail.cw?.progressOf(item),
       episodeLabel: rail.cw?.episodeOf(item),
@@ -8795,7 +8831,7 @@ class _SearchScreenState extends State<SearchScreen>
     final nodes = _canvasRailNodes(rail);
     final cardW = favRail
         ? _stageFavW(context, rowBoxH)
-        : _stagePosterW(rowBoxH);
+        : rowBoxH * _stageCardAspect(rail);
     final count = favRail ? _canvasFavItemCount(rail.favKind!) : items.length;
 
     // The window is [active, active+1]. From the top row UP leaves the
@@ -8875,8 +8911,10 @@ class _SearchScreenState extends State<SearchScreen>
                             rowNodes: nodes,
                             hasBoundSource: _isBound(items[col]),
                             ringColor: Colors.white,
-                            aspectRatio: _titleCardAspect,
-                            artUrl: _titleArtUrl(items[col]),
+                            aspectRatio: _stageCardAspect(rail),
+                            artUrl: _stageCardArt(rail, items[col]),
+                            focusArtUrl: _stageCollection(rail)?.focusArtOf(items[col]),
+                            showTitleOverlay: !(_stageCollection(rail)?.folderOf(items[col])?.hideTitle ?? false),
                             progress: rail.cw?.progressOf(items[col]),
                             episodeLabel: rail.cw?.episodeOf(items[col]),
                             onQuickPlay: rail.cw != null || _pikpakOnly
@@ -8955,7 +8993,7 @@ class _SearchScreenState extends State<SearchScreen>
         // A grid only ever shows ONE rail, and a rail is homogeneous — so
         // the whole wall takes one shape: favourites are always portrait,
         // title cells follow the Home Cards orientation.
-        final cellAspect = favRail ? 2 / 3 : _titleCardAspect;
+        final cellAspect = favRail ? 2 / 3 : _stageCardAspect(rail);
         // Aim for a cell about a third of the board's height — landscape a
         // little shorter, or three backdrops swallow the whole wall — then
         // take whatever whole number of columns actually FITS, as few as one.
@@ -9244,15 +9282,17 @@ class _SearchScreenState extends State<SearchScreen>
     }
     final item = items[col];
     return SizedBox(
-      height: cellW / _titleCardAspect,
+      height: cellW / _stageCardAspect(rail),
       child: _BoardCell(
         item: item,
         isTelevision: true,
         focusNode: nodes[col],
         column: col,
         rowNodes: nodes,
-        aspectRatio: _titleCardAspect,
-        artUrl: _titleArtUrl(item),
+        aspectRatio: _stageCardAspect(rail),
+        artUrl: _stageCardArt(rail, item),
+        focusArtUrl: _stageCollection(rail)?.focusArtOf(item),
+        showTitleOverlay: !(_stageCollection(rail)?.folderOf(item)?.hideTitle ?? false),
         hasBoundSource: _isBound(item),
         ringColor: Colors.white,
         progress: rail.cw?.progressOf(item),
@@ -9510,7 +9550,7 @@ class _SearchScreenState extends State<SearchScreen>
                               child: SizedBox(
                                 width: favRail
                                     ? _stageFavW(context, railBoxH)
-                                    : _stagePosterW(railBoxH),
+                                    : railBoxH * _stageCardAspect(rail),
                                 child: favRail
                                     ? _canvasFavCell(
                                         rail.favKind!,
@@ -9675,8 +9715,10 @@ class _SearchScreenState extends State<SearchScreen>
       rowNodes: nodes,
       hasBoundSource: _isBound(item),
       ringColor: Colors.white,
-      aspectRatio: _titleCardAspect,
-      artUrl: _titleArtUrl(item),
+      aspectRatio: _stageCardAspect(rail),
+      artUrl: _stageCardArt(rail, item),
+      focusArtUrl: _stageCollection(rail)?.focusArtOf(item),
+      showTitleOverlay: !(_stageCollection(rail)?.folderOf(item)?.hideTitle ?? false),
       progress: rail.cw?.progressOf(item),
       episodeLabel: rail.cw?.episodeOf(item),
       onQuickPlay: rail.cw != null || _pikpakOnly
@@ -10240,7 +10282,7 @@ class _SearchScreenState extends State<SearchScreen>
                 child: SizedBox(
                   width: favRail
                       ? _stageFavW(context, boxH)
-                      : _stagePosterW(boxH),
+                      : boxH * _stageCardAspect(rail),
                   child: favRail
                       ? _canvasFavCell(
                           rail.favKind!,
@@ -10439,9 +10481,20 @@ class _SearchScreenState extends State<SearchScreen>
     // Off-TV / blank search prompt the hero isn't rendered, so don't track focus
     // or fire the per-item backdrop-enrichment /meta fetch behind it.
     if (!_heroActive) return;
-    // A folder tile has no /meta, trailer or playback, so the hero keeps
-    // showing the last real title.
-    if (item.type == 'folder') return;
+    // Folders own the stage art too, but never request title metadata or video.
+    if (item.type == 'folder') {
+      _heroTimer?.cancel();
+      _heroReqId++;
+      _heroSwapTimer?.cancel();
+      _clearHeroTrailer();
+      _clearHeroLiveIptv();
+      _canvasFavFocus.value = null;
+      _heroEnriched.value = null;
+      _heroItem.value = item;
+      _publishAmbientArt(item, null);
+      _updateHeroTint(item);
+      return;
+    }
     // A catalog/CW card owns the stage again — drop any Canvas favourites
     // override so its art/identity yield to the hero pipeline.
     _canvasFavFocus.value = null;
@@ -10554,6 +10607,7 @@ class _SearchScreenState extends State<SearchScreen>
   /// lookups (Cinemeta /meta for the YouTube id, then the stream resolve) are
   /// cached in their services, so re-resting on a recent card starts fast.
   void _scheduleHeroTrailer(StremioMeta item, {bool fromSpotlight = false}) {
+    if (item.type == 'folder') return;
     // Off-TV nothing ever calls _applyHero (the TV paths that lift the
     // after-playback suppression), so a NEW title arriving through the
     // spotlight dwell lifts it here — fresh context, fresh trailer, the same

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -719,7 +719,7 @@ class _SearchScreenState extends State<SearchScreen>
   /// of folder tiles. [_homeCollectionsSig] is the store's change token the
   /// settings-changed listener diffs against.
   List<HomeCollection> _homeCollections = const [];
-  String _homeCollectionsSig = '';
+  String _homeCollectionsSig = HomeCollectionsStore.signatureOf(const []);
 
   /// Stable ids in the user's global Home-row order. Rows not present append
   /// canonically; ids whose backing row is temporarily unavailable stay saved.
@@ -2631,6 +2631,8 @@ class _SearchScreenState extends State<SearchScreen>
       final claimed = HomeCollectionsStore.claimedCatalogKeys(
         _homeCollections,
         addons,
+        disabledRows: _homeDisabled,
+        showsCollectionRows: !widget.searchMode && !widget.discoverMode,
       );
       final boardRefs = [
         for (final a in addons)

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -6937,6 +6937,12 @@ class _SearchScreenState extends State<SearchScreen>
             SpotlightCard(
               image: m.poster,
               fallbackImage: m.background,
+              previewBuilder: section.focusArtOf(m) == null
+                  ? null
+                  : (_) => CachedNetworkImage(
+                      imageUrl: section.focusArtOf(m)!,
+                      fit: BoxFit.cover,
+                    ),
               title: m.name,
               shape: section.landscapeTiles
                   ? SpotlightCardShape.wide
@@ -18547,6 +18553,7 @@ class _SearchScreenState extends State<SearchScreen>
                             artUrl: collection != null
                                 ? item.poster
                                 : _titleArtUrl(item),
+                            focusArtUrl: collection?.focusArtOf(item),
                             showTitleOverlay: collection != null
                                 ? !(collection.folderOf(item)?.hideTitle ??
                                       false)

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -14,6 +14,7 @@ import '../theme/artwork_accent.dart';
 import '../utils/platform_util.dart';
 import '../utils/tvos_device.dart';
 import '../models/debrify_tv/channel.dart';
+import '../models/home_collection.dart';
 import '../models/iptv_playlist.dart';
 import '../models/play_loader_art.dart';
 import '../models/playlist_view_mode.dart';
@@ -28,6 +29,8 @@ import '../services/discover_prefs.dart';
 import '../services/engine/dynamic_engine.dart';
 import '../services/engine/settings_manager.dart';
 import '../services/episode_artwork_service.dart';
+import '../services/home_collection_rows.dart';
+import '../services/home_collections_store.dart';
 import '../services/home_list_rows.dart';
 import '../services/home_row_order.dart';
 import '../services/iptv_cw_router.dart';
@@ -85,6 +88,7 @@ import '../widgets/source_row.dart';
 import '../widgets/torrent_filters_sheet.dart';
 import '../widgets/torrent_result_row.dart';
 import '../widgets/tv_text_field.dart';
+import 'collections/collection_folder_screen.dart';
 import 'iptv/xtream_series_detail.dart';
 import 'playlist_content_view_screen.dart';
 import 'see_all/catalog_see_all_screen.dart';
@@ -703,6 +707,12 @@ class _SearchScreenState extends State<SearchScreen>
   // of the board in [_load]; `iptvlist:` ids drive the IPTV list favourites
   // rows. Refreshed by [_reloadForHomeSettings].
   List<HomeExtraRow> _homeExtras = const [];
+
+  /// Imported collections — each enabled one is a [HomeCollectionSection] row
+  /// of folder tiles. [_homeCollectionsSig] is the store's change token the
+  /// settings-changed listener diffs against.
+  List<HomeCollection> _homeCollections = const [];
+  String _homeCollectionsSig = '';
 
   /// Stable ids in the user's global Home-row order. Rows not present append
   /// canonically; ids whose backing row is temporarily unavailable stay saved.
@@ -2447,7 +2457,10 @@ class _SearchScreenState extends State<SearchScreen>
     final extras = await StorageService.getHomeExtraRows();
     final rowOrder = await StorageService.getHomeRowOrder();
     final heroSource = await StorageService.getHomeHeroSource();
+    final collections = await HomeCollectionsStore.instance.getCollections();
     if (!mounted) return;
+    final collectionsSig = HomeCollectionsStore.signatureOf(collections);
+    final collectionsUnchanged = collectionsSig == _homeCollectionsSig;
     final disabledUnchanged =
         disabled.length == _homeDisabled.length &&
         disabled.containsAll(_homeDisabled);
@@ -2482,7 +2495,8 @@ class _SearchScreenState extends State<SearchScreen>
         boardExtrasUnchanged &&
         iptvExtrasUnchanged &&
         rowOrderUnchanged &&
-        heroSourceUnchanged) {
+        heroSourceUnchanged &&
+        collectionsUnchanged) {
       return;
     }
     setState(() {
@@ -2490,9 +2504,12 @@ class _SearchScreenState extends State<SearchScreen>
       _homeExtras = extras;
       _homeRowOrder = rowOrder;
       _heroSource = heroSource;
+      _homeCollections = collections;
+      _homeCollectionsSig = collectionsSig;
     });
     if (!disabledUnchanged ||
         !boardExtrasUnchanged ||
+        !collectionsUnchanged ||
         (!rowOrderUnchanged && !widget.searchMode && !widget.discoverMode)) {
       _requestBoardReload();
     } else if (!heroSourceUnchanged &&
@@ -2550,6 +2567,7 @@ class _SearchScreenState extends State<SearchScreen>
       final extras = await StorageService.getHomeExtraRows();
       final rowOrder = await StorageService.getHomeRowOrder();
       final heroSource = await StorageService.getHomeHeroSource();
+      final collections = await HomeCollectionsStore.instance.getCollections();
       // Commit the prefs and (crucially) start the tracker fan-out only if
       // this load still owns the board — a superseded run kicking off its own
       // resolve would double the concurrent tracker requests beside the
@@ -2559,6 +2577,8 @@ class _SearchScreenState extends State<SearchScreen>
       _homeExtras = extras;
       _homeRowOrder = rowOrder;
       _heroSource = heroSource;
+      _homeCollections = collections;
+      _homeCollectionsSig = HomeCollectionsStore.signatureOf(collections);
       // Opt-in Trakt/Simkl list rows, resolved IN PARALLEL with the first
       // catalog batch below. Home board only — the Search tab runs _load just
       // to warm the catalog refs for its search, and Discover never comes
@@ -2583,11 +2603,18 @@ class _SearchScreenState extends State<SearchScreen>
       // them without a query just returns empty after a wasted round trip, so
       // skip them here (they still power the Keyword/catalog search path).
       // Catalogs the user hid in the Home Rows manager are skipped too.
+      // Catalogs claimed by an enabled collection folder live inside that
+      // folder (as in Nuvio) and never double up as plain board rows.
+      final claimed = HomeCollectionsStore.claimedCatalogKeys(
+        _homeCollections,
+        addons,
+      );
       final boardRefs = [
         for (final a in addons)
           for (final c in a.catalogs)
             if (c.isBrowsable &&
-                !_homeDisabled.contains('${a.id}:${c.type}:${c.id}'))
+                !_homeDisabled.contains('${a.id}:${c.type}:${c.id}') &&
+                !claimed.contains('${a.id}:${c.type}:${c.id}'))
               (a, c),
       ];
       _boardRefs
@@ -2616,7 +2643,20 @@ class _SearchScreenState extends State<SearchScreen>
       if (!mounted || gen != _boardLoadGen) return;
       // List rows lead the sections — after the favourites rows, before every
       // addon catalog row. Batching appends after them untouched.
-      final sections = [...listRows, ...first];
+      // Imported collections follow Nuvio's order: pinned ones lead the
+      // board, the rest sit after the tracker list rows and before every
+      // addon catalog row. No network — folders are static tiles.
+      final collectionRows = widget.searchMode || widget.discoverMode
+          ? const <HomeCollectionSection>[]
+          : _buildCollectionSections();
+      final sections = <CatalogSection>[
+        for (final s in collectionRows)
+          if (s.collection.pinToTop) s,
+        ...listRows,
+        for (final s in collectionRows)
+          if (!s.collection.pinToTop) s,
+        ...first,
+      ];
       _homeSections = sections;
       setState(() => _loading = false);
       MainPageBridge.homeBoardReady.value = true;
@@ -3320,6 +3360,8 @@ class _SearchScreenState extends State<SearchScreen>
   }
 
   String _sectionRowId(CatalogSection section) => section is HomeListSection
+      ? section.rowId
+      : section is HomeCollectionSection
       ? section.rowId
       : '${section.addon.id}:${section.catalog.type}:${section.catalog.id}';
 
@@ -4280,7 +4322,9 @@ class _SearchScreenState extends State<SearchScreen>
     // rows that now lead _homeSections carry only a placeholder addon (empty
     // baseUrl), which can't serve /meta or /stream.
     for (final s in _homeSections) {
-      if (s is! HomeListSection) return s.addon;
+      if (s is! HomeListSection && s is! HomeCollectionSection) {
+        return s.addon;
+      }
     }
     return StremioAddon(
       id: addonId ?? 'continue_watching',
@@ -4300,6 +4344,11 @@ class _SearchScreenState extends State<SearchScreen>
     StremioMeta item, {
     String? heroTag,
   }) {
+    // A folder tile opens the folder's merged grid, never a detail page.
+    if (section is HomeCollectionSection) {
+      _openCollectionFolder(section, item);
+      return;
+    }
     if (section is HomeListSection) {
       _openItem(
         item,
@@ -4317,6 +4366,11 @@ class _SearchScreenState extends State<SearchScreen>
   /// [_playTraktItem] (CW-cached resume, else catalog play with Trakt-first
   /// resume); Simkl rows play plainly like Discover's lists.
   void _sectionQuickPlay(CatalogSection section, StremioMeta item) {
+    // A folder tile has nothing to play — open it instead.
+    if (section is HomeCollectionSection) {
+      _openCollectionFolder(section, item);
+      return;
+    }
     if (section is HomeListSection) {
       if (section.isTrakt) {
         _playTraktItem(item);
@@ -4332,6 +4386,46 @@ class _SearchScreenState extends State<SearchScreen>
       return;
     }
     _onCatalogPlay(item, section.addon);
+  }
+
+  /// Every enabled imported collection as a board row (hidden rows skipped).
+  List<HomeCollectionSection> _buildCollectionSections() => [
+    for (final c in _homeCollections)
+      if (c.enabled && c.folders.isNotEmpty && !_homeDisabled.contains(c.rowId))
+        HomeCollectionSection(collection: c),
+  ];
+
+  /// A folder tile on a collection row opens that folder's merged grid.
+  void _openCollectionFolder(HomeCollectionSection section, StremioMeta item) {
+    final index = section.folderIndexOf(item);
+    _openCollectionScreen(section.collection, index < 0 ? 0 : index);
+  }
+
+  /// Push the folder browser on [folderIndex]. Items open through [_openItem]
+  /// with the addon that served them (the catalog fetch stamps
+  /// `sourceAddon`), so the detail flow is the catalog rows' own.
+  void _openCollectionScreen(HomeCollection collection, int folderIndex) {
+    Navigator.of(context)
+        .push(
+          MaterialPageRoute(
+            builder: (_) => _withHomeExpandedCardSettings(
+              CollectionFolderScreen(
+                collection: collection,
+                initialFolderIndex: folderIndex,
+                isTelevision: widget.isTelevision,
+                onOpenItem: (item) =>
+                    _openItem(item, _addonForContinue(item.sourceAddon?.id)),
+                onQuickPlay: _pikpakOnly
+                    ? null
+                    : (item) => _onCatalogPlay(
+                        item,
+                        _addonForContinue(item.sourceAddon?.id),
+                      ),
+              ),
+            ),
+          ),
+        )
+        .then((_) => _afterSeeAllReturn());
   }
 
   /// Open a Continue Watching title as a normal detail page (no Home-style
@@ -5356,9 +5450,16 @@ class _SearchScreenState extends State<SearchScreen>
     // Seed the hero with the first item so it isn't blank before DPAD focus
     // lands (see [_heroActive] for when the hero is shown).
     if (_heroActive) {
-      final first = sections.isNotEmpty && sections.first.items.isNotEmpty
-          ? sections.first.items.first
-          : null;
+      // Seed from the first real title: a pinned collection row can lead the
+      // board, and folder tiles can't drive the hero.
+      StremioMeta? first;
+      for (final section in sections) {
+        if (section is HomeCollectionSection) continue;
+        if (section.items.isNotEmpty) {
+          first = section.items.first;
+          break;
+        }
+      }
       _heroItem.value = first;
       _heroEnriched.value = null;
       // Outside the null-check: a board that reloads EMPTY must clear the
@@ -6760,6 +6861,8 @@ class _SearchScreenState extends State<SearchScreen>
       return override;
     }
     for (final section in _sections) {
+      // Folder tiles aren't titles, so they can't feed the hero reel.
+      if (section is HomeCollectionSection) continue;
       if (section.items.isNotEmpty) return section;
     }
     return null;
@@ -6818,6 +6921,31 @@ class _SearchScreenState extends State<SearchScreen>
     final fav = rail.favKind;
     if (fav != null) return _spotlightFavShelf(fav, id: railKey);
     final i = rail.sectionIndex!;
+    final section = _sections[i];
+    if (section is HomeCollectionSection) {
+      return SpotlightShelf(
+        id: railKey,
+        title: section.title,
+        tag: _catalogSourceTag(section),
+        nodes: i < _rowNodes.length ? _rowNodes[i] : const [],
+        onSeeAll: () => _openCatalogSeeAll(section),
+        // A brand-logo tile needs no caption; captions stay on only while
+        // some folder still wants its title drawn.
+        captions: section.collection.folders.any((f) => !f.hideTitle),
+        items: [
+          for (final m in section.items)
+            SpotlightCard(
+              image: m.poster,
+              fallbackImage: m.background,
+              title: m.name,
+              shape: section.landscapeTiles
+                  ? SpotlightCardShape.wide
+                  : SpotlightCardShape.poster,
+              onOpen: () => _openCollectionFolder(section, m),
+            ),
+        ],
+      );
+    }
     return SpotlightShelf(
       id: railKey,
       title: _sections[i].title,
@@ -10177,6 +10305,9 @@ class _SearchScreenState extends State<SearchScreen>
     // Off-TV / blank search prompt the hero isn't rendered, so don't track focus
     // or fire the per-item backdrop-enrichment /meta fetch behind it.
     if (!_heroActive) return;
+    // A folder tile has no /meta, trailer or playback, so the hero keeps
+    // showing the last real title.
+    if (item.type == 'folder') return;
     // A catalog/CW card owns the stage again — drop any Canvas favourites
     // override so its art/identity yield to the hero pipeline.
     _canvasFavFocus.value = null;
@@ -17913,6 +18044,7 @@ class _SearchScreenState extends State<SearchScreen>
   /// the heading it used to shout open ("Cinemeta: Popular") and into the
   /// quiet pill this feeds.
   String _sectionTag(CatalogSection section) {
+    if (section is HomeCollectionSection) return 'Collection';
     if (section is HomeListSection) {
       return section.isTrakt
           ? 'Trakt'
@@ -17952,6 +18084,10 @@ class _SearchScreenState extends State<SearchScreen>
     // placeholder addon that can't serve a catalog endpoint.
     if (section is HomeListSection) {
       _openListRowSeeAll(section);
+      return;
+    }
+    if (section is HomeCollectionSection) {
+      _openCollectionScreen(section.collection, 0);
       return;
     }
     Navigator.of(context)
@@ -18303,8 +18439,15 @@ class _SearchScreenState extends State<SearchScreen>
     // Bigger, roomier posters on desktop (Stremio-scale); smaller on phones.
     // Titleless cells (Stremio-style) — just the art box + a little headroom
     // for the hover/focus lift. The box follows the Home Cards orientation.
-    final posterW = _railTitleCardW(context);
+    // Collection rows draw their folders' own tile shape (a brand tile stays
+    // wide even when Home cards are portrait) at the same height as every
+    // other rail, so the row grammar stays intact.
+    final collection = section is HomeCollectionSection ? section : null;
     final cellH = _railTitleCardH(context);
+    final cellAspect = collection?.tileAspectRatio ?? _titleCardAspect;
+    final posterW = collection == null
+        ? _railTitleCardW(context)
+        : cellH * cellAspect;
     final rowH = cellH + 14;
 
     return Column(
@@ -18400,10 +18543,15 @@ class _SearchScreenState extends State<SearchScreen>
                             column: col,
                             rowNodes: nodes,
                             hasBoundSource: _isBound(item),
-                            aspectRatio: _titleCardAspect,
-                            artUrl: _titleArtUrl(item),
-                            showTitleOverlay: !_hideHomeCardTitlesAndRatings,
-                            onQuickPlay: _pikpakOnly
+                            aspectRatio: cellAspect,
+                            artUrl: collection != null
+                                ? item.poster
+                                : _titleArtUrl(item),
+                            showTitleOverlay: collection != null
+                                ? !(collection.folderOf(item)?.hideTitle ??
+                                      false)
+                                : !_hideHomeCardTitlesAndRatings,
+                            onQuickPlay: _pikpakOnly || collection != null
                                 ? null
                                 : () => _sectionQuickPlay(section, item),
                             onFocused: () {

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -11,6 +11,7 @@ import 'package:google_fonts/google_fonts.dart';
 import '../models/advanced_search_selection.dart';
 import '../theme/app_theme_scope.dart';
 import '../theme/artwork_accent.dart';
+import '../utils/home_rail_metrics.dart';
 import '../utils/platform_util.dart';
 import '../utils/tvos_device.dart';
 import '../models/debrify_tv/channel.dart';
@@ -16640,12 +16641,8 @@ class _SearchScreenState extends State<SearchScreen>
   /// tuned for a 720-logical canvas leaves no room for a row (plus its header and
   /// the next row's header) under the hero. So scale the poster with the screen
   /// height.
-  double _railPosterW(BuildContext context) {
-    if (!widget.isTelevision) {
-      return MediaQuery.of(context).size.width >= 900 ? 162.0 : 118.0;
-    }
-    return (MediaQuery.of(context).size.height * 0.17).clamp(92.0, 140.0);
-  }
+  double _railPosterW(BuildContext context) =>
+      homeRailPosterWidth(context, isTelevision: widget.isTelevision);
 
   /// TITLE-card size for a classic board rail under the Home Cards
   /// orientation. Landscape keeps Spotlight's proportions — about 1.6× the

--- a/lib/screens/see_all/catalog_see_all_screen.dart
+++ b/lib/screens/see_all/catalog_see_all_screen.dart
@@ -38,6 +38,10 @@ class CatalogSeeAllScreen extends StatefulWidget {
   /// Type/Catalog re-runs the query on the new catalog, Genre narrows it.
   final String? query;
 
+  /// Genre to open on (a collection folder's list carries one). Only applied
+  /// when the catalog supports the `genre` extra; the dropdown reflects it.
+  final String? initialGenre;
+
   /// Items already loaded on the rail — used to seed the grid without a refetch.
   final List<StremioMeta> seedItems;
 
@@ -72,6 +76,7 @@ class CatalogSeeAllScreen extends StatefulWidget {
     required this.initialCatalog,
     required this.onOpenItem,
     this.query,
+    this.initialGenre,
     this.seedItems = const [],
     this.seedNextSkip = 0,
     this.isTelevision = false,
@@ -143,6 +148,8 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
     _type = widget.initialCatalog.type;
     _catalog = widget.initialCatalog;
     _searchQuery = widget.query?.trim() ?? '';
+    final genre = widget.initialGenre?.trim();
+    if (genre != null && genre.isNotEmpty) _genre = genre;
     // Discover only: reopen on the order the user last picked. Ignore a stored
     // id that is no longer one of the three options.
     if (widget.embedded) {

--- a/lib/screens/settings/collections_settings_page.dart
+++ b/lib/screens/settings/collections_settings_page.dart
@@ -35,6 +35,9 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
 
   bool _loading = true;
   bool _busy = false;
+  bool _refreshPending = false;
+  int _loadToken = 0;
+  String? _loadError;
   List<HomeCollection> _collections = const [];
   List<StremioAddon> _addons = const [];
   CollectionFolderLayout _layout = CollectionFolderLayout.rows;
@@ -43,48 +46,79 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
   void initState() {
     super.initState();
     AnalyticsService.screenView('collections_settings');
+    MainPageBridge.addHomeSettingsListener(_onHomeSettingsChanged);
     unawaited(_load());
   }
 
   @override
   void dispose() {
+    MainPageBridge.removeHomeSettingsListener(_onHomeSettingsChanged);
     _firstTileFocusNode.dispose();
     super.dispose();
   }
 
-  Future<void> _load() async {
-    final collections = await _store.getCollections();
-    final layout = await _store.getFolderLayout();
-    List<StremioAddon> addons = const [];
-    try {
-      addons = await StremioService.instance.getCatalogAddons();
-    } catch (_) {
-      // Addons only feed the "missing addon" hints; the page works without.
+  void _onHomeSettingsChanged() {
+    if (_busy) {
+      _refreshPending = true;
+    } else {
+      unawaited(_load(requestFocus: false));
     }
-    if (!mounted) return;
-    setState(() {
-      _collections = collections;
-      _addons = addons;
-      _layout = layout;
-      _loading = false;
-    });
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted && _firstTileFocusNode.context != null) {
-        _firstTileFocusNode.requestFocus();
+  }
+
+  Future<void> _load({bool requestFocus = true}) async {
+    final token = ++_loadToken;
+    final session = HomeCollectionsStore.captureSession();
+    try {
+      final collections = await _store.getCollections();
+      final layout = await _store.getFolderLayout();
+      List<StremioAddon> addons = const [];
+      try {
+        addons = await StremioService.instance.getCatalogAddons();
+      } catch (_) {
+        // Addons only feed the "missing addon" hints; the page works without.
       }
-    });
+      if (!mounted || token != _loadToken) return;
+      HomeCollectionsStore.checkSession(session);
+      setState(() {
+        _collections = collections;
+        _addons = addons;
+        _layout = layout;
+        _loading = false;
+        _loadError = null;
+      });
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (requestFocus &&
+            mounted &&
+            token == _loadToken &&
+            _firstTileFocusNode.context != null) {
+          _firstTileFocusNode.requestFocus();
+        }
+      });
+    } catch (_) {
+      if (mounted && token == _loadToken) {
+        setState(() {
+          _loading = false;
+          _loadError = 'Could not read collections. Restore a backup or retry.';
+        });
+      }
+    }
   }
 
   // ── Import paths ───────────────────────────────────────────────────────
 
   Future<void> _importFromFile() => _guarded(() async {
+    final session = HomeCollectionsStore.captureSession();
     final result = await FilePicker.platform.pickFiles(
       type: FileType.any,
       allowMultiple: false,
-      withData: true,
+      withData: false,
     );
-    if (result == null || result.files.isEmpty) return;
+    if (result == null || result.files.isEmpty || !mounted) return;
+    HomeCollectionsStore.checkSession(session);
     final file = result.files.first;
+    if (file.size > HomeCollectionsStore.maxImportBytes) {
+      throw const FormatException('That file is too large to be a collection.');
+    }
     final List<int> bytes;
     if (file.bytes != null) {
       bytes = file.bytes!;
@@ -96,15 +130,15 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
     if (bytes.length > HomeCollectionsStore.maxImportBytes) {
       throw const FormatException('That file is too large to be a collection.');
     }
+    if (!mounted) return;
+    HomeCollectionsStore.checkSession(session);
     await _runImport(
-      () => _store.importJson(
-        utf8.decode(bytes, allowMalformed: true),
-        installedAddons: _addons,
-      ),
+      () => _store.importJson(utf8.decode(bytes), installedAddons: _addons),
     );
   });
 
   Future<void> _importFromUrl() => _guarded(() async {
+    final session = HomeCollectionsStore.captureSession();
     final url = await _prompt(
       title: 'Import from link',
       hint: 'https://…/collections.json',
@@ -113,10 +147,12 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
       action: 'Import',
     );
     if (url == null || url.trim().isEmpty || !mounted) return;
+    HomeCollectionsStore.checkSession(session);
     await _runImport(() => _store.importFromUrl(url, installedAddons: _addons));
   });
 
   Future<void> _importFromPaste() => _guarded(() async {
+    final session = HomeCollectionsStore.captureSession();
     final text = await _prompt(
       title: 'Paste collection JSON',
       hint: '[ { "title": "Streaming", "folders": [ … ] } ]',
@@ -125,13 +161,15 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
       action: 'Import',
     );
     if (text == null || text.trim().isEmpty || !mounted) return;
+    HomeCollectionsStore.checkSession(session);
     await _runImport(() => _store.importJson(text, installedAddons: _addons));
   });
 
   /// Runs an import flow unless one is already in progress, surfacing any
   /// failure as a snackbar ([FormatException]s carry user-readable text).
   Future<void> _guarded(Future<void> Function() flow) async {
-    if (_busy) return;
+    if (_busy || !mounted) return;
+    setState(() => _busy = true);
     final messenger = ScaffoldMessenger.of(context);
     try {
       await flow();
@@ -139,42 +177,48 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
       _showError(messenger, e.message);
     } catch (e) {
       _showError(messenger, e.toString().replaceFirst('Exception: ', ''));
+    } finally {
+      if (mounted) {
+        setState(() => _busy = false);
+        if (_refreshPending) {
+          _refreshPending = false;
+          await _load(requestFocus: false);
+        }
+      }
     }
   }
 
   Future<void> _runImport(
     Future<HomeCollectionImportResult> Function() run,
   ) async {
-    setState(() => _busy = true);
-    try {
-      final result = await run();
-      if (!mounted) return;
-      MainPageBridge.notifyHomeSettingsChanged();
-      await _load();
-      if (!mounted) return;
-      await _showImportResult(result);
-    } finally {
-      if (mounted) setState(() => _busy = false);
-    }
+    final result = await run();
+    if (!mounted) return;
+    MainPageBridge.notifyHomeSettingsChanged();
+    await _load();
+    if (mounted) await _showImportResult(result);
   }
 
-  Future<void> _setTabbed(bool tabbed) async {
+  Future<void> _setTabbed(bool tabbed) => _guarded(() async {
     final layout = tabbed
         ? CollectionFolderLayout.tabs
         : CollectionFolderLayout.rows;
-    setState(() => _layout = layout);
     await _store.setFolderLayout(layout);
-  }
+    if (!mounted) return;
+    setState(() => _layout = layout);
+    MainPageBridge.notifyHomeSettingsChanged();
+  });
 
   // ── Per-collection actions ─────────────────────────────────────────────
 
   Future<void> _openCollectionActions(HomeCollection c) async {
+    final session = HomeCollectionsStore.captureSession();
     final unresolved = HomeCollectionsStore.unresolvedAddonIds([c], _addons);
     final action = await showDialog<String>(
       context: context,
       builder: (context) => Theme(
         data: settingsPageTheme(context),
         child: AlertDialog(
+          scrollable: true,
           title: Text(c.title),
           content: Column(
             mainAxisSize: MainAxisSize.min,
@@ -221,6 +265,7 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
       ),
     );
     if (!mounted || action == null) return;
+    HomeCollectionsStore.checkSession(session);
     switch (action) {
       case 'toggle':
         await _store.setEnabled(c.id, !c.enabled);
@@ -235,6 +280,7 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
           action: 'Delete',
         );
         if (confirmed && mounted) {
+          HomeCollectionsStore.checkSession(session);
           await _store.remove(c.id);
           MainPageBridge.notifyHomeSettingsChanged();
           await _load();
@@ -243,6 +289,7 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
   }
 
   Future<void> _removeAll() async {
+    final session = HomeCollectionsStore.captureSession();
     if (_collections.isEmpty) return;
     final confirmed = await _confirm(
       title: 'Remove all collections?',
@@ -250,6 +297,7 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
       action: 'Remove all',
     );
     if (!confirmed || !mounted) return;
+    HomeCollectionsStore.checkSession(session);
     await _store.clear();
     MainPageBridge.notifyHomeSettingsChanged();
     await _load();
@@ -311,6 +359,7 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
       builder: (context) => Theme(
         data: settingsPageTheme(context),
         child: AlertDialog(
+          scrollable: true,
           title: Text(title),
           content: Text(body),
           actions: [
@@ -348,6 +397,7 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
       builder: (context) => Theme(
         data: settingsPageTheme(context),
         child: AlertDialog(
+          scrollable: true,
           title: Text(
             'Imported ${r.collectionCount} collection'
             '${r.collectionCount == 1 ? '' : 's'}',
@@ -366,6 +416,7 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
   }
 
   void _showError(ScaffoldMessengerState messenger, String message) {
+    if (!messenger.mounted) return;
     messenger.showSnackBar(
       SnackBar(content: Text(message), backgroundColor: Colors.red),
     );
@@ -379,6 +430,22 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
       return const SettingsPageScaffold(
         title: 'Collections',
         body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (_loadError != null) {
+      return SettingsPageScaffold(
+        title: 'Collections',
+        body: Center(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(_loadError!, textAlign: TextAlign.center),
+                TextButton(onPressed: _load, child: const Text('Retry')),
+              ],
+            ),
+          ),
+        ),
       );
     }
     return SettingsPageScaffold(
@@ -468,7 +535,7 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
                         title: c.title,
                         subtitle: _subtitle(c),
                         tag: c.pinToTop ? 'PINNED' : null,
-                        onTap: () => _openCollectionActions(c),
+                        onTap: () => _guarded(() => _openCollectionActions(c)),
                       ),
                     if (_collections.isEmpty)
                       const Padding(
@@ -490,7 +557,7 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
                         title: 'Remove all collections',
                         subtitle: 'Delete every imported collection',
                         destructive: true,
-                        onTap: _removeAll,
+                        onTap: () => _guarded(_removeAll),
                       ),
                     ],
                   ),

--- a/lib/screens/settings/collections_settings_page.dart
+++ b/lib/screens/settings/collections_settings_page.dart
@@ -1,0 +1,505 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+
+import '../../models/home_collection.dart';
+import '../../models/stremio_addon.dart';
+import '../../services/analytics_service.dart';
+import '../../services/home_collections_store.dart';
+import '../../services/main_page_bridge.dart';
+import '../../services/stremio_service.dart';
+import '../../theme/app_theme_scope.dart';
+import '../../widgets/text_prompt_dialog.dart';
+import 'widgets/settings_widgets.dart';
+
+/// Settings › Home Screen › Collections: import Nuvio / Xperience-style
+/// collection JSON files and manage what has been imported.
+///
+/// This page owns the data (import, enable/disable, delete); showing and
+/// arranging the resulting Home rows is the Home Rows manager's job.
+class CollectionsSettingsPage extends StatefulWidget {
+  const CollectionsSettingsPage({super.key});
+
+  @override
+  State<CollectionsSettingsPage> createState() =>
+      _CollectionsSettingsPageState();
+}
+
+class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
+  final HomeCollectionsStore _store = HomeCollectionsStore.instance;
+  final FocusNode _firstTileFocusNode = FocusNode(
+    debugLabel: 'collections-first',
+  );
+
+  bool _loading = true;
+  bool _busy = false;
+  List<HomeCollection> _collections = const [];
+  List<StremioAddon> _addons = const [];
+  CollectionFolderLayout _layout = CollectionFolderLayout.rows;
+
+  @override
+  void initState() {
+    super.initState();
+    AnalyticsService.screenView('collections_settings');
+    unawaited(_load());
+  }
+
+  @override
+  void dispose() {
+    _firstTileFocusNode.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    final collections = await _store.getCollections();
+    final layout = await _store.getFolderLayout();
+    List<StremioAddon> addons = const [];
+    try {
+      addons = await StremioService.instance.getCatalogAddons();
+    } catch (_) {
+      // Addons only feed the "missing addon" hints; the page works without.
+    }
+    if (!mounted) return;
+    setState(() {
+      _collections = collections;
+      _addons = addons;
+      _layout = layout;
+      _loading = false;
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _firstTileFocusNode.context != null) {
+        _firstTileFocusNode.requestFocus();
+      }
+    });
+  }
+
+  // ── Import paths ───────────────────────────────────────────────────────
+
+  Future<void> _importFromFile() => _guarded(() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.any,
+      allowMultiple: false,
+      withData: true,
+    );
+    if (result == null || result.files.isEmpty) return;
+    final file = result.files.first;
+    final List<int> bytes;
+    if (file.bytes != null) {
+      bytes = file.bytes!;
+    } else if (file.path != null) {
+      bytes = await file.xFile.readAsBytes();
+    } else {
+      throw const FormatException('Could not read the selected file.');
+    }
+    if (bytes.length > HomeCollectionsStore.maxImportBytes) {
+      throw const FormatException('That file is too large to be a collection.');
+    }
+    await _runImport(
+      () => _store.importJson(
+        utf8.decode(bytes, allowMalformed: true),
+        installedAddons: _addons,
+      ),
+    );
+  });
+
+  Future<void> _importFromUrl() => _guarded(() async {
+    final url = await _prompt(
+      title: 'Import from link',
+      hint: 'https://…/collections.json',
+      helper: 'A direct link to a collections JSON file.',
+      keyboardType: TextInputType.url,
+      action: 'Import',
+    );
+    if (url == null || url.trim().isEmpty || !mounted) return;
+    await _runImport(() => _store.importFromUrl(url, installedAddons: _addons));
+  });
+
+  Future<void> _importFromPaste() => _guarded(() async {
+    final text = await _prompt(
+      title: 'Paste collection JSON',
+      hint: '[ { "title": "Streaming", "folders": [ … ] } ]',
+      helper: 'Paste the contents of a collections JSON file.',
+      multiline: true,
+      action: 'Import',
+    );
+    if (text == null || text.trim().isEmpty || !mounted) return;
+    await _runImport(() => _store.importJson(text, installedAddons: _addons));
+  });
+
+  /// Runs an import flow unless one is already in progress, surfacing any
+  /// failure as a snackbar ([FormatException]s carry user-readable text).
+  Future<void> _guarded(Future<void> Function() flow) async {
+    if (_busy) return;
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await flow();
+    } on FormatException catch (e) {
+      _showError(messenger, e.message);
+    } catch (e) {
+      _showError(messenger, e.toString().replaceFirst('Exception: ', ''));
+    }
+  }
+
+  Future<void> _runImport(
+    Future<HomeCollectionImportResult> Function() run,
+  ) async {
+    setState(() => _busy = true);
+    try {
+      final result = await run();
+      if (!mounted) return;
+      MainPageBridge.notifyHomeSettingsChanged();
+      await _load();
+      if (!mounted) return;
+      await _showImportResult(result);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _setTabbed(bool tabbed) async {
+    final layout = tabbed
+        ? CollectionFolderLayout.tabs
+        : CollectionFolderLayout.rows;
+    setState(() => _layout = layout);
+    await _store.setFolderLayout(layout);
+  }
+
+  // ── Per-collection actions ─────────────────────────────────────────────
+
+  Future<void> _openCollectionActions(HomeCollection c) async {
+    final unresolved = HomeCollectionsStore.unresolvedAddonIds([c], _addons);
+    final action = await showDialog<String>(
+      context: context,
+      builder: (context) => Theme(
+        data: settingsPageTheme(context),
+        child: AlertDialog(
+          title: Text(c.title),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(_describe(c)),
+              if (unresolved.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                Text(
+                  'Needs addons that aren\'t installed:\n'
+                  '${unresolved.join('\n')}',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: AppThemeScope.of(context).settings.dim,
+                  ),
+                ),
+              ],
+              const SizedBox(height: 12),
+              Text(
+                'Folders: ${c.folders.map((f) => f.title).join(', ')}',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: AppThemeScope.of(context).settings.dim,
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop('delete'),
+              child: const Text('Delete'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop('toggle'),
+              child: Text(c.enabled ? 'Hide from Home' : 'Show on Home'),
+            ),
+            TextButton(
+              autofocus: true,
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Close'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (!mounted || action == null) return;
+    switch (action) {
+      case 'toggle':
+        await _store.setEnabled(c.id, !c.enabled);
+        MainPageBridge.notifyHomeSettingsChanged();
+        await _load();
+      case 'delete':
+        final confirmed = await _confirm(
+          title: 'Delete "${c.title}"?',
+          body:
+              'Its ${c.folders.length} folder(s) leave the Home screen. '
+              'Re-import the file to get it back.',
+          action: 'Delete',
+        );
+        if (confirmed && mounted) {
+          await _store.remove(c.id);
+          MainPageBridge.notifyHomeSettingsChanged();
+          await _load();
+        }
+    }
+  }
+
+  Future<void> _removeAll() async {
+    if (_collections.isEmpty) return;
+    final confirmed = await _confirm(
+      title: 'Remove all collections?',
+      body: 'Every imported collection is deleted from this profile.',
+      action: 'Remove all',
+    );
+    if (!confirmed || !mounted) return;
+    await _store.clear();
+    MainPageBridge.notifyHomeSettingsChanged();
+    await _load();
+  }
+
+  // ── Dialog helpers ─────────────────────────────────────────────────────
+
+  String _describe(HomeCollection c) {
+    final folders = c.folders.length;
+    final sources = c.sourceCount;
+    final parts = [
+      '$folders folder${folders == 1 ? '' : 's'}',
+      '$sources catalog${sources == 1 ? '' : 's'}',
+      if (c.pinToTop) 'pinned to top',
+      if (!c.enabled) 'hidden',
+    ];
+    return parts.join(' · ');
+  }
+
+  String _subtitle(HomeCollection c) {
+    final unresolved = HomeCollectionsStore.unresolvedAddonIds([c], _addons);
+    final base = _describe(c);
+    if (unresolved.isEmpty) return base;
+    return '$base · ${unresolved.length} addon'
+        '${unresolved.length == 1 ? '' : 's'} missing';
+  }
+
+  Future<String?> _prompt({
+    required String title,
+    required String hint,
+    required String helper,
+    required String action,
+    bool multiline = false,
+    TextInputType? keyboardType,
+  }) {
+    return showDialog<String>(
+      context: context,
+      builder: (context) => Theme(
+        data: settingsPageTheme(context),
+        child: TextPromptDialog(
+          title: title,
+          hint: hint,
+          helper: helper,
+          action: action,
+          multiline: multiline,
+          keyboardType: keyboardType,
+        ),
+      ),
+    );
+  }
+
+  Future<bool> _confirm({
+    required String title,
+    required String body,
+    required String action,
+  }) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => Theme(
+        data: settingsPageTheme(context),
+        child: AlertDialog(
+          title: Text(title),
+          content: Text(body),
+          actions: [
+            TextButton(
+              autofocus: true,
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: Text(action),
+            ),
+          ],
+        ),
+      ),
+    );
+    return result == true;
+  }
+
+  Future<void> _showImportResult(HomeCollectionImportResult r) {
+    final lines = <String>[
+      if (r.added.isNotEmpty)
+        'Added: ${r.added.map((c) => c.title).join(', ')}',
+      if (r.replaced.isNotEmpty)
+        'Updated: ${r.replaced.map((c) => c.title).join(', ')}',
+      '${r.folderCount} folder${r.folderCount == 1 ? '' : 's'} in total.',
+      if (r.unresolvedAddonIds.isNotEmpty)
+        '\nSome folders need addons that aren\'t installed yet:\n'
+            '${r.unresolvedAddonIds.join('\n')}\n\n'
+            'They show on Home but browse empty until the addon (or one '
+            'serving the same catalogs) is installed.',
+    ];
+    return showDialog<void>(
+      context: context,
+      builder: (context) => Theme(
+        data: settingsPageTheme(context),
+        child: AlertDialog(
+          title: Text(
+            'Imported ${r.collectionCount} collection'
+            '${r.collectionCount == 1 ? '' : 's'}',
+          ),
+          content: SingleChildScrollView(child: Text(lines.join('\n'))),
+          actions: [
+            TextButton(
+              autofocus: true,
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showError(ScaffoldMessengerState messenger, String message) {
+    messenger.showSnackBar(
+      SnackBar(content: Text(message), backgroundColor: Colors.red),
+    );
+  }
+
+  // ── Build ──────────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const SettingsPageScaffold(
+        title: 'Collections',
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return SettingsPageScaffold(
+      title: 'Collections',
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: kSettingsMaxWidth),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SettingsPageHeader(
+                  icon: Icons.collections_bookmark_rounded,
+                  title: 'Collections',
+                  subtitle:
+                      'Import Nuvio-style collection files — groups of '
+                      'folders that bundle addon catalogs into Home rows',
+                ),
+                const SizedBox(height: 24),
+                SettingsSection(
+                  title: 'Import',
+                  blurb:
+                      'A collection file lists folders (Netflix, Action, …) '
+                      'and the addon catalogs behind each. Folders browse '
+                      'through the catalog addons you have installed.',
+                  children: [
+                    SettingsTile(
+                      icon: Icons.upload_file_rounded,
+                      title: 'Import from file',
+                      subtitle: _busy
+                          ? 'Importing…'
+                          : 'Pick a collections .json on this device',
+                      enabled: !_busy,
+                      onTap: _importFromFile,
+                      focusNode: _firstTileFocusNode,
+                    ),
+                    SettingsTile(
+                      icon: Icons.link_rounded,
+                      title: 'Import from link',
+                      subtitle: 'Download a collections .json from a URL',
+                      enabled: !_busy,
+                      onTap: _importFromUrl,
+                    ),
+                    SettingsTile(
+                      icon: Icons.content_paste_rounded,
+                      title: 'Paste JSON',
+                      subtitle: 'Paste the file contents directly',
+                      enabled: !_busy,
+                      onTap: _importFromPaste,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                SettingsSection(
+                  title: 'Folder layout',
+                  blurb:
+                      'How a folder shows its lists when you open it. Rows '
+                      'stack every list; Tabs show one list at a time '
+                      'behind a selector, like Nuvio.',
+                  children: [
+                    SettingsToggleTile(
+                      icon: Icons.tab_rounded,
+                      title: 'Tabbed folders',
+                      subtitle: _layout == CollectionFolderLayout.tabs
+                          ? 'One list at a time, pick it from the List chip'
+                          : 'Lists stacked as rows (each with See all)',
+                      value: _layout == CollectionFolderLayout.tabs,
+                      onChanged: _setTabbed,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                SettingsSection(
+                  title: 'Your collections',
+                  blurb: _collections.isEmpty
+                      ? 'Nothing imported yet. Each collection becomes a '
+                            'row of folder tiles on Home; hide or arrange '
+                            'rows under Home Screen › Home Rows.'
+                      : null,
+                  children: [
+                    for (final c in _collections)
+                      SettingsTile(
+                        icon: c.enabled
+                            ? Icons.folder_rounded
+                            : Icons.folder_off_rounded,
+                        title: c.title,
+                        subtitle: _subtitle(c),
+                        tag: c.pinToTop ? 'PINNED' : null,
+                        onTap: () => _openCollectionActions(c),
+                      ),
+                    if (_collections.isEmpty)
+                      const Padding(
+                        padding: EdgeInsets.all(16),
+                        child: Text(
+                          'No collections yet.',
+                          style: TextStyle(fontSize: 13),
+                        ),
+                      ),
+                  ],
+                ),
+                if (_collections.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  SettingsSection(
+                    title: 'Danger Zone',
+                    children: [
+                      SettingsTile(
+                        icon: Icons.delete_sweep_rounded,
+                        title: 'Remove all collections',
+                        subtitle: 'Delete every imported collection',
+                        destructive: true,
+                        onTap: _removeAll,
+                      ),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/collections_settings_page.dart
+++ b/lib/screens/settings/collections_settings_page.dart
@@ -36,6 +36,7 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
   bool _loading = true;
   bool _busy = false;
   bool _refreshPending = false;
+  bool _damagedInventory = false;
   int _loadToken = 0;
   String? _loadError;
   List<HomeCollection> _collections = const [];
@@ -69,7 +70,8 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
     final token = ++_loadToken;
     final session = HomeCollectionsStore.captureSession();
     try {
-      final collections = await _store.getCollections();
+      final inventory = await _store.getInventory();
+      final collections = inventory.collections;
       final layout = await _store.getFolderLayout();
       List<StremioAddon> addons = const [];
       try {
@@ -81,6 +83,7 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
       HomeCollectionsStore.checkSession(session);
       setState(() {
         _collections = collections;
+        _damagedInventory = inventory.hadCorruption;
         _addons = addons;
         _layout = layout;
         _loading = false;
@@ -194,7 +197,7 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
     final result = await run();
     if (!mounted) return;
     MainPageBridge.notifyHomeSettingsChanged();
-    await _load();
+    await _load(requestFocus: false);
     if (mounted) await _showImportResult(result);
   }
 
@@ -287,6 +290,21 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
         }
     }
   }
+
+  Future<void> _resetDamagedInventory() => _guarded(() async {
+    final session = HomeCollectionsStore.captureSession();
+    final confirmed = await _confirm(
+      title: 'Reset damaged collections?',
+      body:
+          'This removes the saved collections from this profile. You can then import a collection file or restore a backup.',
+      action: 'Reset collections',
+    );
+    if (!confirmed || !mounted) return;
+    HomeCollectionsStore.checkSession(session);
+    await _store.clear();
+    MainPageBridge.notifyHomeSettingsChanged();
+    await _load(requestFocus: false);
+  });
 
   Future<void> _removeAll() async {
     final session = HomeCollectionsStore.captureSession();
@@ -466,6 +484,22 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
                       'folders that bundle addon catalogs into Home rows',
                 ),
                 const SizedBox(height: 24),
+                if (_damagedInventory)
+                  SettingsSection(
+                    title: 'Damaged collection data',
+                    blurb:
+                        'Valid collections are still available. Reset the saved data or restore a backup to recover.',
+                    children: [
+                      SettingsTile(
+                        icon: Icons.restore_rounded,
+                        title: 'Reset damaged collections',
+                        subtitle:
+                            'Clear the saved inventory so it can be imported again',
+                        enabled: !_busy,
+                        onTap: _resetDamagedInventory,
+                      ),
+                    ],
+                  ),
                 SettingsSection(
                   title: 'Import',
                   blurb:
@@ -476,9 +510,7 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
                     SettingsTile(
                       icon: Icons.upload_file_rounded,
                       title: 'Import from file',
-                      subtitle: _busy
-                          ? 'Importing…'
-                          : 'Pick a collections .json on this device',
+                      subtitle: 'Pick a collections .json on this device',
                       enabled: !_busy,
                       onTap: _importFromFile,
                       focusNode: _firstTileFocusNode,
@@ -507,14 +539,23 @@ class _CollectionsSettingsPageState extends State<CollectionsSettingsPage> {
                       'stack every list; Tabs show one list at a time '
                       'behind a selector, like Nuvio.',
                   children: [
-                    SettingsToggleTile(
-                      icon: Icons.tab_rounded,
-                      title: 'Tabbed folders',
-                      subtitle: _layout == CollectionFolderLayout.tabs
-                          ? 'One list at a time, pick it from the List chip'
-                          : 'Lists stacked as rows (each with See all)',
-                      value: _layout == CollectionFolderLayout.tabs,
-                      onChanged: _setTabbed,
+                    IgnorePointer(
+                      ignoring: _busy,
+                      child: ExcludeFocus(
+                        excluding: _busy,
+                        child: Opacity(
+                          opacity: _busy ? 0.5 : 1,
+                          child: SettingsToggleTile(
+                            icon: Icons.tab_rounded,
+                            title: 'Tabbed folders',
+                            subtitle: _layout == CollectionFolderLayout.tabs
+                                ? 'One list at a time, pick it from the List chip'
+                                : 'Lists stacked as rows (each with See all)',
+                            value: _layout == CollectionFolderLayout.tabs,
+                            onChanged: _setTabbed,
+                          ),
+                        ),
+                      ),
                     ),
                   ],
                 ),

--- a/lib/screens/settings/home_page_settings_page.dart
+++ b/lib/screens/settings/home_page_settings_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../models/stremio_addon.dart';
+import '../../services/home_collections_store.dart';
 import '../../services/iptv_media_store.dart' show IptvListMeta;
 import '../../services/main_page_bridge.dart';
 import '../../services/mdblist/mdblist_list_source.dart';
@@ -11,6 +12,7 @@ import '../../services/trakt/trakt_list_source.dart';
 import '../../services/trakt/trakt_service.dart';
 import '../../services/analytics_service.dart';
 import '../../utils/platform_util.dart';
+import 'collections_settings_page.dart';
 import 'home_sections_filter_page.dart';
 import 'spotlight_hero_source_page.dart';
 import 'tv_home_style_page.dart';
@@ -394,6 +396,10 @@ class _HomePageSettingsPageState extends State<HomePageSettingsPage> {
   /// the tile and drops re-taps.
   bool _gatheringHomeRows = false;
 
+  Future<void> _openCollections() async {
+    await pushSettingsPage(context, const CollectionsSettingsPage());
+  }
+
   /// Open the two-pane Home Rows manager (which rows/catalogs appear on the
   /// Home board). Feeds it the same browsable catalog tree the board uses,
   /// plus the opt-in extras and their dynamic leaf data — the user's Trakt
@@ -411,6 +417,8 @@ class _HomePageSettingsPageState extends State<HomePageSettingsPage> {
       final disabled = await StorageService.getHomeDisabledSections();
       final extras = await StorageService.getHomeExtraRows();
       final rowOrder = await StorageService.getHomeRowOrder();
+      final collections = await HomeCollectionsStore.instance
+          .getEnabledCollections();
       var iptvLists = const <IptvListMeta>[];
       try {
         iptvLists = await StorageService.getIptvLists();
@@ -466,6 +474,7 @@ class _HomePageSettingsPageState extends State<HomePageSettingsPage> {
             mdblistLiked: mdblistLiked,
             mdblistTop: mdblistTop,
             iptvLists: iptvLists,
+            collections: collections,
             isTelevision: PlatformUtil.isTelevision,
           ),
         ),
@@ -535,6 +544,10 @@ class _HomePageSettingsPageState extends State<HomePageSettingsPage> {
                           ? 'Loading your lists…'
                           : 'Choose and arrange what appears on Home',
                       onTap: _openHomeRowsManager,
+                    ),
+                    SettingsTile.spec(
+                      SettingsRows.collections,
+                      onTap: _openCollections,
                     ),
                     // Which catalog feeds the Spotlight layout's hero reel.
                     // Always shown, but greyed out under any other layout —

--- a/lib/screens/settings/home_sections_filter_page.dart
+++ b/lib/screens/settings/home_sections_filter_page.dart
@@ -170,7 +170,13 @@ class _HomeSectionsFilterPageState extends State<HomeSectionsFilterPage> {
       additions: const ['mdblist:movies', 'mdblist:shows'],
       anchors: const ['simkl:movies', 'simkl:shows'],
     );
-    _orderIds = HomeRowOrder.reconcile(seededOrder, _canonicalOrderIds());
+    _orderIds = HomeRowOrder.reconcile(
+      HomeRowOrder.seedPinned(seededOrder, [
+        for (final c in widget.collections)
+          if (c.pinToTop) HomeCollectionRowIds.collection(c.id),
+      ]),
+      _canonicalOrderIds(),
+    );
     _railNodes = List.generate(
       _groups.length,
       (i) => FocusNode(debugLabel: 'homeRail$i'),
@@ -410,6 +416,9 @@ class _HomeSectionsFilterPageState extends State<HomeSectionsFilterPage> {
       if (items.containsKey(id) && seen.add(id)) out.add(id);
     }
 
+    for (final c in widget.collections) {
+      if (c.pinToTop) add(HomeCollectionRowIds.collection(c.id));
+    }
     for (final id in const [
       'cw:movies',
       'cw:series',

--- a/lib/screens/settings/home_sections_filter_page.dart
+++ b/lib/screens/settings/home_sections_filter_page.dart
@@ -360,6 +360,7 @@ class _HomeSectionsFilterPageState extends State<HomeSectionsFilterPage> {
     final claimed = HomeCollectionsStore.claimedCatalogKeys(
       widget.collections,
       [for (final e in widget.catalogTree) e.addon],
+      disabledRows: widget.disabled,
     );
     for (final entry in widget.catalogTree) {
       final addon = entry.addon;

--- a/lib/screens/settings/home_sections_filter_page.dart
+++ b/lib/screens/settings/home_sections_filter_page.dart
@@ -539,6 +539,9 @@ class _HomeSectionsFilterPageState extends State<HomeSectionsFilterPage> {
     for (final r in widget.extraRows) {
       if (!modelIds.contains(r.id)) extras.add(r);
     }
+    // A collection can temporarily own/hide an addon leaf. Preserve saved
+    // choices which this screen could not edit, including disabled folders.
+    out.addAll(widget.disabled.where((id) => !modelIds.contains(id)));
     await StorageService.setHomeDisabledSections(out);
     await StorageService.setHomeExtraRows(extras);
     await StorageService.setHomeRowOrder(_orderIds);

--- a/lib/screens/settings/home_sections_filter_page.dart
+++ b/lib/screens/settings/home_sections_filter_page.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import '../../utils/tv_reveal.dart';
 import 'package:flutter/services.dart';
 
+import '../../models/home_collection.dart';
 import '../../models/stremio_addon.dart';
+import '../../services/home_collections_store.dart';
 import '../../services/home_list_rows.dart';
 import '../../services/home_row_order.dart';
 import '../../services/iptv_media_store.dart' show IptvListMeta;
@@ -60,6 +62,9 @@ class HomeSectionsFilterPage extends StatefulWidget {
   /// already has the `fav:iptv` leaf).
   final List<IptvListMeta> iptvLists;
 
+  /// Imported collections (each is one default-on `collection:<id>` row).
+  final List<HomeCollection> collections;
+
   final bool isTelevision;
 
   const HomeSectionsFilterPage({
@@ -73,6 +78,7 @@ class HomeSectionsFilterPage extends StatefulWidget {
     this.mdblistLiked = const [],
     this.mdblistTop = const [],
     this.iptvLists = const [],
+    this.collections = const [],
     required this.isTelevision,
   });
 
@@ -91,6 +97,10 @@ class _Item {
   final bool defaultOn;
   final String? extraTitle;
   final bool unavailable;
+
+  /// False for leaves toggled here that are not Home rows (the lists inside
+  /// a collection folder), so they never enter the row order or Arrange view.
+  final bool arrangeable;
   bool on;
   _Item(
     this.id,
@@ -100,6 +110,7 @@ class _Item {
     this.defaultOn = true,
     this.extraTitle,
     this.unavailable = false,
+    this.arrangeable = true,
   });
 }
 
@@ -266,6 +277,31 @@ class _HomeSectionsFilterPageState extends State<HomeSectionsFilterPage> {
             if (!m.isFavorites)
               opt(HomeExtraRowIds.iptvList(m.id), m.name, badge: 'LIST'),
         ]),
+      if (widget.collections.isNotEmpty)
+        _Group('Collections', [
+          for (final c in widget.collections)
+            _Item(
+              c.rowId,
+              c.title,
+              on(c.rowId),
+              badge: c.pinToTop ? 'PINNED' : 'FOLDERS',
+            ),
+        ]),
+      // Each folder's catalog lists: toggled here like any addon catalog but
+      // never arranged, since they live inside the folder, not on the board.
+      for (final c in widget.collections)
+        for (final f in c.folders)
+          if (f.sources.isNotEmpty)
+            _Group('${c.title} › ${f.title}', [
+              for (final s in f.sources)
+                _Item(
+                  HomeCollectionRowIds.folderList(c.id, f.id, s),
+                  _folderListLabel(s),
+                  on(HomeCollectionRowIds.folderList(c.id, f.id, s)),
+                  badge: s.type,
+                  arrangeable: false,
+                ),
+            ]),
       _Group('My Watchlist', [
         _Item('watchlist:movies', 'Movies', on('watchlist:movies')),
         _Item('watchlist:series', 'Series', on('watchlist:series')),
@@ -319,22 +355,43 @@ class _HomeSectionsFilterPageState extends State<HomeSectionsFilterPage> {
       }
     }
 
+    // Catalogs claimed by a collection folder are listed under that folder
+    // above, not under their addon (the board skips them too).
+    final claimed = HomeCollectionsStore.claimedCatalogKeys(
+      widget.collections,
+      [for (final e in widget.catalogTree) e.addon],
+    );
     for (final entry in widget.catalogTree) {
       final addon = entry.addon;
-      if (entry.catalogs.isEmpty) continue;
-      groups.add(
-        _Group(addon.name, [
-          for (final c in entry.catalogs)
+      final items = [
+        for (final c in entry.catalogs)
+          if (!claimed.contains('${addon.id}:${c.type}:${c.id}'))
             _Item(
               '${addon.id}:${c.type}:${c.id}',
               c.name,
               on('${addon.id}:${c.type}:${c.id}'),
               badge: c.type,
             ),
-        ]),
-      );
+      ];
+      if (items.isEmpty) continue;
+      groups.add(_Group(addon.name, items));
     }
     return groups;
+  }
+
+  /// "Popular Movies · Action" for a folder list, resolved against the
+  /// installed addons. Falls back to the raw catalog id when nothing serves
+  /// it, so the list can still be switched off deliberately.
+  String _folderListLabel(CollectionCatalogSource s) {
+    final addons = [for (final e in widget.catalogTree) e.addon];
+    final addon = HomeCollectionsStore.resolveAddon(s, addons);
+    final catalog = addon == null
+        ? null
+        : HomeCollectionsStore.resolveCatalog(s, addon);
+    final base = catalog == null
+        ? '${s.catalogId} (${s.type})'
+        : CatalogSection.rowTitle(catalog);
+    return s.genre == null ? base : '$base · ${s.genre}';
   }
 
   /// The board's pre-customization order. Keep this aligned with Home's row
@@ -382,11 +439,18 @@ class _HomeSectionsFilterPageState extends State<HomeSectionsFilterPage> {
         if (HomeExtraRowIds.isTracker(item.id)) add(item.id);
       }
     }
+    // Collection rows follow the tracker lists and lead the addon catalogs,
+    // matching the board's placement of unpinned collections.
+    for (final group in _groups) {
+      for (final item in group.items) {
+        if (HomeCollectionRowIds.isCollection(item.id)) add(item.id);
+      }
+    }
     // Anything left is an addon catalog (or a future row family unknown to
     // this version). Stable group/item order is the safest default for both.
     for (final group in _groups) {
       for (final item in group.items) {
-        add(item.id);
+        if (item.arrangeable) add(item.id);
       }
     }
     return out;
@@ -396,7 +460,7 @@ class _HomeSectionsFilterPageState extends State<HomeSectionsFilterPage> {
     final entries = [
       for (final group in _groups)
         for (final item in group.items)
-          if (item.on) _ArrangeEntry(item, group.name),
+          if (item.on && item.arrangeable) _ArrangeEntry(item, group.name),
     ];
     return HomeRowOrder.apply(entries, _orderIds, (entry) => entry.item.id);
   }

--- a/lib/screens/settings/widgets/settings_widgets.dart
+++ b/lib/screens/settings/widgets/settings_widgets.dart
@@ -83,6 +83,11 @@ abstract final class SettingsRows {
     title: 'Home Screen',
     subtitle: 'Layout, rows, trailer & continue watching',
   );
+  static const collections = SettingsRowContent(
+    icon: Icons.collections_bookmark_rounded,
+    title: 'Collections',
+    subtitle: 'Import Nuvio-style folder collections as Home rows',
+  );
   static const player = SettingsRowContent(
     icon: Icons.play_circle_outline_rounded,
     title: 'Playback',

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -98,6 +98,7 @@ import 'settings/pikpak_settings_page.dart';
 import 'settings/real_debrid_settings_page.dart';
 import 'settings/iptv_settings_page.dart';
 import 'settings/iptv_channel_order_page.dart';
+import 'settings/collections_settings_page.dart';
 import 'settings/home_page_settings_page.dart';
 import 'settings/torbox_settings_page.dart';
 import 'settings/premiumize_settings_page.dart';
@@ -1400,6 +1401,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
           'startup',
           'landing',
           'tab',
+        ],
+      ),
+      nav(
+        SettingsRows.collections,
+        'Home & Display',
+        _openCollectionsSettings,
+        keywords: const [
+          'collections',
+          'collection',
+          'nuvio',
+          'xperience',
+          'folders',
+          'import json',
         ],
       ),
 
@@ -4544,6 +4558,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
     await pushSettingsPage(context, const RecordingsPage());
   }
 
+  Future<void> _openCollectionsSettings() async {
+    await pushSettingsPage(context, const CollectionsSettingsPage());
+  }
+
   Future<void> _openHomePageSettings() async {
     await pushSettingsPage(context, const HomePageSettingsPage());
     if (!mounted) return;
@@ -5476,6 +5494,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
         '${s.iptvListChannelCount} channels)',
       );
     }
+    if (s.homeCollectionCount > 0) {
+      lines.add('Collections (${s.homeCollectionCount})');
+    }
     return lines;
   }
 
@@ -5512,6 +5533,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
     }
     if (r.iptvListChannelsImported > 0) {
       parts.add('${r.iptvListChannelsImported} list channel(s)');
+    }
+    if (r.homeCollectionsImported > 0) {
+      parts.add('${r.homeCollectionsImported} collection(s)');
     }
 
     if (parts.isEmpty && !r.hasAnyFailure) {

--- a/lib/services/backup_restore_service.dart
+++ b/lib/services/backup_restore_service.dart
@@ -10,6 +10,7 @@ import 'engine/config_loader.dart';
 import 'engine/engine_registry.dart';
 import 'engine/local_engine_storage.dart';
 import 'engine/remote_engine_manager.dart';
+import 'home_collections_store.dart';
 import 'iptv_transfer_payload.dart';
 import 'mdblist/mdblist_calendar_service.dart';
 import 'mdblist/mdblist_continue_watching_service.dart';
@@ -42,6 +43,7 @@ import 'stremio_service.dart';
 ///     re-import the file on the other device.
 ///   - IPTV Favorites (starred channels)
 ///   - IPTV custom lists (each list with its channels)
+///   - Home collections (imported Nuvio-style folder collections)
 ///
 /// Restore intentionally skips remote validation (network) for credentials —
 /// the user trusts their own backup, so we write the stored values directly.
@@ -168,6 +170,13 @@ class BackupRestoreService {
       throw StateError('Could not read IPTV setup for backup');
     }
 
+    List<Map<String, dynamic>> homeCollections = const [];
+    try {
+      homeCollections = await HomeCollectionsStore.instance.exportJson();
+    } catch (_) {
+      throw StateError('Could not read Home collections for backup');
+    }
+
     return <String, dynamic>{
       'version': payloadVersion,
       'createdAt': DateTime.now().toUtc().toIso8601String(),
@@ -224,6 +233,7 @@ class BackupRestoreService {
       if (iptvPlaylists.isNotEmpty) 'iptvPlaylists': iptvPlaylists,
       if (iptvFavorites.isNotEmpty) 'iptvFavorites': iptvFavorites,
       if (iptvLists.isNotEmpty) 'iptvLists': iptvLists,
+      if (homeCollections.isNotEmpty) 'homeCollections': homeCollections,
     };
   }
 
@@ -267,6 +277,7 @@ class BackupRestoreService {
       iptvListChannelCount: IptvTransferPayload.countListChannels(
         (map['iptvLists'] as List?) ?? const [],
       ),
+      homeCollectionCount: (map['homeCollections'] as List?)?.length ?? 0,
     );
   }
 
@@ -725,6 +736,20 @@ class BackupRestoreService {
       }
     }
 
+    if (selection.homeCollections) {
+      final list = map['homeCollections'];
+      if (list is List && list.isNotEmpty) {
+        try {
+          final counts = await HomeCollectionsStore.instance.applyBackup(list);
+          report.homeCollectionsImported = counts.imported;
+          report.homeCollectionsAlreadyPresent = counts.alreadyPresent;
+          report.homeCollectionsFailed = counts.failed;
+        } catch (_) {
+          report.errors.add('Collections: restore failed');
+        }
+      }
+    }
+
     final trackingPreferences = map['trackingPreferences'];
     if (selection.trackingPreferences && trackingPreferences is Map) {
       try {
@@ -947,6 +972,7 @@ class BackupSummary {
   final int iptvFavoriteCount;
   final int iptvListCount;
   final int iptvListChannelCount;
+  final int homeCollectionCount;
 
   BackupSummary({
     required this.version,
@@ -967,6 +993,7 @@ class BackupSummary {
     this.iptvFavoriteCount = 0,
     this.iptvListCount = 0,
     this.iptvListChannelCount = 0,
+    this.homeCollectionCount = 0,
   });
 
   bool get isEmpty =>
@@ -984,7 +1011,8 @@ class BackupSummary {
       indexerManagerCount == 0 &&
       iptvPlaylistCount == 0 &&
       iptvFavoriteCount == 0 &&
-      iptvListCount == 0;
+      iptvListCount == 0 &&
+      homeCollectionCount == 0;
 }
 
 /// Which categories to include when restoring.
@@ -1004,6 +1032,7 @@ class BackupSelection {
   final bool iptvPlaylists;
   final bool iptvFavorites;
   final bool iptvLists;
+  final bool homeCollections;
   final bool trackingPreferences;
 
   const BackupSelection({
@@ -1022,6 +1051,7 @@ class BackupSelection {
     this.iptvPlaylists = true,
     this.iptvFavorites = true,
     this.iptvLists = true,
+    this.homeCollections = true,
     this.trackingPreferences = false,
   });
 
@@ -1041,6 +1071,7 @@ class BackupSelection {
       iptvPlaylists = true,
       iptvFavorites = true,
       iptvLists = true,
+      homeCollections = true,
       trackingPreferences = true;
 
   BackupSelection copyWith({
@@ -1059,6 +1090,7 @@ class BackupSelection {
     bool? iptvPlaylists,
     bool? iptvFavorites,
     bool? iptvLists,
+    bool? homeCollections,
     bool? trackingPreferences,
   }) {
     return BackupSelection(
@@ -1077,6 +1109,7 @@ class BackupSelection {
       iptvPlaylists: iptvPlaylists ?? this.iptvPlaylists,
       iptvFavorites: iptvFavorites ?? this.iptvFavorites,
       iptvLists: iptvLists ?? this.iptvLists,
+      homeCollections: homeCollections ?? this.homeCollections,
       trackingPreferences: trackingPreferences ?? this.trackingPreferences,
     );
   }
@@ -1119,6 +1152,9 @@ class RestoreReport {
   int iptvListChannelsImported = 0;
   int iptvListChannelsAlreadyPresent = 0;
   int iptvListsFailed = 0;
+  int homeCollectionsImported = 0;
+  int homeCollectionsAlreadyPresent = 0;
+  int homeCollectionsFailed = 0;
   final List<String> errors = [];
 
   int get totalSuccess =>
@@ -1137,7 +1173,8 @@ class RestoreReport {
       iptvPlaylistsImported +
       iptvFavoritesImported +
       iptvListsCreated +
-      iptvListChannelsImported;
+      iptvListChannelsImported +
+      homeCollectionsImported;
 
   int get totalFailed =>
       searchEnginesFailed +
@@ -1147,6 +1184,7 @@ class RestoreReport {
       iptvPlaylistsFailed +
       iptvFavoritesFailed +
       iptvListsFailed +
+      homeCollectionsFailed +
       errors.length +
       (pikpakLoginFailed ? 1 : 0);
 

--- a/lib/services/collection_catalog_pager.dart
+++ b/lib/services/collection_catalog_pager.dart
@@ -1,0 +1,80 @@
+import '../models/stremio_addon.dart';
+
+typedef CatalogFetch =
+    Future<List<StremioMeta>> Function(
+      StremioAddon addon,
+      StremioAddonCatalog catalog, {
+      int skip,
+      String? genre,
+      void Function(int rawCount)? onRawCount,
+    });
+
+/// A raw catalog cursor, shared by folder rails and the merged view. A valid
+/// response with no raw metas is the only proof of exhaustion. Network errors,
+/// invalid metas and overlap must not silently truncate the catalog.
+class CollectionCatalogPager {
+  CollectionCatalogPager({
+    required this.addon,
+    required this.catalog,
+    required this.fetch,
+    this.genre,
+  });
+  static const int maxEmptyWindows = 8;
+  final StremioAddon addon;
+  final StremioAddonCatalog catalog;
+  final CatalogFetch fetch;
+  final String? genre;
+  final Set<String> _seen = {};
+  int skip = 0;
+  bool exhausted = false;
+  String? error;
+
+  static String itemKey(StremioMeta m) => '${m.type}\u0000${m.id}';
+
+  void reset() {
+    _seen.clear();
+    skip = 0;
+    exhausted = false;
+    error = null;
+  }
+
+  Future<List<StremioMeta>> nextPage() async {
+    error = null;
+    if (exhausted) return const [];
+    for (var attempt = 0; attempt < maxEmptyWindows; attempt++) {
+      int? rawCount;
+      try {
+        final items = await fetch(
+          addon,
+          catalog,
+          skip: skip,
+          genre: genre,
+          onRawCount: (count) => rawCount = count,
+        );
+        // StremioService returns [] without reporting a count on HTTP failure.
+        if (items.isEmpty && rawCount == null) {
+          error = 'This list could not load. Retry to continue.';
+          return const [];
+        }
+        final count = rawCount ?? items.length;
+        if (count == 0) {
+          exhausted = true;
+          return const [];
+        }
+        skip += count;
+        final fresh = [
+          for (final m in items)
+            if (_seen.add(itemKey(m)))
+              m.sourceAddon == null ? m.withSourceAddon(addon) : m,
+        ];
+        if (fresh.isNotEmpty) return fresh;
+      } catch (_) {
+        error = 'This list could not load. Retry to continue.';
+        return const [];
+      }
+    }
+    // Bound faulty addons that ignore skip. The cursor remains resumable.
+    error = 'This list returned no new titles. Retry to continue.';
+    return const [];
+  }
+}

--- a/lib/services/collection_catalog_pager.dart
+++ b/lib/services/collection_catalog_pager.dart
@@ -28,6 +28,7 @@ class CollectionCatalogPager {
   int skip = 0;
   bool exhausted = false;
   String? error;
+  bool noProgress = false;
 
   static String itemKey(StremioMeta m) => '${m.type}\u0000${m.id}';
 
@@ -36,12 +37,14 @@ class CollectionCatalogPager {
     skip = 0;
     exhausted = false;
     error = null;
+    noProgress = false;
   }
 
-  Future<List<StremioMeta>> nextPage() async {
+  Future<List<StremioMeta>> nextPage({int maxWindows = maxEmptyWindows}) async {
     error = null;
+    noProgress = false;
     if (exhausted) return const [];
-    for (var attempt = 0; attempt < maxEmptyWindows; attempt++) {
+    for (var attempt = 0; attempt < maxWindows; attempt++) {
       int? rawCount;
       try {
         final items = await fetch(
@@ -74,6 +77,7 @@ class CollectionCatalogPager {
       }
     }
     // Bound faulty addons that ignore skip. The cursor remains resumable.
+    noProgress = true;
     error = 'This list returned no new titles. Retry to continue.';
     return const [];
   }

--- a/lib/services/collection_folder_loader.dart
+++ b/lib/services/collection_folder_loader.dart
@@ -1,0 +1,177 @@
+import '../models/home_collection.dart';
+import '../models/stremio_addon.dart';
+import 'home_collections_store.dart';
+import 'stremio_service.dart';
+
+/// Signature of [StremioService.fetchCatalog]; injectable for tests.
+typedef CatalogFetch =
+    Future<List<StremioMeta>> Function(
+      StremioAddon addon,
+      StremioAddonCatalog catalog, {
+      int skip,
+      String? genre,
+      void Function(int rawCount)? onRawCount,
+    });
+
+/// Pages a folder's catalogs as one merged, de-duplicated list.
+///
+/// Each source keeps its own `skip` cursor; [nextPage] pulls the next window
+/// from every source that still has items (bounded fan-out) and interleaves
+/// them round-robin, so "Netflix movies + Netflix series + Top 10" reads as
+/// a mix rather than one catalog after another. Items are de-duplicated by
+/// meta id across sources (the same title routinely appears in "Popular" and
+/// "Top Rated").
+///
+/// Fetch errors are swallowed per source: one dead addon must not blank the
+/// whole folder.
+class CollectionFolderLoader {
+  CollectionFolderLoader({
+    required this.folder,
+    required List<StremioAddon> installedAddons,
+    StremioService? stremio,
+    CatalogFetch? fetch,
+  }) : _fetch =
+           fetch ??
+           ((addon, catalog, {skip = 0, genre, onRawCount}) =>
+               (stremio ?? StremioService.instance).fetchCatalog(
+                 addon,
+                 catalog,
+                 skip: skip,
+                 genre: genre,
+                 onRawCount: onRawCount,
+               )) {
+    for (final source in folder.sources) {
+      final addon = HomeCollectionsStore.resolveAddon(source, installedAddons);
+      if (addon == null) {
+        _unresolved.add(source.addonId);
+        continue;
+      }
+      final catalog = HomeCollectionsStore.resolveCatalog(source, addon);
+      if (catalog == null) {
+        _unresolved.add(
+          '${source.addonId} → ${source.type}/${source.catalogId}',
+        );
+        continue;
+      }
+      _sources.add(_Source(addon, catalog, source.genre));
+    }
+  }
+
+  final HomeCollectionFolder folder;
+  final CatalogFetch _fetch;
+
+  final List<_Source> _sources = [];
+  final List<String> _unresolved = [];
+  final Set<String> _seen = {};
+
+  /// Catalog requests in flight per page, so a many-source folder pages in a
+  /// few rounds instead of hammering the addon.
+  static const int maxConcurrent = 4;
+
+  /// Sources that resolved to an installed addon and catalog.
+  int get resolvedSourceCount => _sources.length;
+
+  /// Human-readable descriptions of the sources that did not resolve.
+  List<String> get unresolved => List.unmodifiable(_unresolved);
+
+  /// True once every resolved source has run dry.
+  bool get exhausted => _sources.every((s) => s.exhausted);
+
+  /// Forget paging state so the next [nextPage] starts from the top.
+  void reset() {
+    _seen.clear();
+    for (final s in _sources) {
+      s.skip = 0;
+      s.exhausted = false;
+    }
+  }
+
+  /// Fetch the next window from every live source and return the merged,
+  /// interleaved, de-duplicated additions. Empty means [exhausted].
+  Future<List<StremioMeta>> nextPage() async {
+    final live = [
+      for (final s in _sources)
+        if (!s.exhausted) s,
+    ];
+    if (live.isEmpty) return const [];
+
+    final pages = List<List<StremioMeta>>.filled(live.length, const []);
+    for (var start = 0; start < live.length; start += maxConcurrent) {
+      final slice = live.sublist(
+        start,
+        (start + maxConcurrent).clamp(0, live.length),
+      );
+      await Future.wait(
+        slice.indexed.map((entry) async {
+          final (offset, s) = entry;
+          final index = start + offset;
+          try {
+            var rawCount = 0;
+            final items = await _fetch(
+              s.addon,
+              s.catalog,
+              skip: s.skip,
+              genre: s.genre,
+              onRawCount: (c) => rawCount = c,
+            );
+            if (items.isEmpty) {
+              s.exhausted = true;
+              return;
+            }
+            // Advance past the addon's raw window (not the post-filter count)
+            // so paging stays aligned with what the addon actually served.
+            s.skip += rawCount > 0 ? rawCount : items.length;
+            pages[index] = [
+              for (final m in items)
+                m.sourceAddon == null ? m.withSourceAddon(s.addon) : m,
+            ];
+          } catch (_) {
+            s.exhausted = true;
+          }
+        }),
+      );
+    }
+
+    final merged = interleave(pages);
+    final fresh = <StremioMeta>[];
+    for (final m in merged) {
+      if (_seen.add(m.id)) fresh.add(m);
+    }
+    // A page that added nothing new means every source repeated itself
+    // (addons that ignore `skip` do this); stop rather than loop forever.
+    if (fresh.isEmpty) {
+      for (final s in live) {
+        s.exhausted = true;
+      }
+    }
+    return fresh;
+  }
+
+  /// Round-robin merge: first of each list, then second of each, and so on.
+  /// Lists that run out drop out of the rotation.
+  static List<StremioMeta> interleave(List<List<StremioMeta>> pages) {
+    final out = <StremioMeta>[];
+    var index = 0;
+    var any = true;
+    while (any) {
+      any = false;
+      for (final page in pages) {
+        if (index < page.length) {
+          out.add(page[index]);
+          any = true;
+        }
+      }
+      index++;
+    }
+    return out;
+  }
+}
+
+class _Source {
+  _Source(this.addon, this.catalog, this.genre);
+  final StremioAddon addon;
+  final StremioAddonCatalog catalog;
+  final String? genre;
+  int skip = 0;
+  bool exhausted = false;
+}

--- a/lib/services/collection_folder_loader.dart
+++ b/lib/services/collection_folder_loader.dart
@@ -1,177 +1,124 @@
 import '../models/home_collection.dart';
 import '../models/stremio_addon.dart';
+import 'collection_catalog_pager.dart';
 import 'home_collections_store.dart';
 import 'stremio_service.dart';
+export 'collection_catalog_pager.dart' show CatalogFetch;
 
-/// Signature of [StremioService.fetchCatalog]; injectable for tests.
-typedef CatalogFetch =
-    Future<List<StremioMeta>> Function(
-      StremioAddon addon,
-      StremioAddonCatalog catalog, {
-      int skip,
-      String? genre,
-      void Function(int rawCount)? onRawCount,
-    });
-
-/// Pages a folder's catalogs as one merged, de-duplicated list.
-///
-/// Each source keeps its own `skip` cursor; [nextPage] pulls the next window
-/// from every source that still has items (bounded fan-out) and interleaves
-/// them round-robin, so "Netflix movies + Netflix series + Top 10" reads as
-/// a mix rather than one catalog after another. Items are de-duplicated by
-/// meta id across sources (the same title routinely appears in "Popular" and
-/// "Top Rated").
-///
-/// Fetch errors are swallowed per source: one dead addon must not blank the
-/// whole folder.
+/// Pages every catalog with bounded concurrency and retains per-source raw
+/// cursors. Deduplication is presentation only, never proof of exhaustion.
 class CollectionFolderLoader {
   CollectionFolderLoader({
     required this.folder,
     required List<StremioAddon> installedAddons,
     StremioService? stremio,
     CatalogFetch? fetch,
-  }) : _fetch =
-           fetch ??
-           ((addon, catalog, {skip = 0, genre, onRawCount}) =>
-               (stremio ?? StremioService.instance).fetchCatalog(
-                 addon,
-                 catalog,
-                 skip: skip,
-                 genre: genre,
-                 onRawCount: onRawCount,
-               )) {
+    bool forceRefresh = false,
+  }) {
+    final load =
+        fetch ??
+        ((
+          StremioAddon addon,
+          StremioAddonCatalog catalog, {
+          int skip = 0,
+          String? genre,
+          void Function(int)? onRawCount,
+        }) => (stremio ?? StremioService.instance).fetchCatalog(
+          addon,
+          catalog,
+          skip: skip,
+          genre: genre,
+          onRawCount: onRawCount,
+          forceRefresh: forceRefresh,
+        ));
+    final resolved = <String>{};
     for (final source in folder.sources) {
       final addon = HomeCollectionsStore.resolveAddon(source, installedAddons);
-      if (addon == null) {
+      final catalog = addon == null
+          ? null
+          : HomeCollectionsStore.resolveCatalog(source, addon);
+      if (addon == null || catalog == null) {
         _unresolved.add(source.addonId);
         continue;
       }
-      final catalog = HomeCollectionsStore.resolveCatalog(source, addon);
-      if (catalog == null) {
-        _unresolved.add(
-          '${source.addonId} → ${source.type}/${source.catalogId}',
-        );
-        continue;
-      }
-      _sources.add(_Source(addon, catalog, source.genre));
+      final key =
+          '${addon.manifestUrl}|${catalog.type}|${catalog.id}|${source.genre}';
+      if (!resolved.add(key)) continue;
+      _sources.add(
+        CollectionCatalogPager(
+          addon: addon,
+          catalog: catalog,
+          genre: source.genre,
+          fetch: load,
+        ),
+      );
     }
   }
-
   final HomeCollectionFolder folder;
-  final CatalogFetch _fetch;
-
-  final List<_Source> _sources = [];
+  static const int maxConcurrent = 4;
+  final List<CollectionCatalogPager> _sources = [];
   final List<String> _unresolved = [];
   final Set<String> _seen = {};
-
-  /// Catalog requests in flight per page, so a many-source folder pages in a
-  /// few rounds instead of hammering the addon.
-  static const int maxConcurrent = 4;
-
-  /// Sources that resolved to an installed addon and catalog.
+  bool _stalled = false;
+  bool _loading = false;
   int get resolvedSourceCount => _sources.length;
-
-  /// Human-readable descriptions of the sources that did not resolve.
   List<String> get unresolved => List.unmodifiable(_unresolved);
-
-  /// True once every resolved source has run dry.
   bool get exhausted => _sources.every((s) => s.exhausted);
+  bool get hasErrors => _stalled || _sources.any((s) => s.error != null);
 
-  /// Forget paging state so the next [nextPage] starts from the top.
   void reset() {
     _seen.clear();
+    _stalled = false;
     for (final s in _sources) {
-      s.skip = 0;
-      s.exhausted = false;
+      s.reset();
     }
   }
 
-  /// Fetch the next window from every live source and return the merged,
-  /// interleaved, de-duplicated additions. Empty means [exhausted].
   Future<List<StremioMeta>> nextPage() async {
-    final live = [
-      for (final s in _sources)
-        if (!s.exhausted) s,
-    ];
-    if (live.isEmpty) return const [];
-
-    final pages = List<List<StremioMeta>>.filled(live.length, const []);
-    for (var start = 0; start < live.length; start += maxConcurrent) {
-      final slice = live.sublist(
-        start,
-        (start + maxConcurrent).clamp(0, live.length),
-      );
-      await Future.wait(
-        slice.indexed.map((entry) async {
-          final (offset, s) = entry;
-          final index = start + offset;
-          try {
-            var rawCount = 0;
-            final items = await _fetch(
-              s.addon,
-              s.catalog,
-              skip: s.skip,
-              genre: s.genre,
-              onRawCount: (c) => rawCount = c,
-            );
-            if (items.isEmpty) {
-              s.exhausted = true;
-              return;
-            }
-            // Advance past the addon's raw window (not the post-filter count)
-            // so paging stays aligned with what the addon actually served.
-            s.skip += rawCount > 0 ? rawCount : items.length;
-            pages[index] = [
-              for (final m in items)
-                m.sourceAddon == null ? m.withSourceAddon(s.addon) : m,
-            ];
-          } catch (_) {
-            s.exhausted = true;
-          }
-        }),
-      );
-    }
-
-    final merged = interleave(pages);
-    final fresh = <StremioMeta>[];
-    for (final m in merged) {
-      if (_seen.add(m.id)) fresh.add(m);
-    }
-    // A page that added nothing new means every source repeated itself
-    // (addons that ignore `skip` do this); stop rather than loop forever.
-    if (fresh.isEmpty) {
-      for (final s in live) {
-        s.exhausted = true;
+    if (_loading) return const [];
+    _loading = true;
+    _stalled = false;
+    try {
+      // Each source is tried once after failure per user/request, not once for
+      // every overlap window of the remaining successful sources.
+      final failed = <CollectionCatalogPager>{};
+      for (
+        var attempt = 0;
+        attempt < CollectionCatalogPager.maxEmptyWindows;
+        attempt++
+      ) {
+        final live = [
+          for (final s in _sources)
+            if (!s.exhausted && !failed.contains(s)) s,
+        ];
+        if (live.isEmpty) return const [];
+        final pages = <List<StremioMeta>>[];
+        for (var start = 0; start < live.length; start += maxConcurrent) {
+          final batch = live.skip(start).take(maxConcurrent).toList();
+          pages.addAll(await Future.wait(batch.map((s) => s.nextPage())));
+          failed.addAll(batch.where((s) => s.error != null));
+        }
+        final fresh = [
+          for (final m in interleave(pages))
+            if (_seen.add(CollectionCatalogPager.itemKey(m))) m,
+        ];
+        if (fresh.isNotEmpty) return fresh;
+        if (exhausted) return const [];
       }
+      _stalled = true;
+      return const [];
+    } finally {
+      _loading = false;
     }
-    return fresh;
   }
 
-  /// Round-robin merge: first of each list, then second of each, and so on.
-  /// Lists that run out drop out of the rotation.
   static List<StremioMeta> interleave(List<List<StremioMeta>> pages) {
     final out = <StremioMeta>[];
-    var index = 0;
-    var any = true;
-    while (any) {
-      any = false;
+    for (var i = 0; pages.any((p) => i < p.length); i++) {
       for (final page in pages) {
-        if (index < page.length) {
-          out.add(page[index]);
-          any = true;
-        }
+        if (i < page.length) out.add(page[i]);
       }
-      index++;
     }
     return out;
   }
-}
-
-class _Source {
-  _Source(this.addon, this.catalog, this.genre);
-  final StremioAddon addon;
-  final StremioAddonCatalog catalog;
-  final String? genre;
-  int skip = 0;
-  bool exhausted = false;
 }

--- a/lib/services/collection_folder_loader.dart
+++ b/lib/services/collection_folder_loader.dart
@@ -70,7 +70,10 @@ class CollectionFolderLoader {
   int get resolvedSourceCount => _sources.length;
   List<String> get unresolved => List.unmodifiable(_unresolved);
   bool get exhausted => _sources.every((s) => s.exhausted);
-  bool get hasErrors => _stalled || _sources.any((s) => s.error != null);
+  // A source can have an empty/overlapping window while its siblings advance.
+  // Only the shared budget exhausting makes no-progress an All-view error.
+  bool get hasErrors =>
+      _stalled || _sources.any((s) => s.error != null && !s.noProgress);
 
   void reset() {
     _seen.clear();

--- a/lib/services/collection_folder_loader.dart
+++ b/lib/services/collection_folder_loader.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import '../models/home_collection.dart';
 import '../models/stremio_addon.dart';
 import 'collection_catalog_pager.dart';
@@ -41,8 +43,12 @@ class CollectionFolderLoader {
         _unresolved.add(source.addonId);
         continue;
       }
-      final key =
-          '${addon.manifestUrl}|${catalog.type}|${catalog.id}|${source.genre}';
+      final key = jsonEncode([
+        addon.manifestUrl,
+        catalog.type,
+        catalog.id,
+        source.genre,
+      ]);
       if (!resolved.add(key)) continue;
       _sources.add(
         CollectionCatalogPager(
@@ -95,8 +101,10 @@ class CollectionFolderLoader {
         final pages = <List<StremioMeta>>[];
         for (var start = 0; start < live.length; start += maxConcurrent) {
           final batch = live.skip(start).take(maxConcurrent).toList();
-          pages.addAll(await Future.wait(batch.map((s) => s.nextPage())));
-          failed.addAll(batch.where((s) => s.error != null));
+          pages.addAll(
+            await Future.wait(batch.map((s) => s.nextPage(maxWindows: 1))),
+          );
+          failed.addAll(batch.where((s) => s.error != null && !s.noProgress));
         }
         final fresh = [
           for (final m in interleave(pages))

--- a/lib/services/home_collection_rows.dart
+++ b/lib/services/home_collection_rows.dart
@@ -39,12 +39,8 @@ class HomeCollectionSection extends CatalogSection {
       );
 
   /// The folder behind a tile, or null for an item that isn't one of ours.
-  /// The folder's animated focus art for [item], when the file enables it.
-  String? focusArtOf(StremioMeta item) {
-    final f = folderOf(item);
-    if (f == null || !f.focusGifEnabled) return null;
-    return f.focusGifUrl;
-  }
+  /// The folder's animated focus art for [item], when the file carries one.
+  String? focusArtOf(StremioMeta item) => folderOf(item)?.focusGifUrl;
 
   HomeCollectionFolder? folderOf(StremioMeta item) {
     final i = folderIndexOf(item);

--- a/lib/services/home_collection_rows.dart
+++ b/lib/services/home_collection_rows.dart
@@ -39,6 +39,13 @@ class HomeCollectionSection extends CatalogSection {
       );
 
   /// The folder behind a tile, or null for an item that isn't one of ours.
+  /// The folder's animated focus art for [item], when the file enables it.
+  String? focusArtOf(StremioMeta item) {
+    final f = folderOf(item);
+    if (f == null || !f.focusGifEnabled) return null;
+    return f.focusGifUrl;
+  }
+
   HomeCollectionFolder? folderOf(StremioMeta item) {
     final i = folderIndexOf(item);
     return i < 0 ? null : collection.folders[i];

--- a/lib/services/home_collection_rows.dart
+++ b/lib/services/home_collection_rows.dart
@@ -1,0 +1,79 @@
+import '../models/home_collection.dart';
+import '../models/stremio_addon.dart';
+
+/// A Home board row for one imported collection; its folders are the tiles.
+///
+/// Subclassing [CatalogSection] (like `HomeListSection`) lets the row ride
+/// the classic board ListView, the TV stage layouts, `_rowNodes` focus
+/// bookkeeping and row ordering/hiding with no new threading. The items are
+/// synthetic [StremioMeta]s (one per folder, `type: 'folder'`, poster = the
+/// cover art); the board intercepts opens on this section type and pushes
+/// the folder browser instead of a detail page. The addon is a placeholder
+/// (empty baseUrl) — nothing may route a /meta or /stream call through it —
+/// and [CatalogSection.exhausted] is latched so the row never pages.
+class HomeCollectionSection extends CatalogSection {
+  final HomeCollection collection;
+
+  /// The row's Home-row id (`collection:<id>`), for ordering/hiding.
+  final String rowId;
+
+  static final StremioAddon placeholderAddon = StremioAddon(
+    id: 'debrify.home.collection',
+    name: 'Collection',
+    manifestUrl: '',
+    baseUrl: '',
+  );
+
+  HomeCollectionSection({required this.collection})
+    : rowId = collection.rowId,
+      super(
+        title: collection.title,
+        addon: placeholderAddon,
+        catalog: StremioAddonCatalog(
+          id: collection.rowId,
+          type: 'folder',
+          name: collection.title,
+        ),
+        items: [for (final f in collection.folders) folderMeta(collection, f)],
+        exhausted: true,
+      );
+
+  /// The folder behind a tile, or null for an item that isn't one of ours.
+  HomeCollectionFolder? folderOf(StremioMeta item) {
+    final i = folderIndexOf(item);
+    return i < 0 ? null : collection.folders[i];
+  }
+
+  /// Index of the folder behind a tile, or -1 for an item that isn't one.
+  int folderIndexOf(StremioMeta item) {
+    for (var i = 0; i < collection.folders.length; i++) {
+      final f = collection.folders[i];
+      if (HomeCollectionRowIds.folderMetaId(collection.id, f.id) == item.id) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /// Width / height of the row's tiles. The first folder decides — a Nuvio
+  /// collection is uniform in practice, and one shape per row keeps the rail
+  /// grammar intact.
+  double get tileAspectRatio => collection.folders.isEmpty
+      ? CollectionTileShape.landscape.aspectRatio
+      : collection.folders.first.tileShape.aspectRatio;
+
+  bool get landscapeTiles => tileAspectRatio >= 1;
+
+  static StremioMeta folderMeta(HomeCollection c, HomeCollectionFolder f) =>
+      StremioMeta(
+        id: HomeCollectionRowIds.folderMetaId(c.id, f.id),
+        type: 'folder',
+        name: f.title,
+        poster: f.coverImageUrl,
+        background: f.heroBackdropUrl ?? f.coverImageUrl,
+        logo: f.titleLogoUrl,
+        description: f.sources.isEmpty
+            ? null
+            : '${f.sources.length} catalog${f.sources.length == 1 ? '' : 's'}',
+      );
+}

--- a/lib/services/home_collections_store.dart
+++ b/lib/services/home_collections_store.dart
@@ -1,9 +1,14 @@
+import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
+import 'package:crypto/crypto.dart';
+
 import 'package:http/http.dart' as http;
 
 import '../models/home_collection.dart';
+import '../models/home_collection_inventory.dart';
+import 'profiles/profile_runtime.dart';
+import 'profiles/profile_scope.dart';
 import '../models/stremio_addon.dart';
 import 'profiles/profile_preferences.dart';
 
@@ -36,16 +41,16 @@ class HomeCollectionImportResult {
 /// pipeline (file / URL / paste) and the addon-resolution helpers the board,
 /// the folder browser and the settings pages share.
 ///
-/// Persists one JSON string under `home_collections_v1` with the same
-/// conventions as the Home-row stores in `StorageService`: `prefs.remove` on
-/// empty, decode failures swallowed to a safe default.
+/// Persists an atomic inventory under `home_collections_v1`. Deleted IDs
+/// remain as null records for sync; corrupt inventories surface an error
+/// instead of being silently replaced. Legacy JSON arrays remain readable.
 class HomeCollectionsStore {
   HomeCollectionsStore({http.Client Function()? httpClientFactory})
     : _httpClientFactory = httpClientFactory ?? http.Client.new;
 
   static final HomeCollectionsStore instance = HomeCollectionsStore();
 
-  static const String prefsKey = 'home_collections_v1';
+  static const String prefsKey = HomeCollectionInventory.prefsKey;
 
   /// Folder layout preference (`rows` | `tabs`), profile-scoped.
   static const String folderLayoutKey = 'home_collections_folder_layout';
@@ -59,82 +64,125 @@ class HomeCollectionsStore {
 
   // ── Read / write ───────────────────────────────────────────────────────
 
-  Future<List<HomeCollection>> getCollections() async {
-    final prefs = await ProfilePreferences.instance();
-    final json = prefs.getString(prefsKey);
-    if (json == null || json.isEmpty) return const [];
-    try {
-      final decoded = jsonDecode(json);
-      if (decoded is! List) return const [];
-      final seen = <String>{};
-      return [
-        for (final raw in decoded)
-          if (HomeCollection.fromJson(raw) case final c?)
-            if (seen.add(c.id)) c,
-      ];
-    } catch (e) {
-      debugPrint('HomeCollectionsStore: error reading collections: $e');
-      return const [];
+  /// Call before opening a picker/downloading, so completion cannot change
+  /// the profile which owns an import. Also captures legacy -> profile changes.
+  static ({ProfileScope? scope, ProfileScope? active, bool committed})
+  captureSession() => (
+    scope: ProfileRuntime.isProfileCommitted ? ProfileRuntime.capture() : null,
+    active: ProfileRuntime.scope.value,
+    committed: ProfileRuntime.isProfileCommitted,
+  );
+
+  static void checkSession(
+    ({ProfileScope? scope, ProfileScope? active, bool committed}) session,
+  ) {
+    if (session != captureSession()) {
+      throw StateError('The profile changed. Import the collections again.');
     }
   }
 
-  /// Only the collections the board should show.
+  Future<List<HomeCollection>> getCollections() async {
+    final prefs = await ProfilePreferences.instance();
+    return HomeCollectionInventory.decode(
+      prefs.getString(prefsKey),
+    ).collections;
+  }
+
   Future<List<HomeCollection>> getEnabledCollections() async => [
     for (final c in await getCollections())
       if (c.enabled && c.folders.isNotEmpty) c,
   ];
 
-  Future<void> saveCollections(List<HomeCollection> collections) async {
+  Future<T> _mutate<T>(
+    ({ProfileScope? scope, ProfileScope? active, bool committed}) session,
+    T Function(HomeCollectionInventory current) update,
+  ) async {
+    checkSession(session);
     final prefs = await ProfilePreferences.instance();
-    if (collections.isEmpty) {
-      await prefs.remove(prefsKey);
-      return;
+    checkSession(session);
+    late T result;
+    final saved = await prefs.mutateStringAtomically(prefsKey, (old) {
+      checkSession(session);
+      final current = HomeCollectionInventory.decode(old);
+      final previousSize = utf8.encode(current.encode()).length;
+      final previousCount = current.records.length;
+      result = update(current);
+      current.validate();
+      final encoded = current.encode();
+      final size = utf8.encode(encoded).length;
+      // Permit reduction of an older/merged oversized inventory, but never
+      // increase one. Deletions remain records to survive offline peers.
+      if ((size > HomeCollectionInventory.maxStoredBytes &&
+              size > previousSize) ||
+          (current.records.length > HomeCollectionInventory.maxRecords &&
+              current.records.length > previousCount)) {
+        throw const FormatException(
+          'Collections exceed the profile storage limit (128 KiB). Remove a collection or import a smaller file.',
+        );
+      }
+      return encoded;
+    });
+    if (!saved) {
+      throw StateError(
+        'Could not save collections: device storage limit reached.',
+      );
     }
-    await prefs.setString(
-      prefsKey,
-      jsonEncode([for (final c in collections) c.toJson()]),
-    );
+    return result;
   }
 
-  /// Cheap change token for the Home board's settings-changed listener, which
-  /// reloads only when this differs from what it last built from.
-  static String signatureOf(List<HomeCollection> collections) => [
-    for (final c in collections)
-      '${c.id}:${c.enabled ? 1 : 0}:${c.importedAtMs ?? 0}:${c.folders.length}',
-  ].join('|');
+  Future<void> saveCollections(List<HomeCollection> collections) =>
+      _mutate<void>(captureSession(), (current) {
+        final ids = collections.map((c) => c.id).toSet();
+        for (final id in current.records.keys.toList()) {
+          if (!ids.contains(id)) current.remove(id);
+        }
+        for (final c in collections) {
+          current.put(c);
+        }
+        final deletedIds = current.order
+            .where((id) => !ids.contains(id))
+            .toList();
+        current.order
+          ..clear()
+          ..addAll(ids)
+          ..addAll(deletedIds);
+      });
 
-  Future<void> remove(String collectionId) async {
-    final current = await getCollections();
-    await saveCollections([
-      for (final c in current)
-        if (c.id != collectionId) c,
-    ]);
-  }
+  static String signatureOf(List<HomeCollection> collections) => sha256
+      .convert(
+        utf8.encode(jsonEncode([for (final c in collections) c.toJson()])),
+      )
+      .toString();
 
-  Future<void> setEnabled(String collectionId, bool enabled) async {
-    final current = await getCollections();
-    await saveCollections([
-      for (final c in current)
-        if (c.id == collectionId) c.copyWith(enabled: enabled) else c,
-    ]);
-  }
+  Future<void> remove(String id) =>
+      _mutate<void>(captureSession(), (current) => current.remove(id));
 
-  Future<void> clear() => saveCollections(const []);
+  Future<void> setEnabled(String id, bool enabled) =>
+      _mutate<void>(captureSession(), (current) {
+        final c = current.records[id];
+        if (c != null) current.put(c.copyWith(enabled: enabled));
+      });
 
-  // ── Folder layout ──────────────────────────────────────────────────────
+  Future<void> clear() => _mutate<void>(captureSession(), (current) {
+    for (final id in current.records.keys.toList()) {
+      current.remove(id);
+    }
+  });
 
   Future<CollectionFolderLayout> getFolderLayout() async {
-    try {
-      final prefs = await ProfilePreferences.instance();
-      return CollectionFolderLayout.parse(prefs.getString(folderLayoutKey));
-    } catch (_) {
-      return CollectionFolderLayout.rows;
-    }
+    final prefs = await ProfilePreferences.instance();
+    return CollectionFolderLayout.parse(prefs.getString(folderLayoutKey));
   }
 
   Future<void> setFolderLayout(CollectionFolderLayout layout) async {
+    final session = captureSession();
     final prefs = await ProfilePreferences.instance();
-    await prefs.setString(folderLayoutKey, layout.storageValue);
+    checkSession(session);
+    if (!await prefs.setString(folderLayoutKey, layout.storageValue)) {
+      throw StateError(
+        'Could not save folder layout: device storage limit reached.',
+      );
+    }
   }
 
   // ── Import ─────────────────────────────────────────────────────────────
@@ -147,37 +195,31 @@ class HomeCollectionsStore {
     bool replaceExisting = false,
     List<StremioAddon> installedAddons = const [],
   }) async {
+    final session = captureSession();
     final now = DateTime.now().millisecondsSinceEpoch;
-    final current = replaceExisting
-        ? <HomeCollection>[]
-        : List<HomeCollection>.of(await getCollections());
-    final byId = {for (final c in current) c.id: c};
-
-    final added = <HomeCollection>[];
-    final replaced = <HomeCollection>[];
-    for (final c in incoming) {
-      final existing = byId[c.id];
-      final stamped = c.copyWith(
-        importedAtMs: now,
-        enabled: existing?.enabled ?? c.enabled,
-      );
-      if (existing != null) {
-        final i = current.indexWhere((e) => e.id == c.id);
-        current[i] = stamped;
-        replaced.add(stamped);
-      } else {
-        current.add(stamped);
-        added.add(stamped);
+    return _mutate(session, (current) {
+      final added = <HomeCollection>[];
+      final replaced = <HomeCollection>[];
+      if (replaceExisting) {
+        for (final id in current.records.keys.toList()) {
+          current.remove(id);
+        }
       }
-      byId[c.id] = stamped;
-    }
-    await saveCollections(current);
-
-    return HomeCollectionImportResult(
-      added: added,
-      replaced: replaced,
-      unresolvedAddonIds: unresolvedAddonIds(incoming, installedAddons),
-    );
+      for (final c in incoming) {
+        final existing = current.records[c.id];
+        final stamped = c.copyWith(
+          importedAtMs: now,
+          enabled: existing?.enabled ?? c.enabled,
+        );
+        current.put(stamped);
+        (existing == null ? added : replaced).add(stamped);
+      }
+      return HomeCollectionImportResult(
+        added: added,
+        replaced: replaced,
+        unresolvedAddonIds: unresolvedAddonIds(incoming, installedAddons),
+      );
+    });
   }
 
   /// Parse and import a JSON document (file contents, pasted text, or a
@@ -187,7 +229,7 @@ class HomeCollectionsStore {
     bool replaceExisting = false,
     List<StremioAddon> installedAddons = const [],
   }) {
-    if (jsonText.length > maxImportBytes) {
+    if (utf8.encode(jsonText).length > maxImportBytes) {
       throw const FormatException('That file is too large to be a collection.');
     }
     final parsed = HomeCollectionParser.parse(jsonText);
@@ -205,25 +247,34 @@ class HomeCollectionsStore {
     bool replaceExisting = false,
     List<StremioAddon> installedAddons = const [],
   }) async {
+    final session = captureSession();
     final uri = Uri.tryParse(url.trim());
     if (uri == null || !(uri.isScheme('http') || uri.isScheme('https'))) {
       throw const FormatException('Enter an http(s) link to a JSON file.');
     }
     final client = _httpClientFactory();
     try {
-      final response = await client.get(uri).timeout(_fetchTimeout);
-      if (response.statusCode != 200) {
-        throw FormatException(
-          'The server answered ${response.statusCode} for that link.',
-        );
-      }
-      if (response.bodyBytes.length > maxImportBytes) {
-        throw const FormatException(
-          'That file is too large to be a collection.',
-        );
-      }
+      final bytes = await (() async {
+        final response = await client.send(http.Request('GET', uri));
+        if (response.statusCode != 200) {
+          throw FormatException(
+            'The server answered ${response.statusCode} for that link.',
+          );
+        }
+        final bytes = <int>[];
+        await for (final chunk in response.stream) {
+          if (bytes.length + chunk.length > maxImportBytes) {
+            throw const FormatException(
+              'That file is too large to be a collection.',
+            );
+          }
+          bytes.addAll(chunk);
+        }
+        return bytes;
+      })().timeout(_fetchTimeout);
+      checkSession(session);
       return await importJson(
-        utf8.decode(response.bodyBytes, allowMalformed: true),
+        utf8.decode(bytes),
         replaceExisting: replaceExisting,
         installedAddons: installedAddons,
       );
@@ -278,12 +329,10 @@ class HomeCollectionsStore {
     List<StremioAddon> installed,
   ) {
     for (final a in installed) {
-      if (a.id == source.addonId) return a;
+      if (a.id == source.addonId && resolveCatalog(source, a) != null) return a;
     }
     for (final a in installed) {
-      if (a.catalogs.any(
-        (c) => c.id == source.catalogId && c.type == source.type,
-      )) {
+      if (resolveCatalog(source, a) != null) {
         return a;
       }
     }
@@ -296,7 +345,9 @@ class HomeCollectionsStore {
     StremioAddon addon,
   ) {
     for (final c in addon.catalogs) {
-      if (c.id == source.catalogId && c.type == source.type) return c;
+      if (c.id == source.catalogId && c.type == source.type && c.isBrowsable) {
+        return c;
+      }
     }
     return null;
   }

--- a/lib/services/home_collections_store.dart
+++ b/lib/services/home_collections_store.dart
@@ -1,0 +1,344 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import '../models/home_collection.dart';
+import '../models/stremio_addon.dart';
+import 'profiles/profile_preferences.dart';
+
+/// Outcome of an import, for the settings page's result dialog.
+class HomeCollectionImportResult {
+  /// Collections new to this profile.
+  final List<HomeCollection> added;
+
+  /// Collections whose id already existed and were replaced in place
+  /// (keeping their enabled state).
+  final List<HomeCollection> replaced;
+
+  /// Addon ids no installed addon can serve (see
+  /// [HomeCollectionsStore.resolveAddon]). Their folders still import; they
+  /// browse empty until such an addon is installed.
+  final Set<String> unresolvedAddonIds;
+
+  const HomeCollectionImportResult({
+    required this.added,
+    required this.replaced,
+    required this.unresolvedAddonIds,
+  });
+
+  int get collectionCount => added.length + replaced.length;
+  int get folderCount =>
+      [...added, ...replaced].fold(0, (sum, c) => sum + c.folders.length);
+}
+
+/// Profile-scoped store for imported Home collections, plus the import
+/// pipeline (file / URL / paste) and the addon-resolution helpers the board,
+/// the folder browser and the settings pages share.
+///
+/// Persists one JSON string under `home_collections_v1` with the same
+/// conventions as the Home-row stores in `StorageService`: `prefs.remove` on
+/// empty, decode failures swallowed to a safe default.
+class HomeCollectionsStore {
+  HomeCollectionsStore({http.Client Function()? httpClientFactory})
+    : _httpClientFactory = httpClientFactory ?? http.Client.new;
+
+  static final HomeCollectionsStore instance = HomeCollectionsStore();
+
+  static const String prefsKey = 'home_collections_v1';
+
+  /// Folder layout preference (`rows` | `tabs`), profile-scoped.
+  static const String folderLayoutKey = 'home_collections_folder_layout';
+  static const Duration _fetchTimeout = Duration(seconds: 20);
+
+  /// Documents past this are refused before decoding: a collections file is
+  /// a few hundred KB at most, so anything larger is a wrong pick.
+  static const int maxImportBytes = 8 * 1024 * 1024;
+
+  final http.Client Function() _httpClientFactory;
+
+  // ── Read / write ───────────────────────────────────────────────────────
+
+  Future<List<HomeCollection>> getCollections() async {
+    final prefs = await ProfilePreferences.instance();
+    final json = prefs.getString(prefsKey);
+    if (json == null || json.isEmpty) return const [];
+    try {
+      final decoded = jsonDecode(json);
+      if (decoded is! List) return const [];
+      final seen = <String>{};
+      return [
+        for (final raw in decoded)
+          if (HomeCollection.fromJson(raw) case final c?)
+            if (seen.add(c.id)) c,
+      ];
+    } catch (e) {
+      debugPrint('HomeCollectionsStore: error reading collections: $e');
+      return const [];
+    }
+  }
+
+  /// Only the collections the board should show.
+  Future<List<HomeCollection>> getEnabledCollections() async => [
+    for (final c in await getCollections())
+      if (c.enabled && c.folders.isNotEmpty) c,
+  ];
+
+  Future<void> saveCollections(List<HomeCollection> collections) async {
+    final prefs = await ProfilePreferences.instance();
+    if (collections.isEmpty) {
+      await prefs.remove(prefsKey);
+      return;
+    }
+    await prefs.setString(
+      prefsKey,
+      jsonEncode([for (final c in collections) c.toJson()]),
+    );
+  }
+
+  /// Cheap change token for the Home board's settings-changed listener, which
+  /// reloads only when this differs from what it last built from.
+  static String signatureOf(List<HomeCollection> collections) => [
+    for (final c in collections)
+      '${c.id}:${c.enabled ? 1 : 0}:${c.importedAtMs ?? 0}:${c.folders.length}',
+  ].join('|');
+
+  Future<void> remove(String collectionId) async {
+    final current = await getCollections();
+    await saveCollections([
+      for (final c in current)
+        if (c.id != collectionId) c,
+    ]);
+  }
+
+  Future<void> setEnabled(String collectionId, bool enabled) async {
+    final current = await getCollections();
+    await saveCollections([
+      for (final c in current)
+        if (c.id == collectionId) c.copyWith(enabled: enabled) else c,
+    ]);
+  }
+
+  Future<void> clear() => saveCollections(const []);
+
+  // ── Folder layout ──────────────────────────────────────────────────────
+
+  Future<CollectionFolderLayout> getFolderLayout() async {
+    try {
+      final prefs = await ProfilePreferences.instance();
+      return CollectionFolderLayout.parse(prefs.getString(folderLayoutKey));
+    } catch (_) {
+      return CollectionFolderLayout.rows;
+    }
+  }
+
+  Future<void> setFolderLayout(CollectionFolderLayout layout) async {
+    final prefs = await ProfilePreferences.instance();
+    await prefs.setString(folderLayoutKey, layout.storageValue);
+  }
+
+  // ── Import ─────────────────────────────────────────────────────────────
+
+  /// Merge parsed collections into the store: a known id is replaced in place
+  /// (keeping the user's enabled toggle), a new id is appended. With
+  /// [replaceExisting] every stored collection is dropped first.
+  Future<HomeCollectionImportResult> importCollections(
+    List<HomeCollection> incoming, {
+    bool replaceExisting = false,
+    List<StremioAddon> installedAddons = const [],
+  }) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final current = replaceExisting
+        ? <HomeCollection>[]
+        : List<HomeCollection>.of(await getCollections());
+    final byId = {for (final c in current) c.id: c};
+
+    final added = <HomeCollection>[];
+    final replaced = <HomeCollection>[];
+    for (final c in incoming) {
+      final existing = byId[c.id];
+      final stamped = c.copyWith(
+        importedAtMs: now,
+        enabled: existing?.enabled ?? c.enabled,
+      );
+      if (existing != null) {
+        final i = current.indexWhere((e) => e.id == c.id);
+        current[i] = stamped;
+        replaced.add(stamped);
+      } else {
+        current.add(stamped);
+        added.add(stamped);
+      }
+      byId[c.id] = stamped;
+    }
+    await saveCollections(current);
+
+    return HomeCollectionImportResult(
+      added: added,
+      replaced: replaced,
+      unresolvedAddonIds: unresolvedAddonIds(incoming, installedAddons),
+    );
+  }
+
+  /// Parse and import a JSON document (file contents, pasted text, or a
+  /// fetched URL body). Throws [FormatException] for a bad document.
+  Future<HomeCollectionImportResult> importJson(
+    String jsonText, {
+    bool replaceExisting = false,
+    List<StremioAddon> installedAddons = const [],
+  }) {
+    if (jsonText.length > maxImportBytes) {
+      throw const FormatException('That file is too large to be a collection.');
+    }
+    final parsed = HomeCollectionParser.parse(jsonText);
+    return importCollections(
+      parsed,
+      replaceExisting: replaceExisting,
+      installedAddons: installedAddons,
+    );
+  }
+
+  /// Download a collections JSON from [url] and import it. Throws
+  /// [FormatException] for a bad URL / response / document.
+  Future<HomeCollectionImportResult> importFromUrl(
+    String url, {
+    bool replaceExisting = false,
+    List<StremioAddon> installedAddons = const [],
+  }) async {
+    final uri = Uri.tryParse(url.trim());
+    if (uri == null || !(uri.isScheme('http') || uri.isScheme('https'))) {
+      throw const FormatException('Enter an http(s) link to a JSON file.');
+    }
+    final client = _httpClientFactory();
+    try {
+      final response = await client.get(uri).timeout(_fetchTimeout);
+      if (response.statusCode != 200) {
+        throw FormatException(
+          'The server answered ${response.statusCode} for that link.',
+        );
+      }
+      if (response.bodyBytes.length > maxImportBytes) {
+        throw const FormatException(
+          'That file is too large to be a collection.',
+        );
+      }
+      return await importJson(
+        utf8.decode(response.bodyBytes, allowMalformed: true),
+        replaceExisting: replaceExisting,
+        installedAddons: installedAddons,
+      );
+    } on FormatException {
+      rethrow;
+    } catch (e) {
+      throw FormatException('Could not download that link: $e');
+    } finally {
+      client.close();
+    }
+  }
+
+  // ── Backup / restore ───────────────────────────────────────────────────
+
+  /// The store as a JSON-ready list (the backup payload's `homeCollections`).
+  Future<List<Map<String, dynamic>>> exportJson() async => [
+    for (final c in await getCollections()) c.toJson(),
+  ];
+
+  /// Restore a backup's `homeCollections` list, merging by id so a device
+  /// that already holds some of them keeps the rest.
+  Future<({int imported, int alreadyPresent, int failed})> applyBackup(
+    List<dynamic> list,
+  ) async {
+    var failed = 0;
+    final parsed = <HomeCollection>[];
+    for (final raw in list) {
+      final c = HomeCollection.fromJson(raw);
+      if (c == null) {
+        failed++;
+      } else {
+        parsed.add(c);
+      }
+    }
+    if (parsed.isEmpty) return (imported: 0, alreadyPresent: 0, failed: failed);
+    final result = await importCollections(parsed);
+    return (
+      imported: result.added.length,
+      alreadyPresent: result.replaced.length,
+      failed: failed,
+    );
+  }
+
+  // ── Addon resolution ───────────────────────────────────────────────────
+
+  /// The installed addon a source refers to: an exact manifest-id match, else
+  /// any installed addon serving a catalog with the same `type` + `catalogId`.
+  /// The fallback matters because the file was made against someone else's
+  /// install, and the same addon deployed elsewhere can carry another id.
+  static StremioAddon? resolveAddon(
+    CollectionCatalogSource source,
+    List<StremioAddon> installed,
+  ) {
+    for (final a in installed) {
+      if (a.id == source.addonId) return a;
+    }
+    for (final a in installed) {
+      if (a.catalogs.any(
+        (c) => c.id == source.catalogId && c.type == source.type,
+      )) {
+        return a;
+      }
+    }
+    return null;
+  }
+
+  /// The catalog of [addon] a source points at (type + id), or null.
+  static StremioAddonCatalog? resolveCatalog(
+    CollectionCatalogSource source,
+    StremioAddon addon,
+  ) {
+    for (final c in addon.catalogs) {
+      if (c.id == source.catalogId && c.type == source.type) return c;
+    }
+    return null;
+  }
+
+  /// Home-row keys (`addonId:type:catalogId`) of every catalog an enabled
+  /// collection folder resolves to. As in Nuvio, a list lives in its folder
+  /// rather than in both places, so these are left off the Home board and
+  /// out of the addon groups in the Home Rows manager.
+  static Set<String> claimedCatalogKeys(
+    List<HomeCollection> collections,
+    List<StremioAddon> installed,
+  ) {
+    final out = <String>{};
+    for (final c in collections) {
+      if (!c.enabled) continue;
+      for (final f in c.folders) {
+        for (final s in f.sources) {
+          final addon = resolveAddon(s, installed);
+          if (addon == null) continue;
+          final catalog = resolveCatalog(s, addon);
+          if (catalog == null) continue;
+          out.add('${addon.id}:${catalog.type}:${catalog.id}');
+        }
+      }
+    }
+    return out;
+  }
+
+  /// Addon ids referenced by [collections] that nothing in [installed] can
+  /// serve, by id or by catalog match.
+  static Set<String> unresolvedAddonIds(
+    List<HomeCollection> collections,
+    List<StremioAddon> installed,
+  ) {
+    final out = <String>{};
+    for (final c in collections) {
+      for (final f in c.folders) {
+        for (final s in f.sources) {
+          if (resolveAddon(s, installed) == null) out.add(s.addonId);
+        }
+      }
+    }
+    return out;
+  }
+}

--- a/lib/services/home_collections_store.dart
+++ b/lib/services/home_collections_store.dart
@@ -42,8 +42,9 @@ class HomeCollectionImportResult {
 /// the folder browser and the settings pages share.
 ///
 /// Persists an atomic inventory under `home_collections_v1`. Deleted IDs
-/// remain as null records for sync; corrupt inventories surface an error
-/// instead of being silently replaced. Legacy JSON arrays remain readable.
+/// remain as null records until sync journals their deletion. Reads salvage
+/// valid records; ordinary writes reject corruption until explicit reset or
+/// restore. Legacy JSON arrays remain readable.
 class HomeCollectionsStore {
   HomeCollectionsStore({http.Client Function()? httpClientFactory})
     : _httpClientFactory = httpClientFactory ?? http.Client.new;
@@ -81,12 +82,13 @@ class HomeCollectionsStore {
     }
   }
 
-  Future<List<HomeCollection>> getCollections() async {
+  Future<HomeCollectionInventory> getInventory() async {
     final prefs = await ProfilePreferences.instance();
-    return HomeCollectionInventory.decode(
-      prefs.getString(prefsKey),
-    ).collections;
+    return HomeCollectionInventory.recover(prefs.getString(prefsKey));
   }
+
+  Future<List<HomeCollection>> getCollections() async =>
+      (await getInventory()).collections;
 
   Future<List<HomeCollection>> getEnabledCollections() async => [
     for (final c in await getCollections())
@@ -95,29 +97,33 @@ class HomeCollectionsStore {
 
   Future<T> _mutate<T>(
     ({ProfileScope? scope, ProfileScope? active, bool committed}) session,
-    T Function(HomeCollectionInventory current) update,
-  ) async {
+    T Function(HomeCollectionInventory current) update, {
+    bool recoverCorruption = false,
+  }) async {
     checkSession(session);
     final prefs = await ProfilePreferences.instance();
     checkSession(session);
     late T result;
     final saved = await prefs.mutateStringAtomically(prefsKey, (old) {
       checkSession(session);
-      final current = HomeCollectionInventory.decode(old);
-      final previousSize = utf8.encode(current.encode()).length;
-      final previousCount = current.records.length;
+      final current = recoverCorruption
+          ? HomeCollectionInventory.recover(old)
+          : HomeCollectionInventory.decode(old);
+      final previousSize = current.definitionBytes;
+      final previousCount = current.liveCount;
       result = update(current);
       current.validate();
       final encoded = current.encode();
-      final size = utf8.encode(encoded).length;
-      // Permit reduction of an older/merged oversized inventory, but never
-      // increase one. Deletions remain records to survive offline peers.
+      final size = current.definitionBytes;
+      // Bound live definitions, permitting reductions and visibility changes
+      // in an older/merged oversized inventory. Pending deletions are outbox
+      // records that sync moves into its separately retained tombstone tier.
       if ((size > HomeCollectionInventory.maxStoredBytes &&
               size > previousSize) ||
-          (current.records.length > HomeCollectionInventory.maxRecords &&
-              current.records.length > previousCount)) {
+          (current.liveCount > HomeCollectionInventory.maxRecords &&
+              current.liveCount > previousCount)) {
         throw const FormatException(
-          'Collections exceed the profile storage limit (128 KiB). Remove a collection or import a smaller file.',
+          'Collection definitions exceed 128 KiB or 1,024 live collections. Remove a collection or import a smaller file.',
         );
       }
       return encoded;
@@ -167,7 +173,7 @@ class HomeCollectionsStore {
     for (final id in current.records.keys.toList()) {
       current.remove(id);
     }
-  });
+  }, recoverCorruption: true);
 
   Future<CollectionFolderLayout> getFolderLayout() async {
     final prefs = await ProfilePreferences.instance();
@@ -194,6 +200,7 @@ class HomeCollectionsStore {
     List<HomeCollection> incoming, {
     bool replaceExisting = false,
     List<StremioAddon> installedAddons = const [],
+    bool recoverCorruption = false,
   }) async {
     final session = captureSession();
     final now = DateTime.now().millisecondsSinceEpoch;
@@ -219,7 +226,7 @@ class HomeCollectionsStore {
         replaced: replaced,
         unresolvedAddonIds: unresolvedAddonIds(incoming, installedAddons),
       );
-    });
+    }, recoverCorruption: recoverCorruption);
   }
 
   /// Parse and import a JSON document (file contents, pasted text, or a
@@ -310,7 +317,7 @@ class HomeCollectionsStore {
       }
     }
     if (parsed.isEmpty) return (imported: 0, alreadyPresent: 0, failed: failed);
-    final result = await importCollections(parsed);
+    final result = await importCollections(parsed, recoverCorruption: true);
     return (
       imported: result.added.length,
       alreadyPresent: result.replaced.length,
@@ -358,11 +365,14 @@ class HomeCollectionsStore {
   /// out of the addon groups in the Home Rows manager.
   static Set<String> claimedCatalogKeys(
     List<HomeCollection> collections,
-    List<StremioAddon> installed,
-  ) {
+    List<StremioAddon> installed, {
+    Set<String> disabledRows = const {},
+    bool showsCollectionRows = true,
+  }) {
     final out = <String>{};
+    if (!showsCollectionRows) return out;
     for (final c in collections) {
-      if (!c.enabled) continue;
+      if (!c.enabled || disabledRows.contains(c.rowId)) continue;
       for (final f in c.folders) {
         for (final s in f.sources) {
           final addon = resolveAddon(s, installed);

--- a/lib/services/home_collections_store.dart
+++ b/lib/services/home_collections_store.dart
@@ -327,21 +327,14 @@ class HomeCollectionsStore {
 
   // ── Addon resolution ───────────────────────────────────────────────────
 
-  /// The installed addon a source refers to: an exact manifest-id match, else
-  /// any installed addon serving a catalog with the same `type` + `catalogId`.
-  /// The fallback matters because the file was made against someone else's
-  /// install, and the same addon deployed elsewhere can carry another id.
+  /// Resolve within the source's addon identity. Catalog ids are local to an
+  /// addon; matching another provider's generic id can silently claim its rows.
   static StremioAddon? resolveAddon(
     CollectionCatalogSource source,
     List<StremioAddon> installed,
   ) {
     for (final a in installed) {
       if (a.id == source.addonId && resolveCatalog(source, a) != null) return a;
-    }
-    for (final a in installed) {
-      if (resolveCatalog(source, a) != null) {
-        return a;
-      }
     }
     return null;
   }

--- a/lib/services/home_row_order.dart
+++ b/lib/services/home_row_order.dart
@@ -59,6 +59,21 @@ class HomeRowOrder {
     return out;
   }
 
+  /// New pinned rows lead an existing order. Once saved, an explicit manual
+  /// position wins, so arranging a pinned collection remains possible.
+  static List<String> seedPinned(
+    Iterable<String> saved,
+    Iterable<String> pinned,
+  ) {
+    final order = normalize(saved);
+    final known = order.toSet();
+    return normalize([
+      for (final id in pinned)
+        if (!known.contains(id)) id,
+      ...order,
+    ]);
+  }
+
   /// Sort [values] by the saved ids. Unranked values append stably.
   static List<T> apply<T>(
     Iterable<T> values,

--- a/lib/services/stremio_service.dart
+++ b/lib/services/stremio_service.dart
@@ -2414,10 +2414,16 @@ class StremioService {
         }
 
         final Map<String, dynamic> data = await decodeJsonAsync(response.body);
-        final metasRaw = data['metas'] as List<dynamic>?;
-        onRawCount?.call(metasRaw?.length ?? 0);
+        final rawMetas = data['metas'];
+        if (rawMetas is! List) {
+          // A successful HTTP status without a catalog payload is an addon
+          // failure, not proof that its catalog has ended.
+          return [];
+        }
+        final metasRaw = rawMetas;
+        onRawCount?.call(metasRaw.length);
 
-        if (metasRaw == null || metasRaw.isEmpty) {
+        if (metasRaw.isEmpty) {
           debugPrint('StremioService: Catalog returned no items');
           _cacheCatalogPage(url, const [], 0);
           return [];

--- a/lib/services/stremio_service.dart
+++ b/lib/services/stremio_service.dart
@@ -2414,13 +2414,10 @@ class StremioService {
         }
 
         final Map<String, dynamic> data = await decodeJsonAsync(response.body);
-        final rawMetas = data['metas'];
-        if (rawMetas is! List) {
-          // A successful HTTP status without a catalog payload is an addon
-          // failure, not proof that its catalog has ended.
-          return [];
-        }
-        final metasRaw = rawMetas;
+        // Some addons signal exhaustion with {} or metas: null. Match the
+        // catalog browsers' empty-list convention while rejecting wrong types.
+        final metasRaw = data['metas'] ?? const <dynamic>[];
+        if (metasRaw is! List) return [];
         onRawCount?.call(metasRaw.length);
 
         if (metasRaw.isEmpty) {

--- a/lib/services/webdav_sync/webdav_sync_engine.dart
+++ b/lib/services/webdav_sync/webdav_sync_engine.dart
@@ -939,6 +939,7 @@ final class WebDavSyncEngine
               throw StateError('WebDAV sync pending apply mapping changed');
             }
             WebDavSyncHotDocument? replayedTarget;
+            var replayedCollectionDeletions = <String, WebDavSyncTombstone>{};
             var replayedAppliedKeys = const <String>{};
             for (var attempt = 0; attempt < 2; attempt++) {
               final fresh = await _localAdapter.readProfile(
@@ -999,12 +1000,40 @@ final class WebDavSyncEngine
                 protectedPreferenceKeys: built.protectedPreferenceKeys,
               );
               try {
+                replayedCollectionDeletions = {
+                  for (final entry in replayed.tombstones.entries)
+                    if (entry.key.startsWith('homecollection/'))
+                      entry.key: entry.value,
+                };
                 replayedAppliedKeys = await _localAdapter.applyProfile(
                   session,
                   pending.localProfileId,
                   values,
                   expectedMutationToken: fresh.mutationToken,
                   replayingPending: true,
+                  beforeWrite: () => _stateRepository.update(namespaceId, (current) {
+                    final profiles =
+                        Map<String, WebDavSyncProfileEngineState>.from(
+                          current.profiles,
+                        );
+                    final profile = profiles[entry.key] ??
+                        const WebDavSyncProfileEngineState();
+                    // Replay can discover deletions made since the interrupted
+                    // apply. Persist them before materialization removes their
+                    // local null markers, even if replay itself crashes.
+                    profiles[entry.key] = profile.copyWith(
+                      tombstones: {
+                        ...profile.tombstones,
+                        ...replayedCollectionDeletions,
+                      },
+                    );
+                    return current.copyWith(
+                      profiles:
+                          Map<String, WebDavSyncProfileEngineState>.unmodifiable(
+                            profiles,
+                          ),
+                    );
+                  }),
                 );
                 replayedTarget = replayed.document;
                 break;
@@ -1021,6 +1050,10 @@ final class WebDavSyncEngine
                   profiles[entry.key] ?? const WebDavSyncProfileEngineState();
               profiles[entry.key] = profile.copyWith(
                 baseline: replayedTarget!,
+                tombstones: {
+                  ...profile.tombstones,
+                  ...replayedCollectionDeletions,
+                },
                 clearPendingApply: true,
               );
               return current.copyWith(

--- a/lib/services/webdav_sync/webdav_sync_engine.dart
+++ b/lib/services/webdav_sync/webdav_sync_engine.dart
@@ -1535,6 +1535,10 @@ final class WebDavSyncEngine
             localPortableRecords: built.document.watchState.records,
             protectedPreferenceKeys: built.protectedPreferenceKeys,
           );
+          final collectionDeletions = <String, WebDavSyncTombstone>{
+            for (final entry in merged.tombstones.entries)
+              if (entry.key.startsWith('homecollection/')) entry.key: entry.value,
+          };
           final pending = WebDavSyncPendingApply(
             localProfileId: localProfileId,
             values: values,
@@ -1554,6 +1558,12 @@ final class WebDavSyncEngine
                   const WebDavSyncProfileEngineState();
               profiles[circleProfileId] = currentProfile.copyWith(
                 pendingApply: pending,
+                // Durably journal converted collection deletions before their
+                // local null markers disappear, including a failed apply/push.
+                tombstones: {
+                  ...currentProfile.tombstones,
+                  ...collectionDeletions,
+                },
               );
               return current.copyWith(
                 profiles:
@@ -1717,7 +1727,10 @@ final class WebDavSyncEngine
             document: merged.document,
             library: mergedLibrary,
             tombstones: merged.tombstones,
-            originalLocalTombstones: profileState.tombstones,
+            originalLocalTombstones: {
+              ...profileState.tombstones,
+              ...collectionDeletions,
+            },
           );
         } finally {
           instrumentation.finishPhase(_CyclePhase.mergeApply, phaseStarted);

--- a/lib/services/webdav_sync/webdav_sync_hot_merge.dart
+++ b/lib/services/webdav_sync/webdav_sync_hot_merge.dart
@@ -651,7 +651,7 @@ abstract final class WebDavSyncHotMerge {
     final collectionRaw =
         input.portablePreferences[HomeCollectionInventory.prefsKey];
     if (collectionRaw != null) {
-      final inventory = HomeCollectionInventory.decode(collectionRaw);
+      final inventory = HomeCollectionInventory.recover(collectionRaw);
       for (final entry in inventory.records.entries) {
         portableRecords[WebDavSyncRecordKey.homeCollection(entry.key)] = entry
             .value
@@ -768,6 +768,22 @@ abstract final class WebDavSyncHotMerge {
         }
       }
     }
+    // Local nulls are a pending-delete outbox. Move them into the normal
+    // tombstone tier so publication/retention and dormant-peer suppression
+    // apply, and deletion history no longer fills collection preferences.
+    for (final doc in docs) {
+      for (final entry in doc.watchState.records.entries) {
+        if (!entry.key.startsWith('homecollection/') || entry.value.value != null) continue;
+        if (suppressDormantLocal && identical(doc, local) &&
+            entry.value.stamp.normalizedTimeMs <= dormantSinceMs) {
+          continue;
+        }
+        final prior = tombstones[entry.key];
+        if (prior == null || _compareStamp(entry.value.stamp, prior.stamp) > 0) {
+          tombstones[entry.key] = WebDavSyncTombstone(key: entry.key, stamp: entry.value.stamp);
+        }
+      }
+    }
     if (tombstones.length > WebDavSyncLimits.maxTombstonesPerProfile) {
       throw const FormatException(
         'Merged WebDAV sync tombstones exceed their safe limit',
@@ -805,6 +821,7 @@ abstract final class WebDavSyncHotMerge {
     final records = <String, WebDavSyncStampedValue>{};
     for (final doc in docs) {
       for (final entry in doc.watchState.records.entries) {
+        if (entry.key.startsWith('homecollection/') && entry.value.value == null) continue;
         if (suppressDormantLocal &&
             identical(doc, local) &&
             entry.value.stamp.normalizedTimeMs <= dormantSinceMs) {
@@ -1010,10 +1027,15 @@ abstract final class WebDavSyncHotMerge {
     for (final entry in document.watchState.records.entries) {
       final parts = entry.key.split('/');
       if (parts.length == 2 && parts[0] == 'homecollection') {
-        collections[WebDavSyncRecordKey.decodePart(parts[1])] = chosen(
-          entry.key,
-          entry.value,
-        );
+        try {
+          collections[WebDavSyncRecordKey.decodePart(parts[1])] = chosen(
+            entry.key,
+            entry.value,
+          );
+        } on FormatException {
+          // An invalid collection identity must not block unrelated profiles.
+          continue;
+        }
       } else if (parts.length >= 3 && parts[0] == 'playback') {
         final alias = WebDavSyncRecordKey.decodePart(parts[2]);
         if (parts[1] == 'record' && parts.length == 3) {
@@ -1096,7 +1118,7 @@ abstract final class WebDavSyncHotMerge {
         for (final id in (collections.keys.toList()..sort()))
           if (!preferred.contains(id)) id,
       ];
-      final inventory = HomeCollectionInventory.decode({
+      final inventory = HomeCollectionInventory.recover({
         'version': 2,
         'records': collections,
         'order': order,

--- a/lib/services/webdav_sync/webdav_sync_hot_merge.dart
+++ b/lib/services/webdav_sync/webdav_sync_hot_merge.dart
@@ -3,11 +3,15 @@ import 'dart:math';
 
 import 'package:crypto/crypto.dart';
 
+import '../../models/home_collection_inventory.dart';
 import 'webdav_sync_codec.dart';
 import 'webdav_sync_hot_models.dart';
 import '../playlist_dedupe_key.dart';
 
 abstract final class WebDavSyncRecordKey {
+  static String homeCollection(String id) => 'homecollection/${_part(id)}';
+  static const String homeCollectionOrder = 'homecollections/items';
+
   static String playback(String alias) => 'playback/record/${_part(alias)}';
 
   static String playbackMeta(String alias) => 'playback/meta/${_part(alias)}';
@@ -502,6 +506,7 @@ abstract final class WebDavSyncHotMerge {
       'mdblist_sync_checkpoint_v1';
 
   static const Set<String> _specialKeys = <String>{
+    HomeCollectionInventory.prefsKey,
     playbackPreference,
     continueWatchingPreference,
     finishedMoviesPreference,
@@ -642,6 +647,18 @@ abstract final class WebDavSyncHotMerge {
       input.identityMaps,
       playlistDedupeMap,
     );
+
+    final collectionRaw =
+        input.portablePreferences[HomeCollectionInventory.prefsKey];
+    if (collectionRaw != null) {
+      final inventory = HomeCollectionInventory.decode(collectionRaw);
+      for (final entry in inventory.records.entries) {
+        portableRecords[WebDavSyncRecordKey.homeCollection(entry.key)] = entry
+            .value
+            ?.toJson();
+      }
+      orderKeys[WebDavSyncRecordKey.homeCollectionOrder] = inventory.order;
+    }
 
     final wireRecords = <String, WebDavSyncStampedValue>{};
     for (final entry in portableRecords.entries) {
@@ -988,10 +1005,16 @@ abstract final class WebDavSyncHotMerge {
     final series = <String>{};
     final playlist = <String, Map<String, Object?>>{};
     final favorites = <String>{};
+    final collections = <String, Object?>{};
 
     for (final entry in document.watchState.records.entries) {
       final parts = entry.key.split('/');
-      if (parts.length >= 3 && parts[0] == 'playback') {
+      if (parts.length == 2 && parts[0] == 'homecollection') {
+        collections[WebDavSyncRecordKey.decodePart(parts[1])] = chosen(
+          entry.key,
+          entry.value,
+        );
+      } else if (parts.length >= 3 && parts[0] == 'playback') {
         final alias = WebDavSyncRecordKey.decodePart(parts[2]);
         if (parts[1] == 'record' && parts.length == 3) {
           final value = chosen(entry.key, entry.value);
@@ -1053,6 +1076,34 @@ abstract final class WebDavSyncHotMerge {
           favorites.add(key);
         }
       }
+    }
+
+    // Keep deletion markers in local storage so a subsequent local build
+    // cannot forget them when an offline peer rejoins.
+    if (collections.isNotEmpty ||
+        document.watchState.orders.containsKey(
+          WebDavSyncRecordKey.homeCollectionOrder,
+        )) {
+      final preferred =
+          document
+              .watchState
+              .orders[WebDavSyncRecordKey.homeCollectionOrder]
+              ?.keys ??
+          const <String>[];
+      final order = <String>[
+        for (final id in preferred)
+          if (collections.containsKey(id)) id,
+        for (final id in (collections.keys.toList()..sort()))
+          if (!preferred.contains(id)) id,
+      ];
+      final inventory = HomeCollectionInventory.decode({
+        'version': 2,
+        'records': collections,
+        'order': order,
+      });
+      output[HomeCollectionInventory.prefsKey] = WebDavSyncCodec.canonicalJson(
+        inventory.toJson(),
+      );
     }
 
     if (playback.isNotEmpty ||
@@ -1322,7 +1373,9 @@ abstract final class WebDavSyncHotMerge {
     Map<String, WebDavSyncStampedValue> records,
   ) {
     late final String prefix;
-    if (orderKey == WebDavSyncRecordKey.playlistOrder) {
+    if (orderKey == WebDavSyncRecordKey.homeCollectionOrder) {
+      prefix = 'homecollection/';
+    } else if (orderKey == WebDavSyncRecordKey.playlistOrder) {
       prefix = 'playlist/item/';
     } else if (orderKey == WebDavSyncRecordKey.playlistFavoriteOrder) {
       prefix = 'playlist/favorite/';

--- a/lib/services/webdav_sync/webdav_sync_ui_refresh.dart
+++ b/lib/services/webdav_sync/webdav_sync_ui_refresh.dart
@@ -54,6 +54,8 @@ abstract final class WebDavSyncUiRefresh {
     'home_hide_catalog_addon_names': {_WebDavSyncUiRefreshTarget.homeSettings},
     'home_disabled_sections_v1': {_WebDavSyncUiRefreshTarget.homeSettings},
     'home_extra_rows_v1': {_WebDavSyncUiRefreshTarget.homeSettings},
+    'home_collections_v1': {_WebDavSyncUiRefreshTarget.homeSettings},
+    'home_collections_folder_layout': {_WebDavSyncUiRefreshTarget.homeSettings},
     'home_row_order_v1': {_WebDavSyncUiRefreshTarget.homeSettings},
     'home_continue_watching_enabled': {_WebDavSyncUiRefreshTarget.homeSettings},
     'home_hero_trailer_enabled': {_WebDavSyncUiRefreshTarget.homeSettings},

--- a/lib/utils/home_rail_metrics.dart
+++ b/lib/utils/home_rail_metrics.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/widgets.dart';
+
+/// Poster width of a Home board rail card — the single source for every
+/// surface that must look like a Home row (the board itself, collection
+/// folder rails).
+double homeRailPosterWidth(BuildContext context, {required bool isTelevision}) {
+  if (!isTelevision) {
+    return MediaQuery.sizeOf(context).width >= 900 ? 162.0 : 118.0;
+  }
+  return (MediaQuery.sizeOf(context).height * 0.17).clamp(92.0, 140.0);
+}

--- a/lib/widgets/collections/folder_hero_band.dart
+++ b/lib/widgets/collections/folder_hero_band.dart
@@ -25,8 +25,11 @@ class FolderHeroBand extends StatelessWidget {
     if (backdrop == null && logo == null) return const SizedBox.shrink();
     final app = AppThemeScope.of(context);
     final bg = app.seeAll.bg;
-    final height = isTelevision ? 150.0 : 110.0;
-    final logoHeight = isTelevision ? 56.0 : 44.0;
+    final height = (MediaQuery.sizeOf(context).height * 0.18).clamp(
+      0.0,
+      isTelevision ? 150.0 : 110.0,
+    );
+    final logoHeight = (height * 0.5).clamp(0.0, isTelevision ? 56.0 : 44.0);
 
     return SizedBox(
       height: height,
@@ -84,6 +87,8 @@ class FolderHeroBand extends StatelessWidget {
 
   Widget _title(AppTheme app) => Text(
     folder.title,
+    maxLines: 1,
+    overflow: TextOverflow.ellipsis,
     style: TextStyle(
       color: app.core.tx,
       fontSize: isTelevision ? 26 : 22,

--- a/lib/widgets/collections/folder_hero_band.dart
+++ b/lib/widgets/collections/folder_hero_band.dart
@@ -1,0 +1,93 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '../../models/home_collection.dart';
+import '../../theme/app_theme.dart';
+import '../../theme/app_theme_scope.dart';
+
+/// The folder's backdrop and title logo above its lists, when the collection
+/// file provides them. Renders nothing for folders without either.
+class FolderHeroBand extends StatelessWidget {
+  final HomeCollectionFolder folder;
+  final bool isTelevision;
+
+  const FolderHeroBand({
+    super.key,
+    required this.folder,
+    this.isTelevision = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final backdrop = folder.heroBackdropUrl;
+    final logo = folder.titleLogoUrl;
+    if (backdrop == null && logo == null) return const SizedBox.shrink();
+    final app = AppThemeScope.of(context);
+    final bg = app.seeAll.bg;
+    final height = isTelevision ? 150.0 : 110.0;
+    final logoHeight = isTelevision ? 56.0 : 44.0;
+
+    return SizedBox(
+      height: height,
+      width: double.infinity,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          if (backdrop != null)
+            CachedNetworkImage(
+              imageUrl: backdrop,
+              fit: BoxFit.cover,
+              alignment: Alignment.topCenter,
+              memCacheWidth: 1280,
+              errorWidget: (_, __, ___) => const SizedBox.shrink(),
+            ),
+          // Fade the still into the page ground so the filter line below
+          // reads on a settled surface, and keep the logo's corner legible.
+          DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [bg.withValues(alpha: 0.25), bg],
+              ),
+            ),
+          ),
+          DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.centerLeft,
+                end: Alignment.centerRight,
+                colors: [bg.withValues(alpha: 0.7), bg.withValues(alpha: 0)],
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 0, 24, 8),
+            child: Align(
+              alignment: Alignment.bottomLeft,
+              child: logo != null
+                  ? CachedNetworkImage(
+                      imageUrl: logo,
+                      height: logoHeight,
+                      fit: BoxFit.contain,
+                      alignment: Alignment.bottomLeft,
+                      errorWidget: (_, __, ___) => _title(app),
+                    )
+                  : _title(app),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _title(AppTheme app) => Text(
+    folder.title,
+    style: TextStyle(
+      color: app.core.tx,
+      fontSize: isTelevision ? 26 : 22,
+      fontWeight: FontWeight.w800,
+      letterSpacing: -0.3,
+    ),
+  );
+}

--- a/lib/widgets/collections/folder_hero_band.dart
+++ b/lib/widgets/collections/folder_hero_band.dart
@@ -5,8 +5,9 @@ import '../../models/home_collection.dart';
 import '../../theme/app_theme.dart';
 import '../../theme/app_theme_scope.dart';
 
-/// The folder's backdrop and title logo above its lists, when the collection
-/// file provides them. Renders nothing for folders without either.
+/// The folder's backdrop and title logo above its lists. Files without a
+/// dedicated backdrop fall back to the cover art; without a logo the title
+/// is set in text. Renders nothing for a folder with no art at all.
 class FolderHeroBand extends StatelessWidget {
   final HomeCollectionFolder folder;
   final bool isTelevision;
@@ -19,7 +20,7 @@ class FolderHeroBand extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final backdrop = folder.heroBackdropUrl;
+    final backdrop = folder.heroBackdropUrl ?? folder.coverImageUrl;
     final logo = folder.titleLogoUrl;
     if (backdrop == null && logo == null) return const SizedBox.shrink();
     final app = AppThemeScope.of(context);

--- a/lib/widgets/collections/rail_see_all_pill.dart
+++ b/lib/widgets/collections/rail_see_all_pill.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../theme/app_theme_scope.dart';
+
+/// The "See all ›" control at the right of a rail header on a stacked-rails
+/// screen. On TV it is the rung between rails in the DPAD ladder (up to the
+/// rail above, down into this rail's cards); elsewhere it is a plain link.
+class RailSeeAllPill extends StatefulWidget {
+  final FocusNode node;
+  final bool isTelevision;
+  final VoidCallback onPressed;
+  final VoidCallback onUp;
+  final VoidCallback onDown;
+  final VoidCallback onFocused;
+
+  const RailSeeAllPill({
+    super.key,
+    required this.node,
+    required this.isTelevision,
+    required this.onPressed,
+    required this.onUp,
+    required this.onDown,
+    required this.onFocused,
+  });
+
+  @override
+  State<RailSeeAllPill> createState() => _RailSeeAllPillState();
+}
+
+class _RailSeeAllPillState extends State<RailSeeAllPill> {
+  bool _focused = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.node.addListener(_onFocusChange);
+  }
+
+  @override
+  void didUpdateWidget(covariant RailSeeAllPill oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.node != widget.node) {
+      oldWidget.node.removeListener(_onFocusChange);
+      widget.node.addListener(_onFocusChange);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.node.removeListener(_onFocusChange);
+    super.dispose();
+  }
+
+  void _onFocusChange() {
+    final focused = widget.node.hasFocus;
+    if (focused == _focused) return;
+    setState(() => _focused = focused);
+    if (focused) widget.onFocused();
+  }
+
+  KeyEventResult _onKey(FocusNode _, KeyEvent event) {
+    if (!widget.isTelevision || event is! KeyDownEvent) {
+      return KeyEventResult.ignored;
+    }
+    final key = event.logicalKey;
+    if (key == LogicalKeyboardKey.arrowDown) {
+      widget.onDown();
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowUp) {
+      widget.onUp();
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowLeft ||
+        key == LogicalKeyboardKey.arrowRight) {
+      // Nothing beside the pill — swallow so focus can't wander off-screen.
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.select ||
+        key == LogicalKeyboardKey.enter ||
+        key == LogicalKeyboardKey.space ||
+        key == LogicalKeyboardKey.gameButtonA) {
+      widget.onPressed();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final app = AppThemeScope.of(context);
+    final color = _focused ? app.core.tx : app.fade(app.core.tx, 0.62);
+    return Focus(
+      focusNode: widget.node,
+      onKeyEvent: _onKey,
+      child: InkWell(
+        onTap: widget.onPressed,
+        borderRadius: app.shape.br(9),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          padding: const EdgeInsets.fromLTRB(10, 5, 6, 5),
+          decoration: BoxDecoration(
+            borderRadius: app.shape.br(9),
+            color: _focused ? app.fade(app.core.tx, 0.10) : Colors.transparent,
+            border: Border.all(
+              color: _focused ? app.seeAll.accentBorder : Colors.transparent,
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'See all',
+                style: TextStyle(
+                  color: color,
+                  fontSize: 12.5,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              Icon(Icons.chevron_right_rounded, size: 18, color: color),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/home/spotlight_board.dart
+++ b/lib/widgets/home/spotlight_board.dart
@@ -52,6 +52,7 @@ class SpotlightCard {
   final VoidCallback onOpen;
   final VoidCallback? onOptions;
   final SpotlightCardShape shape;
+  final bool showCaption;
 
   /// Title identity for the effective watched marker. Null for channels,
   /// playlists, and other non-title cards.
@@ -74,6 +75,7 @@ class SpotlightCard {
     this.progress,
     this.onOptions,
     this.shape = SpotlightCardShape.poster,
+    this.showCaption = true,
     this.previewBuilder,
     this.watchedImdbId,
     this.watchedContentType,
@@ -84,6 +86,9 @@ class SpotlightCard {
 enum SpotlightCardShape {
   /// 2:3, art cropped to fill. Titles.
   poster(2 / 3, BoxFit.cover),
+
+  /// Square collection cover, cropped to fill.
+  square(1, BoxFit.cover),
 
   /// 1:1, art CONTAINED on a plate. A channel logo is a mark, not a still:
   /// cropping it to fill cuts the wordmark in half.
@@ -2085,7 +2090,7 @@ class SpotlightBoardState extends State<SpotlightBoard> {
                 radius: m.radius,
                 captionBelow: m.compact && captions,
                 captionBlock: captions ? m.captionBlock : 0,
-                showCaption: captions,
+                showCaption: captions && section.items[c].showCaption,
                 showTitleAndRating: widget.showCardTitlesAndRatings,
                 hoverable: !widget.dpad,
                 dpad: widget.dpad,

--- a/lib/widgets/see_all/see_all_poster_grid.dart
+++ b/lib/widgets/see_all/see_all_poster_grid.dart
@@ -139,6 +139,10 @@ class SeeAllPosterGrid extends StatefulWidget {
   /// DPAD-left at column 0 leaves the grid (e.g. to the sidebar). No-op if null.
   final VoidCallback? onExitLeft;
 
+  /// SHELF only: DPAD-down leaves the single row (e.g. to the next rail on a
+  /// stacked-rails screen). Null keeps the shelf's default of swallowing it.
+  final VoidCallback? onExitBottom;
+
   const SeeAllPosterGrid({
     super.key,
     required this.items,
@@ -155,6 +159,7 @@ class SeeAllPosterGrid extends StatefulWidget {
     this.isBound,
     this.onExitTop,
     this.onExitLeft,
+    this.onExitBottom,
   });
 
   @override
@@ -337,6 +342,7 @@ class SeeAllPosterGridState extends State<SeeAllPosterGrid> {
       return KeyEventResult.handled;
     }
     if (key == LogicalKeyboardKey.arrowDown) {
+      widget.onExitBottom?.call();
       return KeyEventResult.handled;
     }
     return KeyEventResult.ignored;

--- a/lib/widgets/see_all/stremio_dropdown.dart
+++ b/lib/widgets/see_all/stremio_dropdown.dart
@@ -349,8 +349,8 @@ class _StremioDropdownState<T extends Object>
           // When a parent hands a TIGHT width (an equal-width filter column —
           // see SeeAllFilterBar's TV single row), fill it and pin the chevron to
           // the right edge, ellipsizing the value. Otherwise stay intrinsic (the
-          // Wrap/Row usages everywhere else are unaffected — they pass loose or
-          // unbounded width, so `hasTightWidth` is false).
+          // Wrap/Row usages use loose sizing, with the value allowed to shrink
+          // when a narrow sheet cannot fit the label and full value).
           child: widget.quiet
               ? _buildQuiet(active)
               : LayoutBuilder(
@@ -404,9 +404,11 @@ class _StremioDropdownState<T extends Object>
                           if (stretch)
                             Expanded(child: valueText)
                           else
-                            ConstrainedBox(
-                              constraints: const BoxConstraints(maxWidth: 200),
-                              child: valueText,
+                            Flexible(
+                              child: ConstrainedBox(
+                                constraints: const BoxConstraints(maxWidth: 200),
+                                child: valueText,
+                              ),
                             ),
                           const SizedBox(width: 8),
                           Icon(

--- a/lib/widgets/text_prompt_dialog.dart
+++ b/lib/widgets/text_prompt_dialog.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+/// A single-field prompt (a URL, a pasted document) that pops the trimmed
+/// text on confirm and null on cancel. Empty input never confirms.
+class TextPromptDialog extends StatefulWidget {
+  final String title;
+  final String hint;
+  final String helper;
+
+  /// Label of the confirm button.
+  final String action;
+  final bool multiline;
+
+  /// Ignored when [multiline] (which forces the multiline keyboard).
+  final TextInputType? keyboardType;
+
+  const TextPromptDialog({
+    super.key,
+    required this.title,
+    required this.hint,
+    required this.helper,
+    required this.action,
+    this.multiline = false,
+    this.keyboardType,
+  });
+
+  @override
+  State<TextPromptDialog> createState() => _TextPromptDialogState();
+}
+
+class _TextPromptDialogState extends State<TextPromptDialog> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+    Navigator.of(context).pop(text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.title),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 520),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _controller,
+              autofocus: true,
+              keyboardType: widget.multiline
+                  ? TextInputType.multiline
+                  : (widget.keyboardType ?? TextInputType.text),
+              maxLines: widget.multiline ? 10 : 1,
+              minLines: widget.multiline ? 6 : 1,
+              textInputAction: widget.multiline
+                  ? TextInputAction.newline
+                  : TextInputAction.done,
+              onSubmitted: widget.multiline ? null : (_) => _submit(),
+              decoration: InputDecoration(
+                hintText: widget.hint,
+                border: const OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(widget.helper, style: const TextStyle(fontSize: 12)),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        TextButton(onPressed: _submit, child: Text(widget.action)),
+      ],
+    );
+  }
+}

--- a/lib/widgets/text_prompt_dialog.dart
+++ b/lib/widgets/text_prompt_dialog.dart
@@ -46,6 +46,7 @@ class _TextPromptDialogState extends State<TextPromptDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
+      scrollable: true,
       title: Text(widget.title),
       content: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 520),

--- a/test/collection_catalog_pager_test.dart
+++ b/test/collection_catalog_pager_test.dart
@@ -1,0 +1,122 @@
+import 'dart:async';
+import 'package:debrify/models/home_collection.dart';
+import 'package:debrify/models/stremio_addon.dart';
+import 'package:debrify/services/collection_catalog_pager.dart';
+import 'package:debrify/services/collection_folder_loader.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final addon = StremioAddon(
+    id: 'a',
+    name: 'A',
+    manifestUrl: 'https://example.invalid/manifest.json',
+    baseUrl: 'https://example.invalid',
+    catalogs: const [
+      StremioAddonCatalog(id: 'popular', type: 'movie', name: 'Popular'),
+    ],
+  );
+  StremioMeta meta(String id, {String type = 'movie'}) =>
+      StremioMeta(id: id, type: type, name: id);
+  CollectionCatalogPager pager(CatalogFetch fetch) => CollectionCatalogPager(
+    addon: addon,
+    catalog: addon.catalogs.single,
+    fetch: fetch,
+  );
+  test(
+    'transport failure preserves cursor and successful retry preserves source',
+    () async {
+      var failed = true;
+      final requested = <int>[];
+      final p = pager((a, c, {skip = 0, genre, onRawCount}) async {
+        requested.add(skip);
+        if (failed) return [];
+        onRawCount?.call(2);
+        return [meta('same'), meta('same', type: 'series')];
+      });
+      expect(await p.nextPage(), isEmpty);
+      expect(p.skip, 0);
+      expect(p.error, isNotNull);
+      expect(p.exhausted, false);
+      failed = false;
+      final items = await p.nextPage();
+      expect(requested, [0, 0]);
+      expect(items, hasLength(2));
+      expect(items.every((m) => identical(m.sourceAddon, addon)), true);
+      expect(p.error, isNull);
+      expect(p.skip, 2);
+    },
+  );
+  test('addon ignoring skip reaches a bounded retryable stop', () async {
+    var calls = 0;
+    final p = pager((a, c, {skip = 0, genre, onRawCount}) async {
+      calls++;
+      onRawCount?.call(1);
+      return [meta('repeat')];
+    });
+    expect(await p.nextPage(), hasLength(1));
+    expect(await p.nextPage(), isEmpty);
+    expect(calls, 1 + CollectionCatalogPager.maxEmptyWindows);
+    expect(p.exhausted, false);
+    expect(p.error, isNotNull);
+  });
+  test('raw end of catalog stops future network calls', () async {
+    var calls = 0;
+    final p = pager((a, c, {skip = 0, genre, onRawCount}) async {
+      calls++;
+      onRawCount?.call(0);
+      return [];
+    });
+    await p.nextPage();
+    await p.nextPage();
+    expect(calls, 1);
+    expect(p.exhausted, true);
+  });
+  test(
+    'merged loader bounds concurrency and does not duplicate concurrent loads',
+    () async {
+      final release = Completer<void>();
+      var running = 0, maximum = 0, calls = 0;
+      final addons = [
+        for (var i = 0; i < 12; i++)
+          StremioAddon(
+            id: 'a$i',
+            name: 'A$i',
+            manifestUrl: 'https://example.invalid/$i/manifest.json',
+            baseUrl: 'https://example.invalid/$i',
+            catalogs: addon.catalogs,
+          ),
+      ];
+      final loader = CollectionFolderLoader(
+        folder: HomeCollectionFolder(
+          id: 'f',
+          title: 'F',
+          sources: [
+            for (final a in addons)
+              CollectionCatalogSource(
+                addonId: a.id,
+                type: 'movie',
+                catalogId: 'popular',
+              ),
+          ],
+        ),
+        installedAddons: addons,
+        fetch: (a, c, {skip = 0, genre, onRawCount}) async {
+          calls++;
+          running++;
+          if (running > maximum) maximum = running;
+          await release.future;
+          running--;
+          onRawCount?.call(1);
+          return [meta(a.id)];
+        },
+      );
+      final pending = loader.nextPage();
+      expect(await loader.nextPage(), isEmpty);
+      expect(calls, CollectionFolderLoader.maxConcurrent);
+      release.complete();
+      expect(await pending, hasLength(12));
+      expect(maximum, CollectionFolderLoader.maxConcurrent);
+      expect(calls, 12);
+    },
+  );
+}

--- a/test/collection_catalog_pager_test.dart
+++ b/test/collection_catalog_pager_test.dart
@@ -59,6 +59,37 @@ void main() {
     expect(p.exhausted, false);
     expect(p.error, isNotNull);
   });
+  test(
+    'All has one shared eight-request budget per repeating source',
+    () async {
+      var calls = 0;
+      final loader = CollectionFolderLoader(
+        folder: const HomeCollectionFolder(
+          id: 'f',
+          title: 'F',
+          sources: [
+            CollectionCatalogSource(
+              addonId: 'a',
+              type: 'movie',
+              catalogId: 'popular',
+            ),
+          ],
+        ),
+        installedAddons: [addon],
+        fetch: (a, c, {skip = 0, genre, onRawCount}) async {
+          calls++;
+          onRawCount?.call(1);
+          return [meta('same')];
+        },
+      );
+      await loader.nextPage();
+      calls = 0;
+      expect(await loader.nextPage(), isEmpty);
+      expect(calls, CollectionCatalogPager.maxEmptyWindows);
+      expect(loader.exhausted, false);
+      expect(loader.hasErrors, true);
+    },
+  );
   test('raw end of catalog stops future network calls', () async {
     var calls = 0;
     final p = pager((a, c, {skip = 0, genre, onRawCount}) async {

--- a/test/collection_catalog_pager_test.dart
+++ b/test/collection_catalog_pager_test.dart
@@ -90,6 +90,76 @@ void main() {
       expect(loader.hasErrors, true);
     },
   );
+  for (final filtered in [false, true]) {
+    test(
+      'All keeps paging when one source ${filtered ? 'is filtered' : 'overlaps'}',
+      () async {
+        final other = StremioAddon(
+          id: 'b',
+          name: 'B',
+          manifestUrl: 'https://example.invalid/b/manifest.json',
+          baseUrl: 'https://example.invalid/b',
+          catalogs: addon.catalogs,
+        );
+        final loader = CollectionFolderLoader(
+          folder: const HomeCollectionFolder(
+            id: 'f',
+            title: 'F',
+            sources: [
+              CollectionCatalogSource(
+                addonId: 'a',
+                type: 'movie',
+                catalogId: 'popular',
+              ),
+              CollectionCatalogSource(
+                addonId: 'b',
+                type: 'movie',
+                catalogId: 'popular',
+              ),
+            ],
+          ),
+          installedAddons: [addon, other],
+          fetch: (a, c, {skip = 0, genre, onRawCount}) async {
+            onRawCount?.call(skip < 3 ? 1 : 0);
+            if (skip >= 3) return [];
+            if (a.id == 'b') return [meta('b$skip')];
+            if (skip == 1) return filtered ? [] : [meta('a0')];
+            return [meta('a$skip')];
+          },
+        );
+        expect((await loader.nextPage()).map((m) => m.id), ['a0', 'b0']);
+        expect((await loader.nextPage()).map((m) => m.id), ['b1']);
+        expect(loader.hasErrors, false);
+        expect(loader.exhausted, false);
+        expect((await loader.nextPage()).map((m) => m.id), ['a2', 'b2']);
+        expect(await loader.nextPage(), isEmpty);
+        expect(loader.exhausted, true);
+        expect(loader.hasErrors, false);
+      },
+    );
+  }
+
+  test('All still reports genuine transport failures', () async {
+    final loader = CollectionFolderLoader(
+      folder: const HomeCollectionFolder(
+        id: 'f',
+        title: 'F',
+        sources: [
+          CollectionCatalogSource(
+            addonId: 'a',
+            type: 'movie',
+            catalogId: 'popular',
+          ),
+        ],
+      ),
+      installedAddons: [addon],
+      fetch: (a, c, {skip = 0, genre, onRawCount}) async => [],
+    );
+    expect(await loader.nextPage(), isEmpty);
+    expect(loader.hasErrors, true);
+    expect(loader.exhausted, false);
+  });
+
   test('raw end of catalog stops future network calls', () async {
     var calls = 0;
     final p = pager((a, c, {skip = 0, genre, onRawCount}) async {

--- a/test/collections_stage_regression_test.dart
+++ b/test/collections_stage_regression_test.dart
@@ -1,0 +1,104 @@
+import 'dart:io';
+
+import 'package:debrify/models/home_collection.dart';
+import 'package:debrify/models/stremio_addon.dart';
+import 'package:debrify/services/home_collections_store.dart';
+import 'package:debrify/services/home_row_order.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('all import forms accept a leading Unicode BOM', () {
+    const record = '{"id":"services","title":"Services","folders":[]}';
+    for (final json in [record, '[$record]', '{"collections":[$record]}']) {
+      expect(HomeCollectionParser.parse('\uFEFF$json').single.id, 'services');
+      expect(
+        HomeCollectionParser.parse(' \n\uFEFF$json').single.id,
+        'services',
+      );
+    }
+  });
+
+  test('a missing provider cannot browse or claim another providers top', () {
+    final cinemeta = StremioAddon(
+      id: 'cinemeta',
+      name: 'Cinemeta',
+      manifestUrl: 'https://cinemeta.invalid/manifest.json',
+      baseUrl: 'https://cinemeta.invalid',
+      resources: ['catalog'],
+      catalogs: const [
+        StremioAddonCatalog(id: 'top', type: 'movie', name: 'Top'),
+      ],
+    );
+    const source = CollectionCatalogSource(
+      addonId: 'missing',
+      type: 'movie',
+      catalogId: 'top',
+    );
+    const collection = HomeCollection(
+      id: 'c',
+      title: 'C',
+      folders: [
+        HomeCollectionFolder(id: 'f', title: 'F', sources: [source]),
+      ],
+    );
+    expect(HomeCollectionsStore.resolveAddon(source, [cinemeta]), isNull);
+    expect(HomeCollectionsStore.unresolvedAddonIds([collection], [cinemeta]), {
+      'missing',
+    });
+    expect(
+      HomeCollectionsStore.claimedCatalogKeys([collection], [cinemeta]),
+      isEmpty,
+    );
+  });
+
+  test('new pins lead saved rows and saved manual positions survive', () {
+    const saved = ['cw:movies', 'traktlist:watchlist', 'collection:old'];
+    final seeded = HomeRowOrder.seedPinned(saved, [
+      'collection:new',
+      'collection:old',
+    ]);
+    expect(seeded, ['collection:new', ...saved]);
+    expect(
+      HomeRowOrder.seedPinned(seeded, ['collection:new', 'collection:old']),
+      seeded,
+    );
+    expect(HomeRowOrder.seedPinned([], ['collection:new']), ['collection:new']);
+  });
+
+  // The stage layouts are private parts of SearchScreen. These wiring guards
+  // supplement the rendered shared-card tests; they catch a layout reverting
+  // to global title geometry while the shared presentation stays correct.
+  final source = File('lib/screens/search_screen.dart').readAsStringSync();
+  for (final (start, end) in [
+    ('Widget _buildCanvasBoard', 'double get _titleCardAspect'),
+    ('Widget _promenadeCell', 'Widget _buildAtriumBoard'),
+    ('Widget _atriumRow', 'Widget _buildMosaicBoard'),
+    ('Widget _mosaicCell', 'Widget _buildDeckBoard'),
+    ('Widget _stageShelfCell', 'Widget _buildTonightBoard'),
+  ]) {
+    test('$start uses collection artwork, shape and focus preview', () {
+      final from = source.indexOf(start);
+      final to = source.indexOf(end, from);
+      expect(from, isNonNegative);
+      expect(to, greaterThan(from));
+      final body = source.substring(from, to);
+      expect(body, contains('_stageCardAspect(rail'));
+      expect(body, contains('_stageCardArt(rail'));
+      expect(body, contains('focusArtOf('));
+      expect(body, contains('hideTitle'));
+    });
+  }
+  test('folder focus retires title work and owns the hero', () {
+    final start = source.indexOf('  void _setHero(');
+    final body = source.substring(
+      start,
+      source.indexOf('// A catalog/CW card owns', start),
+    );
+    expect(body, contains('_heroReqId++'));
+    expect(body, contains('_heroTimer?.cancel()'));
+    expect(body, contains('_clearHeroTrailer()'));
+    expect(body, contains('_clearHeroLiveIptv()'));
+    expect(body, contains('_heroItem.value = item'));
+    expect(body, contains('_heroEnriched.value = null'));
+  });
+}

--- a/test/home_collections_regression_test.dart
+++ b/test/home_collections_regression_test.dart
@@ -511,7 +511,7 @@ void main() {
     });
   });
 
-  test('HTTP 200 without metas remains retryable and is not cached', () async {
+  test('HTTP 200 with wrongly typed metas remains retryable and is not cached', () async {
     final a = addon(id: 'malformed-response');
     final pager = CollectionCatalogPager(
       addon: a,
@@ -521,7 +521,7 @@ void main() {
     );
     await http.runWithClient(
       () => pager.nextPage(),
-      () => MockClient((_) async => http.Response('{}', 200)),
+      () => MockClient((_) async => http.Response('{"metas":{}}', 200)),
     );
     expect(pager.exhausted, false);
     expect(pager.error, isNotNull);
@@ -532,6 +532,29 @@ void main() {
     expect(pager.exhausted, true);
     expect(pager.error, isNull);
   });
+
+  for (final body in ['{}', '{"metas":null}', '{"metas":[]}']) {
+    test('catalog end response $body exhausts a folder without Retry', () async {
+      StremioService.instance.invalidateCache();
+      final a = addon(id: 'empty-response');
+      var calls = 0;
+      final pager = CollectionCatalogPager(
+        addon: a, catalog: a.catalogs.single,
+        fetch: (a, c, {skip = 0, genre, onRawCount}) => StremioService.instance
+            .fetchCatalog(a, c, skip: skip, genre: genre, onRawCount: onRawCount),
+      );
+      await http.runWithClient(() async {
+        expect(await pager.nextPage(), isEmpty);
+        expect(await pager.nextPage(), isEmpty);
+      }, () => MockClient((_) async {
+        calls++;
+        return http.Response(body, 200);
+      }));
+      expect(calls, 1);
+      expect(pager.exhausted, true);
+      expect(pager.error, isNull);
+    });
+  }
 
   test('hidden collection rows and non-Home modes do not claim catalogs', () {
     final installed = [addon()];

--- a/test/home_collections_regression_test.dart
+++ b/test/home_collections_regression_test.dart
@@ -1,0 +1,564 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:debrify/models/home_collection.dart';
+import 'package:debrify/models/home_collection_inventory.dart';
+import 'package:debrify/models/stremio_addon.dart';
+import 'package:debrify/services/home_collections_store.dart';
+import 'package:debrify/services/collection_folder_loader.dart';
+import 'package:debrify/services/profiles/profile_runtime.dart';
+import 'package:debrify/services/profiles/profile_scope.dart';
+import 'package:debrify/services/profiles/profile_preference_budget.dart';
+import 'package:debrify/services/stremio_service.dart';
+import 'package:debrify/screens/collections/collection_folder_screen.dart';
+import 'package:debrify/screens/settings/home_sections_filter_page.dart';
+import 'package:debrify/services/storage_service.dart';
+import 'package:debrify/services/profiles/profile_preferences.dart';
+import 'package:debrify/services/main_page_bridge.dart';
+import 'package:debrify/services/webdav_sync/webdav_sync_ui_refresh.dart';
+import 'package:debrify/services/webdav_sync/webdav_sync_hot_merge.dart';
+import 'package:debrify/services/webdav_sync/webdav_sync_hot_models.dart';
+import 'package:debrify/widgets/see_all/stremio_dropdown.dart';
+import 'package:debrify/widgets/see_all/see_all_poster_grid.dart';
+
+const source = CollectionCatalogSource(
+  addonId: 'addon',
+  type: 'movie',
+  catalogId: 'popular',
+);
+const folder = HomeCollectionFolder(
+  id: 'netflix',
+  title: 'Netflix',
+  sources: [source],
+);
+const collection = HomeCollection(
+  id: 'streaming',
+  title: 'Streaming',
+  folders: [folder],
+);
+StremioAddon addon({String id = 'addon', String catalog = 'popular'}) =>
+    StremioAddon(
+      id: id,
+      name: id,
+      manifestUrl: 'https://example.invalid/$id/manifest.json',
+      baseUrl: 'https://example.invalid/$id',
+      resources: ['catalog'],
+      catalogs: [
+        StremioAddonCatalog(id: catalog, type: 'movie', name: catalog),
+      ],
+    );
+StremioMeta meta(String id) => StremioMeta(id: id, type: 'movie', name: id);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() {
+    ProfileRuntime.debugReset();
+    ProfileRuntime.initializeLegacy();
+    ProfilePreferenceBudget.debugReset();
+    SharedPreferences.setMockInitialValues({});
+    StremioService.instance.invalidateCache();
+  });
+  tearDown(() {
+    ProfileRuntime.debugReset();
+    ProfileRuntime.initializeLegacy();
+    ProfilePreferenceBudget.debugReset();
+  });
+
+  test(
+    'URL import must not write to a different profile after download',
+    () async {
+      ProfileRuntime.initializeCommitted(
+        ProfileScope(profileId: 'one', dataGeneration: 1, sessionEpoch: 1),
+      );
+      final started = Completer<void>(), reply = Completer<http.Response>();
+      final store = HomeCollectionsStore(
+        httpClientFactory: () => MockClient((_) {
+          started.complete();
+          return reply.future;
+        }),
+      );
+      final pending = store.importFromUrl(
+        'https://example.invalid/collections.json',
+      );
+      await started.future;
+      ProfileRuntime.publish(
+        ProfileScope(profileId: 'two', dataGeneration: 1, sessionEpoch: 2),
+      );
+      reply.complete(http.Response(jsonEncode([collection.toJson()]), 200));
+      try {
+        await pending;
+      } catch (_) {}
+      expect(
+        await store.getCollections(),
+        isEmpty,
+        reason: 'Profile two must not receive profile one import',
+      );
+    },
+  );
+
+  test('refused tvOS preference save must not report import success', () async {
+    ProfilePreferenceBudget.debugEnforcedOverride = true;
+    SharedPreferences.setMockInitialValues({'full': 'x' * (512 * 1024)});
+    final store = HomeCollectionsStore();
+    await expectLater(store.importCollections([collection]), throwsA(anything));
+  });
+
+  test('concurrent local imports must preserve both collections', () async {
+    final store = HomeCollectionsStore();
+    await Future.wait([
+      store.importCollections([collection]),
+      store.importCollections([
+        const HomeCollection(id: 'genres', title: 'Genres', folders: [folder]),
+      ]),
+    ]);
+    expect((await store.getCollections()).map((c) => c.id).toSet(), {
+      'streaming',
+      'genres',
+    });
+  });
+
+  test(
+    'catalog fallback must work when exact addon lacks requested catalog',
+    () {
+      final wrong = addon(catalog: 'other');
+      final right = addon(id: 'fork');
+      expect(
+        HomeCollectionsStore.resolveAddon(source, [wrong, right]),
+        same(right),
+      );
+    },
+  );
+
+  test('import must report missing catalog on an installed addon', () async {
+    final result = await HomeCollectionsStore().importCollections(
+      [collection],
+      installedAddons: [addon(catalog: 'other')],
+    );
+    expect(result.unresolvedAddonIds, contains('addon'));
+  });
+
+  test(
+    'merged pagination must continue through cross-catalog duplicates',
+    () async {
+      final a = StremioAddon(
+        id: 'addon',
+        name: 'Addon',
+        manifestUrl: 'https://example.invalid/manifest.json',
+        baseUrl: 'https://example.invalid',
+        resources: ['catalog'],
+        catalogs: [
+          const StremioAddonCatalog(
+            id: 'popular',
+            type: 'movie',
+            name: 'Popular',
+          ),
+          const StremioAddonCatalog(id: 'top', type: 'movie', name: 'Top'),
+        ],
+      );
+      final loader = CollectionFolderLoader(
+        folder: folder.copyWith(
+          sources: [
+            source,
+            const CollectionCatalogSource(
+              addonId: 'addon',
+              type: 'movie',
+              catalogId: 'top',
+            ),
+          ],
+        ),
+        installedAddons: [a],
+        fetch: (a, c, {skip = 0, genre, onRawCount}) async {
+          onRawCount?.call(1);
+          return c.id == 'popular'
+              ? switch (skip) {
+                  0 => [meta('tt1')],
+                  1 => [meta('tt2')],
+                  2 => [meta('tt3')],
+                  _ => [],
+                }
+              : switch (skip) {
+                  0 => [meta('tt2')],
+                  1 => [meta('tt1')],
+                  2 => [meta('tt4')],
+                  _ => [],
+                };
+        },
+      );
+      expect((await loader.nextPage()).map((m) => m.id), ['tt1', 'tt2']);
+      expect((await loader.nextPage()).map((m) => m.id), ['tt3', 'tt4']);
+      expect(loader.exhausted, false);
+    },
+  );
+
+  test(
+    'merged pagination must continue through a raw page filtered to empty',
+    () async {
+      final loader = CollectionFolderLoader(
+        folder: folder,
+        installedAddons: [addon()],
+        fetch: (a, c, {skip = 0, genre, onRawCount}) async {
+          onRawCount?.call(1);
+          return skip == 0 ? [] : [meta('tt2')];
+        },
+      );
+      expect((await loader.nextPage()).map((m) => m.id), ['tt2']);
+      expect(loader.exhausted, false);
+    },
+  );
+
+  testWidgets('TV tabs Down from folder chip must focus a title', (
+    tester,
+  ) async {
+    final a = addon(id: 'widget-tabs');
+    const s = CollectionCatalogSource(
+      addonId: 'widget-tabs',
+      type: 'movie',
+      catalogId: 'popular',
+    );
+    const c = HomeCollection(
+      id: 'widget',
+      title: 'Streaming',
+      folders: [
+        HomeCollectionFolder(id: 'f', title: 'Netflix', sources: [s]),
+      ],
+    );
+    SharedPreferences.setMockInitialValues({
+      'stremio_addons_v1': jsonEncode([a.toJson()]),
+      HomeCollectionsStore.folderLayoutKey: 'tabs',
+    });
+    await tester.runAsync(() async {
+      await StremioService.instance.getCatalogAddons();
+      await http.runWithClient(
+        () => StremioService.instance.fetchCatalog(a, a.catalogs.single),
+        () => MockClient(
+          (_) async => http.Response(
+            jsonEncode({
+              'metas': [
+                for (var i = 0; i < 100; i++)
+                  {'id': 'tt$i', 'type': 'movie', 'name': 'Title $i'},
+              ],
+            }),
+            200,
+          ),
+        ),
+      );
+    });
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CollectionFolderScreen(
+          collection: c,
+          isTelevision: true,
+          onOpenItem: (_) {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(SeeAllPosterGrid), findsOneWidget);
+    final chip = tester
+        .widgetList<StremioDropdown<int>>(find.byType(StremioDropdown<int>))
+        .firstWhere((w) => w.label == 'Folder');
+    chip.focusNode!.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      startsWith('seeall_grid_'),
+    );
+  });
+  testWidgets(
+    'Home Rows must preserve hidden addon flag while catalog lives in a folder',
+    (tester) async {
+      tester.view.physicalSize = const Size(1280, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      final a = addon();
+      await StorageService.setHomeDisabledSections({'addon:movie:popular'});
+      await tester.pumpWidget(
+        MaterialApp(
+          home: HomeSectionsFilterPage(
+            catalogTree: [(addon: a, catalogs: a.catalogs)],
+            collections: [collection],
+            disabled: {'addon:movie:popular'},
+            isTelevision: false,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Movies').first);
+      await tester.pump();
+      await tester.tap(find.byIcon(Icons.arrow_back_rounded));
+      await tester.pumpAndSettle();
+      expect(
+        await StorageService.getHomeDisabledSections(),
+        contains('addon:movie:popular'),
+      );
+    },
+  );
+
+  testWidgets('Retry in tab B must remain on tab B', (tester) async {
+    final a = StremioAddon(
+      id: 'retry-addon',
+      name: 'Retry',
+      manifestUrl: 'https://example.invalid/retry/manifest.json',
+      baseUrl: 'https://example.invalid/retry',
+      resources: ['catalog'],
+      catalogs: [
+        const StremioAddonCatalog(id: 'a', type: 'movie', name: 'A'),
+        const StremioAddonCatalog(id: 'b', type: 'movie', name: 'B'),
+      ],
+    );
+    final c = HomeCollection(
+      id: 'retry',
+      title: 'Retry',
+      folders: [
+        HomeCollectionFolder(
+          id: 'f',
+          title: 'Folder',
+          sources: [
+            for (final cat in a.catalogs)
+              CollectionCatalogSource(
+                addonId: a.id,
+                type: 'movie',
+                catalogId: cat.id,
+              ),
+          ],
+        ),
+      ],
+    );
+    SharedPreferences.setMockInitialValues({
+      'stremio_addons_v1': jsonEncode([a.toJson()]),
+      HomeCollectionsStore.folderLayoutKey: 'tabs',
+    });
+    await tester.runAsync(() async {
+      await StremioService.instance.getCatalogAddons();
+      for (final cat in a.catalogs) {
+        await http.runWithClient(
+          () => StremioService.instance.fetchCatalog(a, cat),
+          () => MockClient(
+            (_) async => http.Response(
+              jsonEncode({
+                'metas': cat.id == 'a'
+                    ? [
+                        for (var i = 0; i < 100; i++)
+                          {'id': 'tt$i', 'type': 'movie', 'name': 'Title $i'},
+                      ]
+                    : [],
+              }),
+              200,
+            ),
+          ),
+        );
+      }
+    });
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CollectionFolderScreen(
+          collection: c,
+          isTelevision: true,
+          onOpenItem: (_) {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    StremioDropdown<int> listChip() => tester
+        .widgetList<StremioDropdown<int>>(find.byType(StremioDropdown<int>))
+        .firstWhere((w) => w.label == 'List');
+    listChip().onSelected(1);
+    await tester.pumpAndSettle();
+    expect(find.text('Nothing in this list'), findsOneWidget);
+    final retry = tester.widget<OutlinedButton>(
+      find.widgetWithText(OutlinedButton, 'Retry'),
+    );
+    retry.focusNode!.requestFocus();
+    await tester.pump();
+    await http.runWithClient(
+      () async {
+        await tester.tap(find.widgetWithText(OutlinedButton, 'Retry'));
+        await tester.pumpAndSettle();
+      },
+      () => MockClient(
+        (request) async => http.Response(
+          jsonEncode({
+            'metas': [
+              for (var i = 0; i < 100; i++)
+                {'id': 'recovered$i', 'type': 'movie', 'name': 'Recovered $i'},
+            ],
+          }),
+          200,
+        ),
+      ),
+    );
+    expect(listChip().value, 1);
+    expect(find.byType(SeeAllPosterGrid), findsOneWidget);
+    expect(
+      tester
+          .widget<SeeAllPosterGrid>(find.byType(SeeAllPosterGrid))
+          .items
+          .first
+          .id,
+      'recovered0',
+    );
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      startsWith('seeall_grid_'),
+    );
+  });
+
+  test(
+    'clearing last collection must remain empty after merging a peer',
+    () async {
+      final store = HomeCollectionsStore();
+      await store.importCollections([collection]);
+      final prefs = await SharedPreferences.getInstance();
+      final old = hot('peer', {
+        HomeCollectionsStore.prefsKey: prefs.getString(
+          HomeCollectionsStore.prefsKey,
+        )!,
+      }, 1);
+      await store.clear();
+      final current = hot('local', {
+        if (prefs.containsKey(HomeCollectionsStore.prefsKey))
+          HomeCollectionsStore.prefsKey: prefs.getString(
+            HomeCollectionsStore.prefsKey,
+          )!,
+      }, 2);
+      final merged = WebDavSyncHotMerge.merge(
+        local: current,
+        peers: [old],
+        tombstoneDocuments: [],
+        nowMs: 3,
+      ).document;
+      final inventory = inventoryOf(merged);
+      expect(inventory.collections, isEmpty);
+      expect(inventory.records.containsKey(collection.id), true);
+      expect(inventory.records[collection.id], isNull);
+    },
+  );
+
+  test('sync must merge independent collections from different devices', () {
+    final one = hot('one', {
+      HomeCollectionsStore.prefsKey: jsonEncode([collection.toJson()]),
+    }, 1);
+    final two = hot('two', {
+      HomeCollectionsStore.prefsKey: jsonEncode([
+        const HomeCollection(
+          id: 'genres',
+          title: 'Genres',
+          folders: [folder],
+        ).toJson(),
+      ]),
+    }, 2);
+    final merged = WebDavSyncHotMerge.merge(
+      local: one,
+      peers: [two],
+      tombstoneDocuments: [],
+      nowMs: 3,
+    ).document;
+    expect(inventoryOf(merged).collections.map((c) => c.id).toSet(), {
+      'streaming',
+      'genres',
+    });
+  });
+
+  test('incoming collection sync must notify Home', () {
+    var calls = 0;
+    void listener() => calls++;
+    MainPageBridge.addHomeSettingsListener(listener);
+    addTearDown(() => MainPageBridge.removeHomeSettingsListener(listener));
+    WebDavSyncUiRefresh.dispatch({HomeCollectionsStore.prefsKey});
+    expect(calls, 1);
+  });
+
+  test(
+    'local import waiting on sync must retain the applied remote collection',
+    () async {
+      final entered = Completer<void>(), resume = Completer<void>();
+      final barrier = ProfilePreferences.captureMutationSnapshot((_) async {
+        entered.complete();
+        await resume.future;
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString(
+          HomeCollectionsStore.prefsKey,
+          jsonEncode([
+            const HomeCollection(
+              id: 'remote',
+              title: 'Remote',
+              folders: [folder],
+            ).toJson(),
+          ]),
+        );
+      });
+      await entered.future;
+      final store = HomeCollectionsStore();
+      final pending = store.importCollections([collection]);
+      await Future<void>.delayed(Duration.zero);
+      resume.complete();
+      await Future.wait([barrier, pending]);
+      expect((await store.getCollections()).map((c) => c.id).toSet(), {
+        'remote',
+        'streaming',
+      });
+    },
+  );
+
+  test('accepted imports must fit the sync hot-document size budget', () async {
+    final store = HomeCollectionsStore();
+    final large = HomeCollection(
+      id: 'large',
+      title: 'Large',
+      folders: [
+        for (var i = 0; i < 4000; i++)
+          HomeCollectionFolder(
+            id: 'f$i',
+            title: 'Folder $i',
+            sources: [source],
+            coverImageUrl: 'https://example.invalid/art/folder-$i.jpg',
+          ),
+      ],
+    );
+    final input = jsonEncode([large.toJson()]);
+    expect(
+      utf8.encode(input).length,
+      lessThan(HomeCollectionsStore.maxImportBytes),
+    );
+    await expectLater(store.importJson(input), throwsFormatException);
+    expect(await store.getCollections(), isEmpty);
+  });
+}
+
+WebDavSyncHotDocument hot(
+  String device,
+  Map<String, Object?> prefs,
+  int time,
+) => WebDavSyncHotMerge.build(
+  WebDavSyncBuildInput(
+    circleProfileId: 'profile-circle',
+    deviceId: device,
+    rawPreferences: prefs,
+    portablePreferences: prefs,
+    identityMaps: WebDavSyncIdentityMaps(
+      circleToLocalProfiles: {'profile-circle': 'local-profile'},
+      circleToLocalResources: {},
+    ),
+    localNowMs: time,
+    clockOffsetMs: 0,
+    serverNowMs: time,
+  ),
+).document;
+
+HomeCollectionInventory inventoryOf(WebDavSyncHotDocument document) =>
+    HomeCollectionInventory.decode(
+      WebDavSyncHotMerge.materializePreferences(
+        document: document,
+        identityMaps: WebDavSyncIdentityMaps(
+          circleToLocalProfiles: {'profile-circle': 'local-profile'},
+          circleToLocalResources: {},
+        ),
+      )[HomeCollectionsStore.prefsKey],
+    );

--- a/test/home_collections_regression_test.dart
+++ b/test/home_collections_regression_test.dart
@@ -11,6 +11,7 @@ import 'package:debrify/models/home_collection_inventory.dart';
 import 'package:debrify/models/stremio_addon.dart';
 import 'package:debrify/services/home_collections_store.dart';
 import 'package:debrify/services/collection_folder_loader.dart';
+import 'package:debrify/services/collection_catalog_pager.dart';
 import 'package:debrify/services/profiles/profile_runtime.dart';
 import 'package:debrify/services/profiles/profile_scope.dart';
 import 'package:debrify/services/profiles/profile_preference_budget.dart';
@@ -230,6 +231,7 @@ void main() {
     SharedPreferences.setMockInitialValues({
       'stremio_addons_v1': jsonEncode([a.toJson()]),
       HomeCollectionsStore.folderLayoutKey: 'tabs',
+      HomeCollectionsStore.prefsKey: jsonEncode([c.toJson()]),
     });
     await tester.runAsync(() async {
       await StremioService.instance.getCatalogAddons();
@@ -270,6 +272,20 @@ void main() {
       FocusManager.instance.primaryFocus?.debugLabel,
       startsWith('seeall_grid_'),
     );
+    final focused = FocusManager.instance.primaryFocus;
+    final grid = tester.state(find.byType(SeeAllPosterGrid));
+    MainPageBridge.notifyHomeSettingsChanged();
+    await tester.pumpAndSettle();
+    expect(identical(tester.state(find.byType(SeeAllPosterGrid)), grid), true);
+    expect(identical(FocusManager.instance.primaryFocus, focused), true);
+    // A real definition change rebuilds content but returns focus to a usable
+    // filter control instead of leaving it attached to a disposed poster.
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(HomeCollectionsStore.folderLayoutKey, 'rows');
+    MainPageBridge.notifyHomeSettingsChanged();
+    await tester.pumpAndSettle();
+    expect(FocusManager.instance.primaryFocus?.debugLabel, 'collection_folder');
+    expect(tester.takeException(), isNull);
   });
   testWidgets(
     'Home Rows must preserve hidden addon flag while catalog lives in a folder',
@@ -408,6 +424,32 @@ void main() {
       FocusManager.instance.primaryFocus?.debugLabel,
       startsWith('seeall_grid_'),
     );
+    await tester.runAsync(() async {
+      await http.runWithClient(
+        () => StremioService.instance.fetchCatalog(a, a.catalogs[1], skip: 100),
+        () => MockClient(
+          (_) async => http.Response(
+            jsonEncode({
+              'metas': [
+                for (var i = 0; i < 100; i++)
+                  {'id': 'cached$i', 'type': 'movie', 'name': 'Cached $i'},
+              ],
+            }),
+            200,
+          ),
+        ),
+      );
+    });
+    tester.widget<SeeAllPosterGrid>(find.byType(SeeAllPosterGrid)).onLoadMore();
+    await tester.pumpAndSettle();
+    expect(
+      tester
+          .widget<SeeAllPosterGrid>(find.byType(SeeAllPosterGrid))
+          .items
+          .last
+          .id,
+      'cached99',
+    );
   });
 
   test(
@@ -433,11 +475,14 @@ void main() {
         peers: [old],
         tombstoneDocuments: [],
         nowMs: 3,
-      ).document;
-      final inventory = inventoryOf(merged);
+      );
+      final inventory = inventoryOf(merged.document);
       expect(inventory.collections, isEmpty);
-      expect(inventory.records.containsKey(collection.id), true);
-      expect(inventory.records[collection.id], isNull);
+      expect(inventory.records.containsKey(collection.id), false);
+      expect(
+        merged.tombstones,
+        contains(WebDavSyncRecordKey.homeCollection(collection.id)),
+      );
     },
   );
 
@@ -464,6 +509,128 @@ void main() {
       'streaming',
       'genres',
     });
+  });
+
+  test('HTTP 200 without metas remains retryable and is not cached', () async {
+    final a = addon(id: 'malformed-response');
+    final pager = CollectionCatalogPager(
+      addon: a,
+      catalog: a.catalogs.single,
+      fetch: (a, c, {skip = 0, genre, onRawCount}) => StremioService.instance
+          .fetchCatalog(a, c, skip: skip, genre: genre, onRawCount: onRawCount),
+    );
+    await http.runWithClient(
+      () => pager.nextPage(),
+      () => MockClient((_) async => http.Response('{}', 200)),
+    );
+    expect(pager.exhausted, false);
+    expect(pager.error, isNotNull);
+    await http.runWithClient(
+      () => pager.nextPage(),
+      () => MockClient((_) async => http.Response('{"metas":[]}', 200)),
+    );
+    expect(pager.exhausted, true);
+    expect(pager.error, isNull);
+  });
+
+  test('hidden collection rows and non-Home modes do not claim catalogs', () {
+    final installed = [addon()];
+    expect(
+      HomeCollectionsStore.claimedCatalogKeys([collection], installed),
+      isNotEmpty,
+    );
+    expect(
+      HomeCollectionsStore.claimedCatalogKeys(
+        [collection],
+        installed,
+        disabledRows: {collection.rowId},
+      ),
+      isEmpty,
+    );
+    expect(
+      HomeCollectionsStore.claimedCatalogKeys(
+        [collection],
+        installed,
+        showsCollectionRows: false,
+      ),
+      isEmpty,
+    );
+  });
+
+  test('corrupt local collections do not block other hot preferences', () {
+    final document = hot('local', {
+      HomeCollectionsStore.prefsKey: '{broken',
+      'theme': 'dark',
+    }, 1);
+    expect(document.scalars.values['theme'], 'dark');
+    expect(inventoryOf(document).collections, isEmpty);
+  });
+
+  test('bad peer collection records cannot block materialization', () {
+    final base = hot('peer', {'theme': 'light'}, 1);
+    final stamp = base.watchState.stamp;
+    final records = <String, WebDavSyncStampedValue>{
+      WebDavSyncRecordKey.homeCollection(collection.id): WebDavSyncStampedValue(
+        stamp: stamp,
+        value: collection.toJson(),
+      ),
+      WebDavSyncRecordKey.homeCollection('bad'): WebDavSyncStampedValue(
+        stamp: stamp,
+        value: 123,
+      ),
+      'homecollection/%': WebDavSyncStampedValue(stamp: stamp, value: 123),
+    };
+    final document = WebDavSyncHotDocument(
+      circleProfileId: base.circleProfileId,
+      scalars: base.scalars,
+      watchState: WebDavSyncWatchPart(
+        stamp: stamp,
+        semanticDigest: '',
+        records: records,
+        orders: const {},
+      ),
+    );
+    expect(inventoryOf(document).collections.single.id, collection.id);
+  });
+
+  test('collection tombstones expire with the shared retention policy', () {
+    final deleted = HomeCollectionInventory(
+      records: {'old': null},
+      order: ['old'],
+    );
+    final first = WebDavSyncHotMerge.merge(
+      local: hot('one', {HomeCollectionsStore.prefsKey: deleted.encode()}, 1),
+      peers: [],
+      tombstoneDocuments: [],
+      nowMs: 2,
+    );
+    final key = WebDavSyncRecordKey.homeCollection('old');
+    expect(first.tombstones, contains(key));
+    expect(inventoryOf(first.document).records, isEmpty);
+    final expired = WebDavSyncHotMerge.merge(
+      local: first.document,
+      peers: [],
+      nowMs: const Duration(days: 91).inMilliseconds,
+      tombstoneDocuments: [
+        WebDavSyncTombstoneDocument(
+          circleProfileId: first.document.circleProfileId,
+          items: {key: first.tombstones[key]!.copyWith(firstPublishedAtMs: 2)},
+        ),
+      ],
+    );
+    expect(expired.tombstones, isEmpty);
+    final dormant = WebDavSyncHotMerge.merge(
+      local: hot('offline', {
+        HomeCollectionsStore.prefsKey: jsonEncode([
+          const HomeCollection(id: 'old', title: 'Old').toJson(),
+        ]),
+      }, 1),
+      peers: [expired.document],
+      tombstoneDocuments: [],
+      nowMs: const Duration(days: 91).inMilliseconds,
+      dormantSinceMs: 1,
+    );
+    expect(inventoryOf(dormant.document).collections, isEmpty);
   });
 
   test('incoming collection sync must notify Home', () {

--- a/test/home_collections_regression_test.dart
+++ b/test/home_collections_regression_test.dart
@@ -124,13 +124,13 @@ void main() {
   });
 
   test(
-    'catalog fallback must work when exact addon lacks requested catalog',
+    'missing catalog must not silently switch providers',
     () {
       final wrong = addon(catalog: 'other');
       final right = addon(id: 'fork');
       expect(
         HomeCollectionsStore.resolveAddon(source, [wrong, right]),
-        same(right),
+        isNull,
       );
     },
   );

--- a/test/home_collections_responsive_test.dart
+++ b/test/home_collections_responsive_test.dart
@@ -1,0 +1,241 @@
+import 'dart:convert';
+
+import 'package:debrify/models/home_collection.dart';
+import 'package:debrify/models/stremio_addon.dart';
+import 'package:debrify/screens/collections/collection_folder_screen.dart';
+import 'package:debrify/screens/settings/collections_settings_page.dart';
+import 'package:debrify/services/home_collections_store.dart';
+import 'package:debrify/services/main_page_bridge.dart';
+import 'package:debrify/services/profiles/profile_runtime.dart';
+import 'package:debrify/services/stremio_service.dart';
+import 'package:debrify/widgets/see_all/see_all_poster_grid.dart';
+import 'package:debrify/widgets/see_all/stremio_dropdown.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  final addon = StremioAddon(
+    id: 'responsive',
+    name: 'A very long addon name that should never overflow a phone screen',
+    manifestUrl: 'https://example.invalid/responsive/manifest.json',
+    baseUrl: 'https://example.invalid/responsive',
+    resources: ['catalog'],
+    catalogs: const [
+      StremioAddonCatalog(
+        id: 'popular',
+        type: 'movie',
+        name: 'Popular films with a very long title',
+      ),
+      StremioAddonCatalog(id: 'recent', type: 'movie', name: 'Recent'),
+    ],
+  );
+  const collection = HomeCollection(
+    id: 'responsive',
+    title: 'Streaming services with a very long collection title',
+    folders: [
+      HomeCollectionFolder(
+        id: 'folder',
+        title: 'Netflix and other streaming services with a very long title',
+        coverImageUrl: 'https://example.invalid/cover.png',
+        sources: [
+          CollectionCatalogSource(
+            addonId: 'responsive',
+            type: 'movie',
+            catalogId: 'popular',
+          ),
+          CollectionCatalogSource(
+            addonId: 'responsive',
+            type: 'movie',
+            catalogId: 'recent',
+          ),
+        ],
+      ),
+    ],
+  );
+  setUp(() {
+    ProfileRuntime.debugReset();
+    ProfileRuntime.initializeLegacy();
+    StremioService.instance.invalidateCache();
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Future<void> seed(WidgetTester tester, String layout) async {
+    SharedPreferences.setMockInitialValues({
+      'stremio_addons_v1': jsonEncode([addon.toJson()]),
+      HomeCollectionsStore.folderLayoutKey: layout,
+      HomeCollectionsStore.prefsKey: jsonEncode([collection.toJson()]),
+    });
+    await tester.runAsync(() async {
+      await StremioService.instance.getCatalogAddons();
+      await http.runWithClient(
+        () async {
+          for (final catalog in addon.catalogs) {
+            await StremioService.instance.fetchCatalog(addon, catalog);
+          }
+        },
+        () => MockClient(
+          (_) async => http.Response(
+            jsonEncode({
+              'metas': [
+                for (var i = 0; i < 100; i++)
+                  {'id': 'tt$i', 'type': 'movie', 'name': 'Title $i'},
+              ],
+            }),
+            200,
+          ),
+        ),
+      );
+    });
+  }
+
+  for (final size in [
+    const Size(320, 568),
+    const Size(568, 320),
+    const Size(768, 1024),
+    const Size(1280, 720),
+    const Size(1920, 1080),
+  ]) {
+    for (final layout in ['rows', 'tabs']) {
+      testWidgets('$layout folder fits $size and refreshes after removal', (
+        tester,
+      ) async {
+        tester.view.physicalSize = size;
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+        await seed(tester, layout);
+        await tester.pumpWidget(
+          MaterialApp(
+            home: CollectionFolderScreen(
+              collection: collection,
+              isTelevision: size.width >= 1280,
+              onOpenItem: (_) {},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(tester.takeException(), isNull);
+        expect(find.byType(SeeAllPosterGrid), findsWidgets);
+        final narrow = size.width < 640;
+        if (narrow) {
+          await tester.tap(find.text('Filters'));
+          await tester.pumpAndSettle();
+        }
+        final selector = find.byWidgetPredicate(
+          (w) =>
+              w is StremioDropdown &&
+              w.label == (layout == 'tabs' ? 'List' : 'View'),
+        );
+        await tester.tap(selector);
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('All').last);
+        await tester.pumpAndSettle();
+        if (narrow) {
+          await tester.tap(find.byIcon(Icons.close_rounded));
+          await tester.pumpAndSettle();
+        }
+        expect(tester.takeException(), isNull);
+        expect(find.byType(SeeAllPosterGrid), findsOneWidget);
+        final grid = tester.widget<SeeAllPosterGrid>(
+          find.byType(SeeAllPosterGrid),
+        );
+        expect(
+          grid.items,
+          hasLength(100),
+          reason: 'Overlapping lists are deduplicated in All',
+        );
+        expect(grid.items.every((m) => m.sourceAddon?.id == addon.id), true);
+        await HomeCollectionsStore.instance.clear();
+        MainPageBridge.notifyHomeSettingsChanged();
+        await tester.pumpAndSettle();
+        expect(find.text('This collection has no folders'), findsOneWidget);
+        expect(find.byType(SeeAllPosterGrid), findsNothing);
+        expect(tester.takeException(), isNull);
+      });
+    }
+  }
+  testWidgets('open settings refreshes after remote collection changes', (
+    tester,
+  ) async {
+    await seed(tester, 'rows');
+    await tester.pumpWidget(const MaterialApp(home: CollectionsSettingsPage()));
+    await tester.pumpAndSettle();
+    expect(find.text(collection.title), findsOneWidget);
+    await HomeCollectionsStore.instance.clear();
+    MainPageBridge.notifyHomeSettingsChanged();
+    await tester.pumpAndSettle();
+    expect(find.text(collection.title), findsNothing);
+    expect(find.text('No collections yet.'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('paste dialog remains usable with landscape keyboard', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(568, 320);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    await seed(tester, 'rows');
+    await tester.pumpWidget(const MaterialApp(home: CollectionsSettingsPage()));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text('Paste JSON'));
+    await tester.tap(find.text('Paste JSON'));
+    await tester.pumpAndSettle();
+    tester.view.viewInsets = const FakeViewPadding(bottom: 140);
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    await tester.enterText(
+      find.byType(TextField),
+      jsonEncode([
+        const HomeCollection(id: 'pasted', title: 'Pasted').toJson(),
+      ]),
+    );
+    await tester.tap(find.widgetWithText(TextButton, 'Import'));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(
+      (await HomeCollectionsStore.instance.getCollections()).map((c) => c.id),
+      contains('pasted'),
+    );
+    expect(find.text('Imported 1 collection'), findsOneWidget);
+  });
+
+  for (final size in [
+    const Size(320, 568),
+    const Size(568, 320),
+    const Size(1280, 720),
+  ]) {
+    testWidgets(
+      'settings and long collection dialog fit $size with large text',
+      (tester) async {
+        tester.view.physicalSize = size;
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+        await seed(tester, 'rows');
+        await tester.pumpWidget(
+          MaterialApp(
+            builder: (context, child) => MediaQuery(
+              data: MediaQuery.of(
+                context,
+              ).copyWith(textScaler: TextScaler.linear(1.5)),
+              child: child!,
+            ),
+            home: const CollectionsSettingsPage(),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(tester.takeException(), isNull);
+        await tester.ensureVisible(find.text(collection.title));
+        await tester.tap(find.text(collection.title));
+        await tester.pumpAndSettle();
+        expect(find.byType(AlertDialog), findsOneWidget);
+        expect(tester.takeException(), isNull);
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+}

--- a/test/home_collections_responsive_test.dart
+++ b/test/home_collections_responsive_test.dart
@@ -10,6 +10,9 @@ import 'package:debrify/services/profiles/profile_runtime.dart';
 import 'package:debrify/services/stremio_service.dart';
 import 'package:debrify/widgets/see_all/see_all_poster_grid.dart';
 import 'package:debrify/widgets/see_all/stremio_dropdown.dart';
+import 'package:debrify/widgets/see_all/discover_card_settings_scope.dart';
+import 'package:debrify/widgets/collections/rail_see_all_pill.dart';
+import 'package:debrify/screens/see_all/catalog_see_all_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -175,7 +178,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('fallback sources sharing a catalog produce one rail', (
+  testWidgets('duplicate sources sharing a catalog produce one rail', (
     tester,
   ) async {
     await seed(tester, 'rows');
@@ -190,7 +193,7 @@ void main() {
           sources: [
             original,
             CollectionCatalogSource(
-              addonId: 'missing',
+              addonId: original.addonId,
               type: original.type,
               catalogId: original.catalogId,
             ),
@@ -209,6 +212,28 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.byType(SeeAllPosterGrid), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('rail See All preserves hidden Discover card details', (tester) async {
+    await seed(tester, 'rows');
+    await tester.pumpWidget(MaterialApp(
+      home: DiscoverCardSettingsScope(
+        showTitles: false, showRatings: false, showTypeTags: false,
+        child: CollectionFolderScreen(
+          collection: collection, onOpenItem: (_) {},
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    tester.widget<RailSeeAllPill>(find.byType(RailSeeAllPill).first).onPressed();
+    await tester.pumpAndSettle();
+    expect(find.byType(CatalogSeeAllScreen), findsOneWidget);
+    final scope = DiscoverCardSettingsScope.maybeOf(tester.element(find.byType(CatalogSeeAllScreen)));
+    expect(scope, isNotNull);
+    expect(scope!.showTitles, isFalse);
+    expect(scope.showRatings, isFalse);
+    expect(scope.showTypeTags, isFalse);
     expect(tester.takeException(), isNull);
   });
 

--- a/test/home_collections_responsive_test.dart
+++ b/test/home_collections_responsive_test.dart
@@ -156,6 +156,62 @@ void main() {
       });
     }
   }
+  testWidgets('damaged settings offer an in-app reset', (tester) async {
+    await seed(tester, 'rows');
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(HomeCollectionsStore.prefsKey, '{broken');
+    await tester.pumpWidget(const MaterialApp(home: CollectionsSettingsPage()));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text('Reset damaged collections'));
+    await tester.tap(find.text('Reset damaged collections'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reset collections'));
+    await tester.pumpAndSettle();
+    expect(find.text('Damaged collection data'), findsNothing);
+    expect(
+      (await HomeCollectionsStore.instance.getInventory()).hadCorruption,
+      false,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('fallback sources sharing a catalog produce one rail', (
+    tester,
+  ) async {
+    await seed(tester, 'rows');
+    final original = collection.folders.first.sources.first;
+    final duplicate = HomeCollection(
+      id: collection.id,
+      title: collection.title,
+      folders: [
+        HomeCollectionFolder(
+          id: 'f',
+          title: 'F',
+          sources: [
+            original,
+            CollectionCatalogSource(
+              addonId: 'missing',
+              type: original.type,
+              catalogId: original.catalogId,
+            ),
+          ],
+        ),
+      ],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CollectionFolderScreen(
+          collection: duplicate,
+          isTelevision: true,
+          onOpenItem: (_) {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(SeeAllPosterGrid), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('open settings refreshes after remote collection changes', (
     tester,
   ) async {

--- a/test/home_collections_storage_test.dart
+++ b/test/home_collections_storage_test.dart
@@ -1,0 +1,175 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:debrify/models/home_collection.dart';
+import 'package:debrify/models/home_collection_inventory.dart';
+import 'package:debrify/services/home_collections_store.dart';
+import 'package:debrify/services/profiles/profile_runtime.dart';
+import 'package:debrify/services/profiles/profile_preference_budget.dart';
+
+const c = HomeCollection(
+  id: 'one',
+  title: 'One',
+  folders: [HomeCollectionFolder(id: 'f', title: 'Folder')],
+);
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() {
+    ProfileRuntime.debugReset();
+    ProfileRuntime.initializeLegacy();
+    ProfilePreferenceBudget.debugReset();
+    SharedPreferences.setMockInitialValues({});
+  });
+  tearDown(ProfilePreferenceBudget.debugReset);
+  test('invalid sync order identities cannot enter storage', () async {
+    final store = HomeCollectionsStore();
+    for (final id in ['', 'bad\u0000id']) {
+      await expectLater(
+        store.importCollections([HomeCollection(id: id, title: 'Bad')]),
+        throwsFormatException,
+      );
+    }
+    expect(await store.getCollections(), isEmpty);
+  });
+  test('explicit save applies order and retains deletion records', () async {
+    final store = HomeCollectionsStore();
+    const two = HomeCollection(id: 'two', title: 'Two');
+    const removed = HomeCollection(id: 'removed', title: 'Removed');
+    await store.importCollections([c, two, removed]);
+    await store.saveCollections([two, c]);
+    expect((await store.getCollections()).map((item) => item.id), [
+      'two',
+      'one',
+    ]);
+    final prefs = await SharedPreferences.getInstance();
+    final inventory = HomeCollectionInventory.decode(
+      prefs.getString(HomeCollectionsStore.prefsKey),
+    );
+    expect(inventory.records.containsKey('removed'), true);
+    expect(inventory.records['removed'], isNull);
+  });
+  test(
+    'legacy preferences upgrade on mutation with explicit deletions',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        HomeCollectionsStore.prefsKey: jsonEncode([c.toJson()]),
+      });
+      final store = HomeCollectionsStore();
+      expect((await store.getCollections()).single.id, 'one');
+      await store.clear();
+      final raw = (await SharedPreferences.getInstance()).getString(
+        HomeCollectionsStore.prefsKey,
+      );
+      expect(raw, isNotNull);
+      final inventory = HomeCollectionInventory.decode(raw);
+      expect(inventory.records.containsKey('one'), true);
+      expect(inventory.records['one'], null);
+      expect(await HomeCollectionsStore().getCollections(), isEmpty);
+    },
+  );
+  test('reimport can deliberately restore a deleted collection', () async {
+    final store = HomeCollectionsStore();
+    await store.importCollections([c]);
+    await store.remove('one');
+    await store.importCollections([c]);
+    expect((await store.getCollections()).single.title, 'One');
+  });
+  test(
+    'reimport updates contents without resetting disabled state or order',
+    () async {
+      final store = HomeCollectionsStore();
+      await store.importCollections([
+        c,
+        const HomeCollection(id: 'two', title: 'Two'),
+      ]);
+      await store.setEnabled('one', false);
+      await store.importCollections([
+        const HomeCollection(id: 'one', title: 'Updated'),
+      ]);
+      final list = await store.getCollections();
+      expect(list.map((c) => c.id), ['one', 'two']);
+      expect(list.first.title, 'Updated');
+      expect(list.first.enabled, false);
+    },
+  );
+  test(
+    'backup array exports active records and restores their visibility',
+    () async {
+      final store = HomeCollectionsStore();
+      await store.importCollections([
+        c.copyWith(enabled: false),
+        const HomeCollection(id: 'two', title: 'Two'),
+      ]);
+      await store.remove('two');
+      final backup = await store.exportJson();
+      expect(backup, hasLength(1));
+      SharedPreferences.setMockInitialValues({});
+      final report = await store.applyBackup(backup);
+      expect(report.imported, 1);
+      expect(report.failed, 0);
+      expect((await store.getCollections()).single.enabled, false);
+    },
+  );
+  test(
+    'invalid persisted data cannot be silently overwritten or exported empty',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        HomeCollectionsStore.prefsKey: 'broken',
+      });
+      final store = HomeCollectionsStore();
+      await expectLater(store.importCollections([c]), throwsFormatException);
+      await expectLater(store.exportJson(), throwsFormatException);
+      expect(
+        (await SharedPreferences.getInstance()).getString(
+          HomeCollectionsStore.prefsKey,
+        ),
+        'broken',
+      );
+    },
+  );
+  test(
+    'oversized sync identities are refused without changing inventory',
+    () async {
+      final store = HomeCollectionsStore();
+      await store.importCollections([c]);
+      await expectLater(
+        store.importCollections([
+          HomeCollection(id: 'x' * 1024, title: 'Too long'),
+        ]),
+        throwsFormatException,
+      );
+      expect((await store.getCollections()).map((c) => c.id), ['one']);
+    },
+  );
+  test('failed layout write surfaces a failure', () async {
+    ProfilePreferenceBudget.debugEnforcedOverride = true;
+    SharedPreferences.setMockInitialValues({'full': 'x' * (512 * 1024)});
+    await expectLater(
+      HomeCollectionsStore().setFolderLayout(CollectionFolderLayout.tabs),
+      throwsStateError,
+    );
+    expect(
+      (await SharedPreferences.getInstance()).getString(
+        HomeCollectionsStore.folderLayoutKey,
+      ),
+      null,
+    );
+  });
+  test(
+    'signature reflects content edits with identical counts and timestamps',
+    () {
+      expect(
+        HomeCollectionsStore.signatureOf([c]),
+        isNot(
+          HomeCollectionsStore.signatureOf([
+            const HomeCollection(
+              id: 'one',
+              title: 'Changed',
+              folders: [HomeCollectionFolder(id: 'f', title: 'Folder')],
+            ),
+          ]),
+        ),
+      );
+    },
+  );
+}

--- a/test/home_collections_storage_test.dart
+++ b/test/home_collections_storage_test.dart
@@ -111,20 +111,80 @@ void main() {
     },
   );
   test(
-    'invalid persisted data cannot be silently overwritten or exported empty',
+    'invalid persisted data is preserved until reset while reads and backup remain usable',
     () async {
       SharedPreferences.setMockInitialValues({
         HomeCollectionsStore.prefsKey: 'broken',
       });
       final store = HomeCollectionsStore();
       await expectLater(store.importCollections([c]), throwsFormatException);
-      await expectLater(store.exportJson(), throwsFormatException);
+      expect(await store.exportJson(), isEmpty);
       expect(
         (await SharedPreferences.getInstance()).getString(
           HomeCollectionsStore.prefsKey,
         ),
         'broken',
       );
+    },
+  );
+  test('reset and explicit restore recover a corrupt inventory', () async {
+    SharedPreferences.setMockInitialValues({
+      HomeCollectionsStore.prefsKey: 'broken',
+    });
+    final store = HomeCollectionsStore();
+    expect((await store.getInventory()).hadCorruption, true);
+    await store.clear();
+    expect((await store.getInventory()).hadCorruption, false);
+    await store.importCollections([c]);
+    SharedPreferences.setMockInitialValues({
+      HomeCollectionsStore.prefsKey: 'broken again',
+    });
+    await store.applyBackup([c.toJson()]);
+    expect((await store.getCollections()).single.id, c.id);
+  });
+  test(
+    'reads salvage valid records alongside a malformed collection',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        HomeCollectionsStore.prefsKey: jsonEncode({
+          'version': 2,
+          'records': {'one': c.toJson(), 'bad': 123},
+          'order': ['bad', 'one'],
+        }),
+      });
+      final store = HomeCollectionsStore();
+      expect((await store.getInventory()).hadCorruption, true);
+      expect((await store.getEnabledCollections()).single.id, 'one');
+      expect((await store.exportJson()).single['id'], 'one');
+    },
+  );
+  test(
+    'pending deletion identities do not consume live import capacity',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        HomeCollectionsStore.prefsKey: jsonEncode({
+          'version': 2,
+          'records': {for (var i = 0; i < 1100; i++) 'deleted$i': null},
+          'order': [for (var i = 0; i < 1100; i++) 'deleted$i'],
+        }),
+      });
+      final store = HomeCollectionsStore();
+      await store.importCollections([c]);
+      expect((await store.getCollections()).single.id, 'one');
+    },
+  );
+  test(
+    'visibility changes remain possible on oversized synced definitions',
+    () async {
+      final large = HomeCollection(id: 'large', title: 'x' * (140 * 1024));
+      SharedPreferences.setMockInitialValues({
+        HomeCollectionsStore.prefsKey: jsonEncode([large.toJson()]),
+      });
+      final store = HomeCollectionsStore();
+      await store.setEnabled('large', false);
+      expect((await store.getCollections()).single.enabled, false);
+      await store.setEnabled('large', true);
+      expect((await store.getCollections()).single.enabled, true);
     },
   );
   test(

--- a/test/home_collections_test.dart
+++ b/test/home_collections_test.dart
@@ -352,7 +352,10 @@ void main() {
         installedAddons: [addon],
         fetch: (a, c, {skip = 0, genre, onRawCount}) async {
           calls.add('${c.id}:$skip:${genre ?? ''}');
-          if (skip > 0) return const [];
+          if (skip > 0) {
+            onRawCount?.call(0);
+            return const [];
+          }
           onRawCount?.call(2);
           return c.id == 'popular'
               ? [_meta('tt1'), _meta('tt2')]

--- a/test/home_collections_test.dart
+++ b/test/home_collections_test.dart
@@ -212,7 +212,7 @@ void main() {
       ],
     );
 
-    test('matches by manifest id first, then by catalog type+id', () {
+    test('requires manifest identity even when another addon has the catalog', () {
       const byId = CollectionCatalogSource(
         addonId: 'com.linvo.cinemeta',
         type: 'movie',
@@ -230,7 +230,7 @@ void main() {
       );
       expect(
         HomeCollectionsStore.resolveAddon(byCatalog, [cinemeta, fork]),
-        fork,
+        isNull,
       );
 
       const missing = CollectionCatalogSource(
@@ -250,7 +250,7 @@ void main() {
         [c],
         [cinemeta, fork],
       );
-      // Netflix movies matched the fork by catalog id; Netflix series did not.
+      // Both Netflix sources remain unresolved without their provider.
       expect(unresolved, {'app.xperience.abc'});
       expect(HomeCollectionsStore.unresolvedAddonIds([c], [cinemeta]), {
         'app.xperience.abc',
@@ -259,10 +259,8 @@ void main() {
 
     test('claimedCatalogKeys names the board rows a folder takes over', () {
       final c = HomeCollectionParser.parse(_xperienceSample).single;
-      // Netflix movies resolve to the fork by catalog id; Action resolves to
-      // Cinemeta by manifest id; Netflix series resolve to nothing.
+      // Only Action resolves to Cinemeta by manifest id.
       expect(HomeCollectionsStore.claimedCatalogKeys([c], [cinemeta, fork]), {
-        'someone.elses.fork:movie:streaming_netflix_movies',
         'com.linvo.cinemeta:movie:top',
       });
       // A disabled collection claims nothing — its catalogs return to Home.

--- a/test/home_collections_test.dart
+++ b/test/home_collections_test.dart
@@ -1,0 +1,372 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:debrify/models/home_collection.dart';
+import 'package:debrify/models/stremio_addon.dart';
+import 'package:debrify/services/collection_folder_loader.dart';
+import 'package:debrify/services/home_collection_rows.dart';
+import 'package:debrify/services/home_collections_store.dart';
+
+const _xperienceSample = '''
+[
+  {
+    "id": "ee8e31f3-14b6-4295-8ac1-782d294d70d0",
+    "title": "Streaming",
+    "pinToTop": true,
+    "focusGlowEnabled": true,
+    "viewMode": "FOLLOW_LAYOUT",
+    "showAllTab": true,
+    "backdropImageUrl": null,
+    "folders": [
+      {
+        "id": "dd534772-7be8-4d52-a17a-45cc65cce83b",
+        "title": "Netflix",
+        "hideTitle": true,
+        "coverImageUrl": "https://cdn.example/netflix.webp",
+        "coverEmoji": null,
+        "heroBackdropUrl": "https://cdn.example/netflix.backdrop.webp",
+        "titleLogoUrl": "https://cdn.example/netflix.logo.webp",
+        "tileShape": "LANDSCAPE",
+        "catalogSources": [
+          {"addonId": "app.xperience.abc", "type": "movie", "catalogId": "streaming_netflix_movies", "genre": null},
+          {"addonId": "app.xperience.abc", "type": "series", "catalogId": "streaming_netflix_series", "genre": null}
+        ],
+        "sources": [
+          {"provider": "addon", "addonId": "app.xperience.abc", "type": "movie", "catalogId": "streaming_netflix_movies", "genre": null},
+          {"provider": "addon", "addonId": "app.xperience.abc", "type": "series", "catalogId": "streaming_netflix_series", "genre": null}
+        ]
+      },
+      {
+        "title": "Action",
+        "tileShape": "PORTRAIT",
+        "catalogSources": [
+          {"addonId": "com.linvo.cinemeta", "type": "movie", "catalogId": "top", "genre": "Action"}
+        ]
+      }
+    ]
+  }
+]
+''';
+
+StremioMeta _meta(String id) => StremioMeta(id: id, type: 'movie', name: id);
+
+void main() {
+  group('HomeCollectionParser', () {
+    test('parses the Nuvio / Xperience export shape', () {
+      final collections = HomeCollectionParser.parse(_xperienceSample);
+      expect(collections, hasLength(1));
+      final c = collections.single;
+      expect(c.id, 'ee8e31f3-14b6-4295-8ac1-782d294d70d0');
+      expect(c.title, 'Streaming');
+      expect(c.pinToTop, isTrue);
+      expect(c.enabled, isTrue);
+      expect(c.folders, hasLength(2));
+
+      final netflix = c.folders.first;
+      expect(netflix.title, 'Netflix');
+      expect(netflix.hideTitle, isTrue);
+      expect(netflix.tileShape, CollectionTileShape.landscape);
+      expect(netflix.coverImageUrl, 'https://cdn.example/netflix.webp');
+      // catalogSources + sources describe the same two catalogs — deduped.
+      expect(netflix.sources, hasLength(2));
+      expect(netflix.sources.first.addonId, 'app.xperience.abc');
+      expect(netflix.sources.first.catalogId, 'streaming_netflix_movies');
+      expect(netflix.sources.first.genre, isNull);
+
+      final action = c.folders[1];
+      expect(action.tileShape, CollectionTileShape.portrait);
+      expect(action.sources.single.genre, 'Action');
+      // A folder without an id gets a stable one so re-imports replace.
+      expect(action.id, isNotEmpty);
+      expect(
+        action.id,
+        HomeCollectionParser.parse(_xperienceSample).single.folders[1].id,
+      );
+    });
+
+    test('accepts a wrapped object and a single collection', () {
+      final wrapped = HomeCollectionParser.parse(
+        '{"collections": $_xperienceSample}',
+      );
+      expect(wrapped.single.title, 'Streaming');
+
+      final single = HomeCollectionParser.parse(
+        '{"title": "Solo", "folders": [{"title": "F", "catalogSources": []}]}',
+      );
+      expect(single.single.title, 'Solo');
+      expect(single.single.folders.single.title, 'F');
+    });
+
+    test('wraps a bare folder list into one collection', () {
+      final parsed = HomeCollectionParser.parse(
+        '[{"title": "Only folder", "catalogSources": '
+        '[{"addonId": "a", "type": "movie", "catalogId": "c"}]}]',
+      );
+      expect(parsed.single.title, 'Imported');
+      expect(parsed.single.folders.single.title, 'Only folder');
+    });
+
+    test('rejects non-JSON and empty documents with readable messages', () {
+      expect(
+        () => HomeCollectionParser.parse('not json'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('not valid JSON'),
+          ),
+        ),
+      );
+      expect(() => HomeCollectionParser.parse('[]'), throwsFormatException);
+      expect(
+        () => HomeCollectionParser.parse('{"foo": 1}'),
+        throwsFormatException,
+      );
+    });
+
+    test('round-trips through toJson', () {
+      final original = HomeCollectionParser.parse(_xperienceSample).single;
+      final again = HomeCollection.fromJson(original.toJson())!;
+      expect(again.id, original.id);
+      expect(again.folders.length, original.folders.length);
+      expect(
+        again.folders.first.sources.map((s) => s.key),
+        original.folders.first.sources.map((s) => s.key),
+      );
+      expect(again.folders[1].tileShape, CollectionTileShape.portrait);
+    });
+  });
+
+  group('CollectionFolderLayout', () {
+    test('parses leniently and defaults to rows', () {
+      expect(CollectionFolderLayout.parse('tabs'), CollectionFolderLayout.tabs);
+      expect(
+        CollectionFolderLayout.parse(' TABS '),
+        CollectionFolderLayout.tabs,
+      );
+      expect(CollectionFolderLayout.parse('rows'), CollectionFolderLayout.rows);
+      expect(CollectionFolderLayout.parse(null), CollectionFolderLayout.rows);
+      expect(CollectionFolderLayout.parse(42), CollectionFolderLayout.rows);
+      expect(CollectionFolderLayout.tabs.storageValue, 'tabs');
+    });
+  });
+
+  group('HomeCollectionRowIds', () {
+    test('row id grammar', () {
+      expect(HomeCollectionRowIds.collection('x'), 'collection:x');
+      expect(HomeCollectionRowIds.isCollection('collection:x'), isTrue);
+      expect(HomeCollectionRowIds.isCollection('traktlist:x'), isFalse);
+      expect(HomeCollectionRowIds.collectionId('collection:abc'), 'abc');
+      expect(HomeCollectionRowIds.collectionId('cw:movies'), isNull);
+    });
+  });
+
+  group('HomeCollectionSection', () {
+    test('one tile per folder, folders resolvable from tiles', () {
+      final c = HomeCollectionParser.parse(_xperienceSample).single;
+      final section = HomeCollectionSection(collection: c);
+      expect(section.rowId, 'collection:${c.id}');
+      expect(section.items, hasLength(2));
+      expect(section.items.first.type, 'folder');
+      expect(section.items.first.poster, 'https://cdn.example/netflix.webp');
+      expect(section.exhausted, isTrue);
+      expect(section.folderOf(section.items[1])?.title, 'Action');
+      expect(section.folderIndexOf(section.items[1]), 1);
+      expect(section.folderOf(_meta('tt1')), isNull);
+      expect(section.landscapeTiles, isTrue);
+    });
+  });
+
+  group('HomeCollectionsStore addon resolution', () {
+    final cinemeta = StremioAddon(
+      id: 'com.linvo.cinemeta',
+      name: 'Cinemeta',
+      manifestUrl: 'https://v3-cinemeta.strem.io/manifest.json',
+      baseUrl: 'https://v3-cinemeta.strem.io',
+      resources: const ['catalog'],
+      catalogs: const [
+        StremioAddonCatalog(id: 'top', type: 'movie', name: 'Popular'),
+        StremioAddonCatalog(id: 'top', type: 'series', name: 'Popular'),
+      ],
+    );
+    final fork = StremioAddon(
+      id: 'someone.elses.fork',
+      name: 'Fork',
+      manifestUrl: 'https://fork/manifest.json',
+      baseUrl: 'https://fork',
+      resources: const ['catalog'],
+      catalogs: const [
+        StremioAddonCatalog(
+          id: 'streaming_netflix_movies',
+          type: 'movie',
+          name: 'Netflix',
+        ),
+      ],
+    );
+
+    test('matches by manifest id first, then by catalog type+id', () {
+      const byId = CollectionCatalogSource(
+        addonId: 'com.linvo.cinemeta',
+        type: 'movie',
+        catalogId: 'top',
+      );
+      expect(
+        HomeCollectionsStore.resolveAddon(byId, [fork, cinemeta]),
+        cinemeta,
+      );
+
+      const byCatalog = CollectionCatalogSource(
+        addonId: 'app.xperience.abc',
+        type: 'movie',
+        catalogId: 'streaming_netflix_movies',
+      );
+      expect(
+        HomeCollectionsStore.resolveAddon(byCatalog, [cinemeta, fork]),
+        fork,
+      );
+
+      const missing = CollectionCatalogSource(
+        addonId: 'app.xperience.abc',
+        type: 'series',
+        catalogId: 'streaming_netflix_series',
+      );
+      expect(
+        HomeCollectionsStore.resolveAddon(missing, [cinemeta, fork]),
+        isNull,
+      );
+    });
+
+    test('unresolvedAddonIds reports only what nothing can serve', () {
+      final c = HomeCollectionParser.parse(_xperienceSample).single;
+      final unresolved = HomeCollectionsStore.unresolvedAddonIds(
+        [c],
+        [cinemeta, fork],
+      );
+      // Netflix movies matched the fork by catalog id; Netflix series did not.
+      expect(unresolved, {'app.xperience.abc'});
+      expect(HomeCollectionsStore.unresolvedAddonIds([c], [cinemeta]), {
+        'app.xperience.abc',
+      });
+    });
+
+    test('claimedCatalogKeys names the board rows a folder takes over', () {
+      final c = HomeCollectionParser.parse(_xperienceSample).single;
+      // Netflix movies resolve to the fork by catalog id; Action resolves to
+      // Cinemeta by manifest id; Netflix series resolve to nothing.
+      expect(HomeCollectionsStore.claimedCatalogKeys([c], [cinemeta, fork]), {
+        'someone.elses.fork:movie:streaming_netflix_movies',
+        'com.linvo.cinemeta:movie:top',
+      });
+      // A disabled collection claims nothing — its catalogs return to Home.
+      expect(
+        HomeCollectionsStore.claimedCatalogKeys(
+          [c.copyWith(enabled: false)],
+          [cinemeta, fork],
+        ),
+        isEmpty,
+      );
+    });
+
+    test('folder list ids are distinct per source and never board rows', () {
+      final c = HomeCollectionParser.parse(_xperienceSample).single;
+      final netflix = c.folders.first;
+      final ids = [
+        for (final s in netflix.sources)
+          HomeCollectionRowIds.folderList(c.id, netflix.id, s),
+      ];
+      expect(ids.toSet(), hasLength(2));
+      expect(ids.every(HomeCollectionRowIds.isFolderList), isTrue);
+      expect(ids.every(HomeCollectionRowIds.isCollection), isFalse);
+      final action = c.folders[1];
+      expect(
+        HomeCollectionRowIds.folderList(c.id, action.id, action.sources.single),
+        endsWith(':com.linvo.cinemeta:movie:top:Action'),
+      );
+      expect(netflix.copyWith(sources: const []).sources, isEmpty);
+    });
+
+    test('signature changes with enabled state and membership', () {
+      final c = HomeCollectionParser.parse(_xperienceSample).single;
+      final a = HomeCollectionsStore.signatureOf([c]);
+      final b = HomeCollectionsStore.signatureOf([c.copyWith(enabled: false)]);
+      expect(a, isNot(b));
+      expect(HomeCollectionsStore.signatureOf([]), isNot(a));
+    });
+  });
+
+  group('CollectionFolderLoader', () {
+    test('interleave merges round-robin and drops exhausted lists', () {
+      final merged = CollectionFolderLoader.interleave([
+        [_meta('a1'), _meta('a2'), _meta('a3')],
+        [_meta('b1')],
+        [_meta('c1'), _meta('c2')],
+      ]);
+      expect(merged.map((m) => m.id), ['a1', 'b1', 'c1', 'a2', 'c2', 'a3']);
+    });
+
+    test('pages every source, dedupes across them, and exhausts', () async {
+      final addon = StremioAddon(
+        id: 'com.test',
+        name: 'Test',
+        manifestUrl: 'https://t/manifest.json',
+        baseUrl: 'https://t',
+        resources: const ['catalog'],
+        catalogs: const [
+          StremioAddonCatalog(id: 'popular', type: 'movie', name: 'Popular'),
+          StremioAddonCatalog(id: 'top', type: 'movie', name: 'Top'),
+        ],
+      );
+      const folder = HomeCollectionFolder(
+        id: 'f',
+        title: 'Mixed',
+        sources: [
+          CollectionCatalogSource(
+            addonId: 'com.test',
+            type: 'movie',
+            catalogId: 'popular',
+          ),
+          CollectionCatalogSource(
+            addonId: 'com.test',
+            type: 'movie',
+            catalogId: 'top',
+            genre: 'Action',
+          ),
+          CollectionCatalogSource(
+            addonId: 'missing.addon',
+            type: 'movie',
+            catalogId: 'nope',
+          ),
+        ],
+      );
+      final calls = <String>[];
+      final loader = CollectionFolderLoader(
+        folder: folder,
+        installedAddons: [addon],
+        fetch: (a, c, {skip = 0, genre, onRawCount}) async {
+          calls.add('${c.id}:$skip:${genre ?? ''}');
+          if (skip > 0) return const [];
+          onRawCount?.call(2);
+          return c.id == 'popular'
+              ? [_meta('tt1'), _meta('tt2')]
+              : [_meta('tt2'), _meta('tt3')];
+        },
+      );
+      expect(loader.resolvedSourceCount, 2);
+      expect(loader.unresolved, ['missing.addon']);
+
+      final first = await loader.nextPage();
+      expect(first.map((m) => m.id), ['tt1', 'tt2', 'tt3']);
+      expect(first.every((m) => m.sourceAddon?.id == 'com.test'), isTrue);
+      expect(calls, ['popular:0:', 'top:0:Action']);
+      expect(loader.exhausted, isFalse);
+
+      final second = await loader.nextPage();
+      expect(second, isEmpty);
+      expect(loader.exhausted, isTrue);
+      expect(calls.length, 4);
+
+      loader.reset();
+      expect(loader.exhausted, isFalse);
+      expect((await loader.nextPage()).length, 3);
+    });
+  });
+}

--- a/test/home_collections_test.dart
+++ b/test/home_collections_test.dart
@@ -25,6 +25,8 @@ const _xperienceSample = '''
         "coverEmoji": null,
         "heroBackdropUrl": "https://cdn.example/netflix.backdrop.webp",
         "titleLogoUrl": "https://cdn.example/netflix.logo.webp",
+        "focusGifUrl": "https://cdn.example/netflix.focus.gif",
+        "focusGifEnabled": true,
         "tileShape": "LANDSCAPE",
         "catalogSources": [
           {"addonId": "app.xperience.abc", "type": "movie", "catalogId": "streaming_netflix_movies", "genre": null},
@@ -172,6 +174,13 @@ void main() {
       expect(section.folderOf(section.items[1])?.title, 'Action');
       expect(section.folderIndexOf(section.items[1]), 1);
       expect(section.folderOf(_meta('tt1')), isNull);
+      expect(
+        section.focusArtOf(section.items.first),
+        'https://cdn.example/netflix.focus.gif',
+      );
+      expect(section.focusArtOf(section.items[1]), isNull);
+      expect(c.folders.first.heroBackdropUrl, endsWith('backdrop.webp'));
+      expect(c.folders.first.titleLogoUrl, endsWith('logo.webp'));
       expect(section.landscapeTiles, isTrue);
     });
   });

--- a/test/home_collections_test.dart
+++ b/test/home_collections_test.dart
@@ -26,7 +26,7 @@ const _xperienceSample = '''
         "heroBackdropUrl": "https://cdn.example/netflix.backdrop.webp",
         "titleLogoUrl": "https://cdn.example/netflix.logo.webp",
         "focusGifUrl": "https://cdn.example/netflix.focus.gif",
-        "focusGifEnabled": true,
+        "focusGifEnabled": false,
         "tileShape": "LANDSCAPE",
         "catalogSources": [
           {"addonId": "app.xperience.abc", "type": "movie", "catalogId": "streaming_netflix_movies", "genre": null},

--- a/test/home_expanded_card_settings_test.dart
+++ b/test/home_expanded_card_settings_test.dart
@@ -26,11 +26,11 @@ void main() {
     expect(helper, contains('showTitles: DiscoverPrefs.showTitles'));
 
     // Catalog rows, tracker-list rows, generic Continue Watching rows (also
-    // used by Simkl/MDBList), and Trakt Continue Watching each push a
-    // different screen. All four route builders must opt into the helper.
+    // used by Simkl/MDBList), Trakt Continue Watching, and collection folders
+    // each push a different screen. All five builders must use the helper.
     final routeUses = RegExp(
       r'builder: \(_\) => _withHomeExpandedCardSettings\(',
     ).allMatches(source);
-    expect(routeUses.length, 4);
+    expect(routeUses.length, 5);
   });
 }

--- a/test/home_sections_filter_page_test.dart
+++ b/test/home_sections_filter_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:debrify/models/home_collection.dart';
 
 import 'package:debrify/screens/settings/home_sections_filter_page.dart';
 import 'package:debrify/services/storage_service.dart';
@@ -9,6 +10,7 @@ import 'package:debrify/services/storage_service.dart';
 Future<void> _pumpPage(
   WidgetTester tester, {
   List<HomeExtraRow> extraRows = const [],
+  List<HomeCollection> collections = const [],
   Set<String> disabled = const {},
   List<String> rowOrder = const [],
 }) async {
@@ -23,6 +25,7 @@ Future<void> _pumpPage(
         catalogTree: const [],
         disabled: Set.of(disabled),
         extraRows: extraRows,
+        collections: collections,
         rowOrder: rowOrder,
         isTelevision: false,
       ),
@@ -40,6 +43,16 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('saving Home Rows preserves a new pinned collections leading slot', (tester) async {
+    await _pumpPage(tester, rowOrder: ['cw:movies', 'trakt:movies'], collections: const [
+      HomeCollection(id: 'pinned', title: 'Pinned', pinToTop: true, folders: []),
+    ]);
+    await tester.tap(find.text('Movies').first);
+    await tester.pump();
+    await _saveAndClose(tester);
+    expect((await StorageService.getHomeRowOrder()).first, 'collection:pinned');
+  });
 
   testWidgets('opt-in leaf toggles persist to the extras store, not the '
       'disabled set', (tester) async {

--- a/test/services/webdav_sync/webdav_sync_engine_test.dart
+++ b/test/services/webdav_sync/webdav_sync_engine_test.dart
@@ -4,6 +4,8 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:debrify/models/home_collection.dart';
+import 'package:debrify/models/home_collection_inventory.dart';
 import 'package:debrify/models/profiles/connection_resource.dart';
 import 'package:debrify/models/profiles/profile_policy.dart';
 import 'package:debrify/models/profiles/user_profile.dart';
@@ -104,6 +106,80 @@ void main() {
     );
     return WebDavSyncManifest.fromJson(payload);
   }
+
+  test('collections converge across devices, deletion and restart', () async {
+    Map<String, Object?> initial(String id) => {
+      HomeCollectionInventory.prefsKey: jsonEncode([
+        HomeCollection(id: id, title: id).toJson(),
+      ]),
+    };
+    final a = _FakeLocalAdapter(initial('a'));
+    final b = _FakeLocalAdapter(initial('b'));
+    final aStates = _MemoryStateRepository();
+    final bStates = _MemoryStateRepository();
+    var cycleTime = now;
+    WebDavSyncEngine makeEngine(
+      _FakeLocalAdapter adapter,
+      _MemoryStateRepository repository,
+    ) => WebDavSyncEngine(
+      stateRepository: repository,
+      localAdapter: adapter,
+      transportFactory: (_) => transport,
+      codec: codec,
+      clock: () => cycleTime,
+    );
+    var ae = makeEngine(a, aStates);
+    final be = makeEngine(b, bStates);
+    WebDavSyncCycleContext ctx(String device) => WebDavSyncCycleContext(
+      namespaceId: 'circle:circle-1',
+      deviceId: device,
+      markerPin: marker,
+      root: root,
+      circleToLocalProfiles: const {'profile-circle': 'local-profile'},
+      circleToLocalResources: const {},
+    );
+    Future<void> cycle(WebDavSyncEngine engine, String device) async {
+      cycleTime = cycleTime.add(const Duration(seconds: 1));
+      transport.serverDate = cycleTime;
+      final report = await engine.runCycle(ctx(device), allowPreActivation: true);
+      expect(report.disposition, WebDavSyncCycleDisposition.completed);
+    }
+    HomeCollectionInventory inventory(_FakeLocalAdapter adapter) =>
+        HomeCollectionInventory.decode(
+          adapter.preferences[HomeCollectionInventory.prefsKey],
+        );
+    void save(_FakeLocalAdapter adapter, HomeCollectionInventory value) {
+      adapter.preferences[HomeCollectionInventory.prefsKey] = value.encode();
+    }
+
+    await cycle(ae, 'device-a');
+    await cycle(be, 'device-b');
+    await cycle(ae, 'device-a');
+    await cycle(be, 'device-b');
+    expect(inventory(a).collections.map((c) => c.id), unorderedEquals(['a', 'b']));
+    expect(inventory(b).collections.map((c) => c.id), unorderedEquals(['a', 'b']));
+
+    // B stays offline while A deletes. Recreate A's engine to exercise its
+    // persisted state rather than relying on a merge object's memory.
+    save(a, inventory(a)..remove('a'));
+    await cycle(ae, 'device-a');
+    ae = makeEngine(a, aStates);
+    await cycle(ae, 'device-a');
+    await cycle(be, 'device-b');
+    await cycle(ae, 'device-a');
+    for (final adapter in [a, b]) {
+      expect(inventory(adapter).collections.map((c) => c.id), ['b']);
+      expect(inventory(adapter).records.containsKey('a'), true);
+      expect(inventory(adapter).records['a'], isNull);
+    }
+
+    // An explicit later reimport is an edit, so it may restore the record.
+    save(b, inventory(b)..put(const HomeCollection(id: 'a', title: 'Restored')));
+    await cycle(be, 'device-b');
+    await cycle(ae, 'device-a');
+    expect(inventory(a).records['a']!.title, 'Restored');
+    expect(inventory(a).records['b'], isNotNull);
+  });
 
   for (final malformedEnvelope in [true, false]) {
     test(

--- a/test/services/webdav_sync/webdav_sync_engine_test.dart
+++ b/test/services/webdav_sync/webdav_sync_engine_test.dart
@@ -195,6 +195,86 @@ void main() {
     expect(inventory(a).records['b'], isNotNull);
   });
 
+  test('deletion during pending replay survives another crash and reaches peers', () async {
+    Map<String, Object?> initial(String id) => {
+      HomeCollectionInventory.prefsKey: jsonEncode([
+        HomeCollection(id: id, title: id).toJson(),
+      ]),
+    };
+    final a = _FakeLocalAdapter(initial('a'));
+    final b = _FakeLocalAdapter(initial('b'));
+    final aStates = _MemoryStateRepository();
+    final bStates = _MemoryStateRepository();
+    var cycleTime = now;
+    WebDavSyncEngine makeEngine(
+      _FakeLocalAdapter adapter,
+      _MemoryStateRepository repository,
+    ) => WebDavSyncEngine(
+      stateRepository: repository,
+      localAdapter: adapter,
+      transportFactory: (_) => transport,
+      codec: codec,
+      clock: () => cycleTime,
+    );
+    var ae = makeEngine(a, aStates);
+    final be = makeEngine(b, bStates);
+    WebDavSyncCycleContext ctx(String device) => WebDavSyncCycleContext(
+      namespaceId: 'circle:circle-1',
+      deviceId: device,
+      markerPin: marker,
+      root: root,
+      circleToLocalProfiles: const {'profile-circle': 'local-profile'},
+      circleToLocalResources: const {},
+    );
+    Future<void> cycle(WebDavSyncEngine engine, String device) async {
+      cycleTime = cycleTime.add(const Duration(seconds: 1));
+      transport.serverDate = cycleTime;
+      final report = await engine.runCycle(ctx(device), allowPreActivation: true);
+      expect(report.disposition, WebDavSyncCycleDisposition.completed);
+    }
+    HomeCollectionInventory inventory(_FakeLocalAdapter adapter) =>
+        HomeCollectionInventory.decode(
+          adapter.preferences[HomeCollectionInventory.prefsKey],
+        );
+    void save(_FakeLocalAdapter adapter, HomeCollectionInventory value) {
+      adapter.preferences[HomeCollectionInventory.prefsKey] = value.encode();
+    }
+
+    await cycle(ae, 'device-a');
+    await cycle(be, 'device-b');
+    await cycle(ae, 'device-a');
+    await cycle(be, 'device-b');
+    expect(inventory(a).collections.map((c) => c.id), unorderedEquals(['a', 'b']));
+    expect(inventory(b).collections.map((c) => c.id), unorderedEquals(['a', 'b']));
+
+    // Journal a pending target, then delete while that apply is interrupted.
+    a.failNextApply = true;
+    await expectLater(cycle(ae, 'device-a'), throwsStateError);
+    expect(aStates.state.profiles['profile-circle']!.pendingApply, isNotNull);
+    save(a, inventory(a)..remove('b'));
+    a.afterApply = () {
+      a.afterApply = null;
+      throw StateError('crash after replay materializes the new deletion');
+    };
+    ae = makeEngine(a, aStates);
+    await expectLater(cycle(ae, 'device-a'), throwsStateError);
+    expect(a.replayingPendingFlags.last, true);
+    expect(inventory(a).records.containsKey('b'), false);
+    expect(aStates.state.profiles['profile-circle']!.tombstones,
+      contains(WebDavSyncRecordKey.homeCollection('b')));
+
+    // A second restart must publish the deletion even though its null marker
+    // disappeared during replay. B still holds the live record at this point.
+    ae = makeEngine(a, aStates);
+    await cycle(ae, 'device-a');
+    await cycle(be, 'device-b');
+    await cycle(ae, 'device-a');
+    for (final adapter in [a, b]) {
+      expect(inventory(adapter).collections.map((c) => c.id), ['a']);
+      expect(inventory(adapter).records.containsKey('b'), false);
+    }
+  });
+
   for (final malformedEnvelope in [true, false]) {
     test(
       'invalid peer reports ${malformedEnvelope ? 'decode' : 'parse'} stage',

--- a/test/services/webdav_sync/webdav_sync_engine_test.dart
+++ b/test/services/webdav_sync/webdav_sync_engine_test.dart
@@ -107,6 +107,14 @@ void main() {
     return WebDavSyncManifest.fromJson(payload);
   }
 
+  test('corrupt collection inventory cannot stop a multi-profile cycle', () async {
+    local.preferences = {HomeCollectionInventory.prefsKey: '{broken', 'theme': 'dark'};
+    final report = await runFixture(context(profiles: {'profile-circle': 'local-profile', 'profile-two': 'other-profile'}));
+    expect(report.disposition, WebDavSyncCycleDisposition.completed);
+    expect(report.profilesApplied, 2);
+    expect(local.preferences['theme'], 'dark');
+  });
+
   test('collections converge across devices, deletion and restart', () async {
     Map<String, Object?> initial(String id) => {
       HomeCollectionInventory.prefsKey: jsonEncode([
@@ -162,15 +170,21 @@ void main() {
     // B stays offline while A deletes. Recreate A's engine to exercise its
     // persisted state rather than relying on a merge object's memory.
     save(a, inventory(a)..remove('a'));
-    await cycle(ae, 'device-a');
+    a.afterApply = () {
+      a.afterApply = null;
+      throw StateError('crash after collection apply, before publish');
+    };
+    await expectLater(cycle(ae, 'device-a'), throwsStateError);
+    expect(inventory(a).records.containsKey('a'), false);
+    expect(aStates.state.profiles['profile-circle']!.tombstones,
+      contains(WebDavSyncRecordKey.homeCollection('a')));
     ae = makeEngine(a, aStates);
     await cycle(ae, 'device-a');
     await cycle(be, 'device-b');
     await cycle(ae, 'device-a');
     for (final adapter in [a, b]) {
       expect(inventory(adapter).collections.map((c) => c.id), ['b']);
-      expect(inventory(adapter).records.containsKey('a'), true);
-      expect(inventory(adapter).records['a'], isNull);
+      expect(inventory(adapter).records.containsKey('a'), false);
     }
 
     // An explicit later reimport is an edit, so it may restore the record.

--- a/test/spotlight_board_test.dart
+++ b/test/spotlight_board_test.dart
@@ -1319,6 +1319,24 @@ void main() {
     );
   });
 
+  testWidgets('square collection covers retain their ratio and per-card hidden titles', (tester) async {
+    await tester.pumpWidget(host([_meta('tt1', 'Hero')], [
+      SpotlightShelf(title: 'Folders', nodes: rows[0], items: [
+        SpotlightCard(title: 'Hidden folder', shape: SpotlightCardShape.square,
+          showCaption: false, onOpen: _noop),
+        SpotlightCard(title: 'Visible folder', shape: SpotlightCardShape.square,
+          onOpen: _noop),
+      ]),
+    ]));
+    await tester.pumpAndSettle();
+    final cardHost = tester.widgetList<ParallaxFocus>(find.byType(ParallaxFocus))
+        .firstWhere((p) => p.fixedScaleForeground != null);
+    final box = tester.getSize(find.byWidget(cardHost));
+    expect(box.width / box.height, closeTo(1, 0.005));
+    expect(find.text('Hidden folder'), findsNothing);
+    expect(find.text('Visible folder'), findsOneWidget);
+  });
+
   testWidgets('a wide shelf uses the readable landscape rail width', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

Adds **Collections**: import a Nuvio/Xperience-style collections JSON (groups of folders, each folder a bundle of Stremio addon catalogs) and browse it from the Home board. Each collection becomes a Home row of folder tiles; opening a folder shows its catalogs as separate lists. Everything is per profile, rides Backup & Restore, and integrates with the existing Home Rows manager rather than adding a parallel settings surface.

## Motivation

Community-maintained collection files already exist for Nuvio/Xperience (streaming services, genres, "new & trending" groupings, each with cover art and a curated set of catalogs). Users with the same catalog addons installed in Debrify currently have to recreate that structure by hand, and a large catalog addon floods the Home board with one row per catalog. Collections give those catalogs a home: a folder, with the board showing one tile per folder instead of dozens of rows.

## User-facing changes

- **Settings → Home Screen → Collections**: import from a file, a URL, or pasted JSON; list, show/hide, or delete imported collections; choose the folder layout (Rows or Tabs).
- **Home**: one row per collection, its folders as tiles using the file's cover art and tile shape (landscape/portrait/square). Tiles play the file's focus GIF while focused or hovered. Pinned collections lead the board; the rest sit after the tracker list rows.
- **Folder screen**: the folder's backdrop and title logo head the page when the file provides them. *Rows* layout stacks one horizontal rail per catalog, each with See All into the normal catalog browser (pinned to the source's genre). *Tabs* layout shows one catalog at a time as a poster wall behind a List chip. Collections that enable `showAllTab` also get an *All* view: every catalog paged together into one merged, de-duplicated grid.
- **Home Rows manager**: each collection row is toggleable/arrangeable like any row; each folder appears as a group ("Streaming › Netflix") with a switch per list. A catalog claimed by an enabled folder is folder-only: it no longer appears as a plain Home row and is listed under its folder instead of its addon. Turning the collection off returns those catalogs to the board.
- **Backup & Restore**: collections are included (`homeCollections`), merged by id on restore.

## Design notes

- **Model + parser** (`lib/models/home_collection.dart`): tolerant of the shapes seen in the wild (bare list, `{collections:[…]}`, single collection, bare folder list). `catalogSources` and `sources` are read and de-duplicated. Records without an id get a stable hash id so re-imports replace rather than duplicate. Unknown fields are ignored.
- **Storage** (`lib/services/home_collections_store.dart`): one JSON string under `home_collections_v1` via `ProfilePreferences`, same conventions as the other Home-row stores. Import merges by id and keeps the user's show/hide choice.
- **Addon resolution**: a source is matched to an installed catalog addon by manifest id, falling back to any installed addon serving the same `type` + `catalogId`, so a file authored against another deployment of the same addon still works. Unresolved sources are reported at import and in the folder's empty state; installing the addon later needs no re-import.
- **Board integration**: `HomeCollectionSection extends CatalogSection` (same pattern as `HomeListSection`), so collection rows ride the classic board, Spotlight, the TV stage layouts, focus bookkeeping, ordering and hiding without new threading. Folder tiles are synthetic `StremioMeta`s of type `folder`; the section dispatchers route their opens to the folder screen, and the hero pipeline skips them.
- **Folder screen**: rails reuse `SeeAllPosterGrid` in its existing shelf mode (`DiscoverShelfScope`), so paging, DPAD walking and card chrome are the Discover stage's own. Two small additive hooks were needed: `SeeAllPosterGrid.onExitBottom` (shelf DPAD-down to the next rail) and `CatalogSeeAllScreen.initialGenre`.
- **Merged "All" view** (`lib/services/collection_folder_loader.dart`): pages every catalog with bounded fan-out, interleaves round-robin, de-duplicates by meta id, and advances each source's `skip` by the addon's raw count.
- **Row-id grammar**: `collection:<id>` for a collection row (participates in `home_row_order_v1` / `home_disabled_sections_v1`); `collectionlist:<collection>:<folder>:<addon>:<type>:<catalog>[:<genre>]` for a folder's list (hide/show only, never arranged).

## Compatibility

- No changes to existing stored data or keys; the feature is inert until a collection is imported.
- Remote "Transfer Everything" (`ConfigCommand`) is intentionally not extended in this PR; Backup & Restore is.
- Method-channel names, application id and platform code are untouched.

## Testing

- `flutter analyze`: clean for all touched files (pre-existing vendored `packages/media_kit_*` diagnostics excluded).
- `flutter test test/home_collections_test.dart`: parser shapes and round-trip, id grammar, addon resolution (id and catalog fallback), claimed-catalog keys, layout preference parsing, merged-loader paging/dedup/exhaustion.
- Manual: Windows desktop and Android (Samsung, Android 16) with a 4-collection / 51-folder Xperience export — import from file and paste, Rows and Tabs layouts, All view, See All from a rail with genre, Home Rows toggles for collection rows and folder lists, folder-only catalogs leaving the board, backup export/restore.

## Documentation

`docs/collections.md` covers the file format, resolution rules, layouts and the Home Rows behaviour; `CODEMAP.md` gained a routing entry.

