### PR TITLE
Add "Hide watched titles" switch to Tracking settings

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -98,6 +98,11 @@ right code instead of re-discovering it. Flutter app; code under `lib/{screens,s
 ## Settings · storage · misc infra
 - Settings: `screens/settings/*` (+ `home_sections_filter_page.dart` = show/hide home rows,
   `home_page_settings_page.dart`). Metrics/format helpers: `utils/*`.
+- Hide watched (Settings › Tracking): `services/hide_watched_prefs.dart` (sync flag),
+  `services/watched_filter.dart` (predicate over `WatchedStatusService`),
+  `services/filtered_catalog_pager.dart` (`fetchFilteredPage` top-up paging). Wired in
+  `search_screen.dart` (`_fetchBoardBatch`, `_loadMoreRow`, catalog search, hero source),
+  `see_all/catalog_see_all_screen.dart`, `services/home_list_rows.dart`, Trakt/MDBList See-All.
 - Backup/transfer/sync: `services/backup_restore_service.dart` (full config snapshot),
   `widgets/remote/*` + `services/remote_control/*` (device-to-device over LAN, no server).
 - Onboarding: `widgets/initial_setup_flow.dart` 🔴. Migration: `services/app_migration_service.dart`.

--- a/docs/hide-watched.md
+++ b/docs/hide-watched.md
@@ -1,0 +1,88 @@
+# Hide watched titles
+
+Settings → **Tracking** → **Hide watched** → "Hide watched titles". Off by
+default, saved per profile, and included in Backup & Restore as `hide_watched`
+inside the tracking-preferences payload.
+
+When ON, movies you have finished and shows you have completed disappear from
+the catalog surfaces:
+
+- Home board rows (addon catalogs) and their horizontal paging
+- the Spotlight hero reel
+- catalog search results
+- See All grids and Discover's catalog source
+- Trakt's discovery lists (Trending, Popular, Anticipated, Recommendations) on
+  Home and in Discover / See All
+- MDBList public "top" lists on Home and the MDBList catalog browse
+
+Never hidden, because they are your own lists rather than catalogs:
+
+- Continue Watching (every provider)
+- My Watchlist and the Favorites rows
+- Trakt History, Watchlist, Collection, Ratings, your custom and liked lists
+- every Simkl list (Plan to Watch, Watching, Completed, …)
+- your own and liked MDBList lists
+- IPTV
+
+## What "watched" means
+
+The same answer that draws the ✓ on posters (`WatchedStatusService`): a union
+of what you finished in Debrify, your Trakt watched history, and Simkl and
+MDBList "completed", **masked by the Watched-ticks selection** on the same
+settings page. So the ✓ and the hiding always agree. For shows it means the
+whole show is finished (every aired episode locally, or fully watched on the
+tracker), never "saw one episode". Only movies and series with an IMDb id can
+be matched; anything else passes through.
+
+## Paging
+
+Filtering a page can leave it short or empty, so paged surfaces fetch through
+`fetchFilteredPage`, which keeps pulling windows until enough titles survive
+(default 12, at most 4 windows) and treats only a raw-empty window from the
+addon as the end of the catalog. Skip offsets advance by the addon's raw counts
+so paging stays aligned. With the switch off it is exactly one fetch, so
+nothing changes for anyone who leaves it off.
+
+## Timing
+
+Decisions are pinned at fetch time. Finishing a movie does not rip it out of a
+row you are looking at; it is gone on the next board load. On a cold start the
+board waits (at most 1.5 s) for the local watched snapshot before fetching, so
+the first paint is already filtered; tracker histories arrive asynchronously
+and apply from the next load.
+
+## Code
+
+| Piece | Where |
+|---|---|
+| Switch (sync cache, warmed in `main()` and on profile switch) | `lib/services/hide_watched_prefs.dart` |
+| Predicate over `WatchedStatusService` (`hides`, `apply`, `predicate`) | `lib/services/watched_filter.dart` |
+| Top-up pager (`fetchFilteredPage`) | `lib/services/filtered_catalog_pager.dart` |
+| Snapshot readiness (`hasSnapshot`, `firstSnapshot`) | `lib/services/watched_status_service.dart` |
+| Which Trakt lists filter (`TraktSeeAllList.hidesWatched`) | `lib/services/trakt/trakt_list_source.dart` |
+| Home board, row paging, hero reel, catalog search | `lib/screens/search_screen.dart` |
+| See All / Discover grids | `lib/screens/see_all/catalog_see_all_screen.dart` |
+| Trakt / MDBList rows and See All | `lib/services/home_list_rows.dart`, `lib/screens/see_all/{trakt,mdblist}_see_all_screen.dart` |
+| Settings toggle, search leaf, backup payload | `lib/screens/settings/tracking_settings_page.dart`, `lib/screens/settings_screen.dart`, `lib/services/storage_service.dart` |
+| Tests | `test/hide_watched_test.dart` |
+
+## Design decisions
+
+- **Watchlist rows are exempt.** Hiding titles from "my list" would make the
+  list lie about its contents; the switch is about catalogs the user browses.
+- **The Watched-ticks mask is reused** rather than a separate source
+  selection, so there is one mental model: the ✓ and the hiding use the same
+  histories. Swapping `isWatchedForTicks` for `isWatched` in `WatchedFilter`
+  would make the switch independent of ticks.
+- **Series threshold is "fully watched"**, inherited from the tick logic. A
+  "hide once started" variant would be a progress-based feature like the
+  Trakt See All watched/unwatched chip, not this switch.
+- **No live removal.** `WatchedStatusService` is a `ChangeNotifier`, so
+  re-running `WatchedFilter.apply` over the loaded sections on change would be
+  a small follow-up if immediacy is ever wanted.
+
+## Not yet covered
+
+Collection folders (the collections feature on its own branch) are not wired
+yet; the intended change is to run the folder loader through
+`fetchFilteredPage` in the same way.

--- a/docs/hide-watched.md
+++ b/docs/hide-watched.md
@@ -3,7 +3,8 @@
 Settings → **Tracking** → **Hide watched** → "Hide watched titles". Off by
 default, saved per profile, and included in Backup & Restore as `hide_watched`
 inside the tracking-preferences payload. WebDAV sync applies the setting to the
-active profile immediately, including refreshing the Home board.
+active profile immediately, including refreshing the Home board. Remote-control
+tracking-preferences pushes also refresh Home.
 
 When ON, movies you have finished and shows you have completed disappear from
 the catalog surfaces:
@@ -45,15 +46,17 @@ addon as the end of the catalog. Skip offsets advance by the addon's raw counts
 so paging stays aligned. Repeated items are deduplicated across the windows.
 If a batch has no visible titles but the addon has more, Home and See All show
 **Continue loading**. This resumes at the saved offset instead of restarting or
-marking the catalog exhausted. On Home, additional catalog rows load before
-paused rows are retried, so one watched-only source cannot block the rest of
-the board. MDBList also offers continuation when its filtered first page is
+marking the catalog exhausted. Home offers separate **Continue paused rows** and **Load more catalogs**
+actions, so paused rows can resume while more catalogs remain. TV action buttons
+retain focus while loading and ignore repeated presses until the batch finishes. MDBList also offers continuation when its filtered first page is
 empty and the provider returns a next cursor. A failed request without a raw count also keeps
-its cursor for retry. With the switch off each pager call makes one fetch.
+its cursor for retry. With the switch off each pager call makes one fetch and preserves legacy
+termination on empty or duplicate-only results, including failed empty fetches.
 
 Collection folders use their existing raw cursor pager with the same watched
 predicate. Their bounded empty-window budget and Retry action remain in place;
-watched-only windows never mark a folder source exhausted.
+watched-only windows never mark a folder source exhausted. Paused windows use
+“No new titles loaded · Continue”; only request failures say a list could not load.
 
 ## Timing
 
@@ -61,7 +64,8 @@ Decisions are pinned at fetch time. Finishing a movie does not rip it out of a
 row you are looking at; it is gone on the next board load. On a cold start the
 board waits (at most 1.5 s) for the local watched snapshot before fetching, so
 the first paint is already filtered; tracker histories arrive asynchronously
-and apply from the next load.
+and apply from the next load. Local snapshot reads retry transient failures up
+to three times; a failed first snapshot can retry on a later activation.
 
 ## Code
 

--- a/docs/hide-watched.md
+++ b/docs/hide-watched.md
@@ -45,7 +45,10 @@ addon as the end of the catalog. Skip offsets advance by the addon's raw counts
 so paging stays aligned. Repeated items are deduplicated across the windows.
 If a batch has no visible titles but the addon has more, Home and See All show
 **Continue loading**. This resumes at the saved offset instead of restarting or
-marking the catalog exhausted. A failed request without a raw count also keeps
+marking the catalog exhausted. On Home, additional catalog rows load before
+paused rows are retried, so one watched-only source cannot block the rest of
+the board. MDBList also offers continuation when its filtered first page is
+empty and the provider returns a next cursor. A failed request without a raw count also keeps
 its cursor for retry. With the switch off each pager call makes one fetch.
 
 Collection folders use their existing raw cursor pager with the same watched

--- a/docs/hide-watched.md
+++ b/docs/hide-watched.md
@@ -2,7 +2,8 @@
 
 Settings → **Tracking** → **Hide watched** → "Hide watched titles". Off by
 default, saved per profile, and included in Backup & Restore as `hide_watched`
-inside the tracking-preferences payload.
+inside the tracking-preferences payload. WebDAV sync applies the setting to the
+active profile immediately, including refreshing the Home board.
 
 When ON, movies you have finished and shows you have completed disappear from
 the catalog surfaces:
@@ -13,7 +14,8 @@ the catalog surfaces:
 - See All grids and Discover's catalog source
 - Trakt's discovery lists (Trending, Popular, Anticipated, Recommendations) on
   Home and in Discover / See All
-- MDBList public "top" lists on Home and the MDBList catalog browse
+- MDBList public lists on Home and in See All / Discover, recommendations, and catalog browse
+- Collection folder rails, tabs, and the merged All view
 
 Never hidden, because they are your own lists rather than catalogs:
 
@@ -40,8 +42,15 @@ Filtering a page can leave it short or empty, so paged surfaces fetch through
 `fetchFilteredPage`, which keeps pulling windows until enough titles survive
 (default 12, at most 4 windows) and treats only a raw-empty window from the
 addon as the end of the catalog. Skip offsets advance by the addon's raw counts
-so paging stays aligned. With the switch off it is exactly one fetch, so
-nothing changes for anyone who leaves it off.
+so paging stays aligned. Repeated items are deduplicated across the windows.
+If a batch has no visible titles but the addon has more, Home and See All show
+**Continue loading**. This resumes at the saved offset instead of restarting or
+marking the catalog exhausted. A failed request without a raw count also keeps
+its cursor for retry. With the switch off each pager call makes one fetch.
+
+Collection folders use their existing raw cursor pager with the same watched
+predicate. Their bounded empty-window budget and Retry action remain in place;
+watched-only windows never mark a folder source exhausted.
 
 ## Timing
 
@@ -64,7 +73,9 @@ and apply from the next load.
 | See All / Discover grids | `lib/screens/see_all/catalog_see_all_screen.dart` |
 | Trakt / MDBList rows and See All | `lib/services/home_list_rows.dart`, `lib/screens/see_all/{trakt,mdblist}_see_all_screen.dart` |
 | Settings toggle, search leaf, backup payload | `lib/screens/settings/tracking_settings_page.dart`, `lib/screens/settings_screen.dart`, `lib/services/storage_service.dart` |
-| Tests | `test/hide_watched_test.dart` |
+| Tests | `test/hide_watched_test.dart`, `test/hide_watched_surfaces_test.dart`, `test/filtered_catalog_pager_regression_test.dart` |
+| Collection filtering | `lib/services/collection_catalog_pager.dart`, `lib/services/collection_folder_loader.dart` |
+| WebDAV cache and Home refresh | `lib/services/webdav_sync/webdav_sync_active_profile_refresh.dart`, `lib/services/webdav_sync/webdav_sync_ui_refresh.dart` |
 
 ## Design decisions
 
@@ -80,9 +91,3 @@ and apply from the next load.
 - **No live removal.** `WatchedStatusService` is a `ChangeNotifier`, so
   re-running `WatchedFilter.apply` over the loaded sections on change would be
   a small follow-up if immediacy is ever wanted.
-
-## Not yet covered
-
-Collection folders (the collections feature on its own branch) are not wired
-yet; the intended change is to run the folder loader through
-`fetchFilteredPage` in the same way.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,6 +39,7 @@ import 'screens/playlist_screen.dart';
 import 'screens/addons_screen.dart';
 import 'services/android_native_downloader.dart';
 import 'services/discover_prefs.dart';
+import 'services/hide_watched_prefs.dart';
 import 'services/iptv_catalog_db.dart';
 import 'services/profiles/profile_bootstrap.dart';
 import 'services/profiles/profile_migration_service.dart';
@@ -709,6 +710,8 @@ Future<void> _continueApplicationStartup() async {
   // panels can read it synchronously in initState and paint already-sorted.
   // Cheap: SharedPreferences is already open by this point.
   await DiscoverPrefs.warmUp();
+  // Same for the hide-watched switch: the catalog filter reads it inline.
+  await HideWatchedPrefs.warmUp();
   // Old-playback-state cleanup is pure housekeeping — never block first frame
   // on a storage sweep (slow flash on TV boxes).
   unawaited(_cleanupPlaybackState());

--- a/lib/models/stremio_addon.dart
+++ b/lib/models/stremio_addon.dart
@@ -457,9 +457,11 @@ class CatalogSection {
   /// True while a page fetch is in flight (re-entrancy guard).
   bool loadingMore;
 
-  /// True once the addon stops returning new items (empty or all-duplicate
-  /// page), so we stop asking.
+  /// True once the catalog has ended, so we stop asking.
   bool exhausted;
+
+  /// A bounded fetch found no visible titles; the cursor can be resumed.
+  bool pagingPaused;
 
   /// The search query that produced these items, when this section is a
   /// per-catalog SEARCH result (Search tab) rather than a browsed catalog
@@ -476,6 +478,7 @@ class CatalogSection {
     int? nextSkip,
     this.loadingMore = false,
     this.exhausted = false,
+    this.pagingPaused = false,
     this.query,
   }) : nextSkip = nextSkip ?? items.length;
 

--- a/lib/screens/collections/collection_folder_screen.dart
+++ b/lib/screens/collections/collection_folder_screen.dart
@@ -9,6 +9,7 @@ import '../../models/stremio_addon.dart';
 import '../../services/analytics_service.dart';
 import '../../services/collection_folder_loader.dart';
 import '../../services/collection_catalog_pager.dart';
+import '../../services/watched_filter.dart';
 import '../../services/main_page_bridge.dart';
 import '../../services/home_collections_store.dart';
 import '../../services/storage_service.dart';
@@ -90,6 +91,7 @@ class _Rail {
       addon: addon,
       catalog: catalog,
       genre: source.genre,
+      hides: WatchedFilter.predicate,
       fetch: (a, c, {skip = 0, genre, onRawCount}) {
         final refresh = forceRefresh;
         forceRefresh = false;

--- a/lib/screens/collections/collection_folder_screen.dart
+++ b/lib/screens/collections/collection_folder_screen.dart
@@ -761,7 +761,9 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
                   focusNode: _retryNode,
                   onPressed: _retryCurrent,
                   icon: const Icon(Icons.refresh),
-                  label: const Text('Some lists could not load · Retry'),
+                  label: Text(_hasVisibleLoadFailure
+                      ? 'Some lists could not load · Retry'
+                      : 'No new titles loaded · Continue'),
                 ),
               ),
             Expanded(child: _buildBody()),
@@ -853,6 +855,15 @@ class _CollectionFolderScreenState extends State<CollectionFolderScreen> {
       isTelevision: widget.isTelevision,
     );
     return DiscoverShelfMetrics(cardHeight: posterW * 1.5, hPad: 24);
+  }
+
+  bool get _hasVisibleLoadFailure {
+    if (_showingAll) return _loader?.hasLoadFailures ?? false;
+    if (_tabs) {
+      final pager = _tabRail?.pager;
+      return pager != null && pager.error != null && !pager.noProgress;
+    }
+    return _rails.any((r) => r.error != null && !r.pager.noProgress);
   }
 
   bool get _hasVisibleLoadError {

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -2,6 +2,7 @@ import '../widgets/see_all/discover_browsing_input.dart';
 import '../services/home_catalog_refresh.dart';
 import '../services/home_load_deadline.dart';
 import '../widgets/home/home_row_focus.dart';
+import '../widgets/home/home_continuation_focus.dart';
 import '../services/home_row_refresh.dart';
 import '../services/profiles/connection_resource_service.dart';
 import 'dart:async';
@@ -687,6 +688,7 @@ class _SearchScreenState extends State<SearchScreen>
   // is currently shown (homepage OR per-addon catalog search results). Both the
   // board and catalog search render through the same horizontal-row layout.
   final _catalogContinueNode = FocusNode(debugLabel: 'catalog_continue');
+  FocusNode? _catalogReturnFocus;
   bool _catalogContinuing = false;
   int _catalogContinueCursor = 0;
   bool _loading = true;
@@ -7782,12 +7784,13 @@ class _SearchScreenState extends State<SearchScreen>
     final current = _resolveCanvasRailIndex(rails);
     final next = (current + delta).clamp(0, rails.length - 1);
     if (next == current) {
-      if (delta > 0 && _focusCatalogContinuation()) return;
       if (delta > 0 && _boardHasMore) {
         // Remember the move so it COMPLETES when the batch lands — otherwise
         // the keypress is silently eaten and the user has to press again.
         _deferStageAdvance(_canvasRailKeyOf(rails[current]));
         _loadMoreBoard();
+      } else if (delta > 0) {
+        _focusCatalogContinuation();
       }
       return;
     }
@@ -17629,8 +17632,21 @@ class _SearchScreenState extends State<SearchScreen>
 
   bool _focusCatalogContinuation() {
     if (!(_catalogContinueNode.context?.mounted ?? false)) return false;
+    final origin = FocusManager.instance.primaryFocus;
+    if (!identical(origin, _catalogContinueNode)) _catalogReturnFocus = origin;
     _catalogContinueNode.requestFocus();
     return true;
+  }
+
+  void _restoreCatalogContinuationFocus() {
+    if (focusMountedHomeNode([
+      _catalogReturnFocus,
+      _stageFocusTarget(),
+      for (final rail in _canvasRails) ..._canvasRailNodes(rail),
+    ])) {
+      return;
+    }
+    MainPageBridge.focusTvSidebar?.call();
   }
 
   Widget _buildBoard() {
@@ -17638,8 +17654,14 @@ class _SearchScreenState extends State<SearchScreen>
       for (var i = 0; i < _sections.length; i++)
         if (_sections[i].pagingPaused && !_sections[i].exhausted) i,
     ];
+    final hasMoreCatalogs = _boardHasMore;
+    final showContinuation =
+        pending.isNotEmpty ||
+        (hasMoreCatalogs && _sections.every((s) => s.items.isEmpty));
     final busy =
-        _catalogContinuing || pending.any((i) => _sections[i].loadingMore);
+        _catalogContinuing ||
+        _boardLoadingMore ||
+        pending.any((i) => _sections[i].loadingMore);
     return Column(
       children: [
         Expanded(
@@ -17652,25 +17674,23 @@ class _SearchScreenState extends State<SearchScreen>
                   !_anyFavVisible
               ? _message(
                   Icons.movie_filter_rounded,
-                  pending.isEmpty
+                  !showContinuation
                       ? 'No unwatched titles found'
                       : 'No new titles loaded yet',
-                  pending.isEmpty
+                  !showContinuation
                       ? 'Try another catalog or turn off Hide watched titles in Tracking settings.'
                       : 'Continue browsing to check more titles in these catalogs.',
                 )
               : _buildBoardContent(),
         ),
-        if (!_loading && pending.isNotEmpty)
+        if (!_loading && showContinuation)
           SafeArea(
             top: false,
             child: Focus(
               onKeyEvent: (_, event) {
                 if (event is KeyDownEvent &&
                     event.logicalKey == LogicalKeyboardKey.arrowUp) {
-                  if (!_focusHomeRailAt(0, 0)) {
-                    MainPageBridge.focusTvSidebar?.call();
-                  }
+                  _restoreCatalogContinuationFocus();
                   return KeyEventResult.handled;
                 }
                 return KeyEventResult.ignored;
@@ -17682,21 +17702,29 @@ class _SearchScreenState extends State<SearchScreen>
                     ? null
                     : () async {
                         final gen = _boardLoadGen;
-                        final offset = _catalogContinueCursor % pending.length;
-                        final batch = [
-                          ...pending.skip(offset),
-                          ...pending.take(offset),
-                        ].take(4).map((i) => _sections[i]).toList();
-                        _catalogContinueCursor =
-                            (offset + batch.length) % pending.length;
+                        final wasEmpty = _sections.every(
+                          (s) => s.items.isEmpty,
+                        );
                         setState(() => _catalogContinuing = true);
                         try {
-                          // Rotate bounded batches so a faulty addon cannot
-                          // strand the catalogs behind it.
-                          for (final section in batch) {
-                            if (!mounted || gen != _boardLoadGen) return;
-                            final i = _sections.indexOf(section);
-                            if (i >= 0) await _loadMoreRow(i, resume: true);
+                          // Vertical paging must remain independent of a
+                          // watched-only or failing row already on the board.
+                          if (_boardHasMore) {
+                            await _loadMoreBoard();
+                          } else if (pending.isNotEmpty) {
+                            final offset =
+                                _catalogContinueCursor % pending.length;
+                            final batch = [
+                              ...pending.skip(offset),
+                              ...pending.take(offset),
+                            ].take(4).map((i) => _sections[i]).toList();
+                            _catalogContinueCursor =
+                                (offset + batch.length) % pending.length;
+                            for (final section in batch) {
+                              if (!mounted || gen != _boardLoadGen) return;
+                              final i = _sections.indexOf(section);
+                              if (i >= 0) await _loadMoreRow(i, resume: true);
+                            }
                           }
                         } finally {
                           if (mounted) {
@@ -17706,12 +17734,13 @@ class _SearchScreenState extends State<SearchScreen>
                         if (mounted && gen == _boardLoadGen) {
                           WidgetsBinding.instance.addPostFrameCallback((_) {
                             if (!mounted || gen != _boardLoadGen) return;
-                            if (!_sections.any(
-                              (s) => s.pagingPaused && !s.exhausted,
-                            )) {
-                              if (!_focusHomeRailAt(0, 0)) {
-                                MainPageBridge.focusTvSidebar?.call();
-                              }
+                            if ((wasEmpty &&
+                                    _sections.any((s) => s.items.isNotEmpty)) ||
+                                (!_boardHasMore &&
+                                    !_sections.any(
+                                      (s) => s.pagingPaused && !s.exhausted,
+                                    ))) {
+                              _restoreCatalogContinuationFocus();
                             }
                           });
                         }

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -686,6 +686,9 @@ class _SearchScreenState extends State<SearchScreen>
   // Board state. [_homeSections] is the homepage cache; [_sections] is whatever
   // is currently shown (homepage OR per-addon catalog search results). Both the
   // board and catalog search render through the same horizontal-row layout.
+  final _catalogContinueNode = FocusNode(debugLabel: 'catalog_continue');
+  bool _catalogContinuing = false;
+  int _catalogContinueCursor = 0;
   bool _loading = true;
   String? _error;
   List<CatalogSection> _homeSections = [];
@@ -2142,6 +2145,7 @@ class _SearchScreenState extends State<SearchScreen>
 
   @override
   void dispose() {
+    _catalogContinueNode.dispose();
     WidgetsBinding.instance.removeObserver(this);
     _mdblistRevisionRefreshToken++;
     _spotlightHeroNode.dispose();
@@ -2841,24 +2845,10 @@ class _SearchScreenState extends State<SearchScreen>
             catalog: catalog,
             previous: previousRows[_catalogRefRowId(ref)],
             isCurrent: () => mounted && gen == _boardLoadGen,
-            fetch: (skip, onRawCount) async {
-              // Preserve the refresh loader's raw extent across every window
-              // consumed while topping up the filtered row.
-              final page = await fetchFilteredPage(
-                (cursor, onRaw) {
-                  if (!mounted || gen != _boardLoadGen) {
-                    return Future.value(const <StremioMeta>[]);
-                  }
-                  return _stremio.fetchCatalog(
-                    addon, catalog, skip: cursor, onRawCount: onRaw,
-                  );
-                },
-                skip: skip,
-                hides: WatchedFilter.predicate,
-              );
-              onRawCount(page.nextSkip - skip);
-              return page.items;
-            },
+            hides: WatchedFilter.predicate,
+            fetch: (skip, onRawCount) => _stremio.fetchCatalog(
+              addon, catalog, skip: skip, onRawCount: onRawCount,
+            ),
           );
         } catch (_) {
           return null;
@@ -2954,12 +2944,13 @@ class _SearchScreenState extends State<SearchScreen>
   /// board rows paginate; search-result rows are single-shot. Safe to call
   /// repeatedly — [CatalogSection.loadingMore]/[CatalogSection.exhausted] guard
   /// re-entrancy and the end of the catalog.
-  Future<void> _loadMoreRow(int rowIndex) async {
+  Future<void> _loadMoreRow(int rowIndex, {bool resume = false}) async {
     // While a catalog search is active, `_sections` holds search results, which
     // don't paginate — leave them alone.
     if (_catalogQuery.isNotEmpty || _catalogSearching) return;
     if (rowIndex < 0 || rowIndex >= _sections.length) return;
     final section = _sections[rowIndex];
+    if (section.pagingPaused && !resume) return;
     if (section.loadingMore || section.exhausted) return;
     // Android TV: flip the guard silently. The setState exists to show the
     // classic row's tail spinner, but it fires on the exact keypress that
@@ -2967,7 +2958,7 @@ class _SearchScreenState extends State<SearchScreen>
     // input frame, which an Amlogic box renders as the cursor hitching every
     // time a row pages. The spinner is a nicety; the page landing repaints
     // either way.
-    if (PlatformUtil.isAndroidTvCached) {
+    if (PlatformUtil.isAndroidTvCached && !resume) {
       section.loadingMore = true;
     } else {
       setState(() => section.loadingMore = true);
@@ -2999,11 +2990,8 @@ class _SearchScreenState extends State<SearchScreen>
       section.nextSkip = page.nextSkip;
       if (page.exhausted) section.exhausted = true;
       final fresh = page.items;
-      if (fresh.isEmpty) {
-        // Only duplicates, or the addon ignores skip — end of the row.
-        section.exhausted = true;
-        return;
-      }
+      section.pagingPaused = fresh.isEmpty && !page.exhausted;
+      if (fresh.isEmpty) return;
       // Grow this row's focus nodes in lockstep with the new items.
       final nodes = _rowNodes[rowIndex];
       final base = nodes.length;
@@ -3550,6 +3538,7 @@ class _SearchScreenState extends State<SearchScreen>
     String? homeRowId,
     required int column,
   }) {
+    if (_focusCatalogContinuation()) return;
     _pendingDownOrigin = FocusManager.instance.primaryFocus;
     if (_pendingDownOrigin == null) return;
     _pendingDownRowIndex = rowIndex;
@@ -7793,6 +7782,7 @@ class _SearchScreenState extends State<SearchScreen>
     final current = _resolveCanvasRailIndex(rails);
     final next = (current + delta).clamp(0, rails.length - 1);
     if (next == current) {
+      if (delta > 0 && _focusCatalogContinuation()) return;
       if (delta > 0 && _boardHasMore) {
         // Remember the move so it COMPLETES when the batch lands — otherwise
         // the keypress is silently eaten and the user has to press again.
@@ -17637,7 +17627,105 @@ class _SearchScreenState extends State<SearchScreen>
     );
   }
 
+  bool _focusCatalogContinuation() {
+    if (!(_catalogContinueNode.context?.mounted ?? false)) return false;
+    _catalogContinueNode.requestFocus();
+    return true;
+  }
+
   Widget _buildBoard() {
+    final pending = [
+      for (var i = 0; i < _sections.length; i++)
+        if (_sections[i].pagingPaused && !_sections[i].exhausted) i,
+    ];
+    final busy =
+        _catalogContinuing || pending.any((i) => _sections[i].loadingMore);
+    return Column(
+      children: [
+        Expanded(
+          child:
+              !_loading &&
+                  _error == null &&
+                  _sections.isNotEmpty &&
+                  _sections.every((s) => s.items.isEmpty) &&
+                  !_cwVisible &&
+                  !_anyFavVisible
+              ? _message(
+                  Icons.movie_filter_rounded,
+                  pending.isEmpty
+                      ? 'No unwatched titles found'
+                      : 'No new titles loaded yet',
+                  pending.isEmpty
+                      ? 'Try another catalog or turn off Hide watched titles in Tracking settings.'
+                      : 'Continue browsing to check more titles in these catalogs.',
+                )
+              : _buildBoardContent(),
+        ),
+        if (!_loading && pending.isNotEmpty)
+          SafeArea(
+            top: false,
+            child: Focus(
+              onKeyEvent: (_, event) {
+                if (event is KeyDownEvent &&
+                    event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                  if (!_focusHomeRailAt(0, 0)) {
+                    MainPageBridge.focusTvSidebar?.call();
+                  }
+                  return KeyEventResult.handled;
+                }
+                return KeyEventResult.ignored;
+              },
+              child: TextButton.icon(
+                focusNode: _catalogContinueNode,
+                autofocus: _sections.every((s) => s.items.isEmpty),
+                onPressed: busy
+                    ? null
+                    : () async {
+                        final gen = _boardLoadGen;
+                        final offset = _catalogContinueCursor % pending.length;
+                        final batch = [
+                          ...pending.skip(offset),
+                          ...pending.take(offset),
+                        ].take(4).map((i) => _sections[i]).toList();
+                        _catalogContinueCursor =
+                            (offset + batch.length) % pending.length;
+                        setState(() => _catalogContinuing = true);
+                        try {
+                          // Rotate bounded batches so a faulty addon cannot
+                          // strand the catalogs behind it.
+                          for (final section in batch) {
+                            if (!mounted || gen != _boardLoadGen) return;
+                            final i = _sections.indexOf(section);
+                            if (i >= 0) await _loadMoreRow(i, resume: true);
+                          }
+                        } finally {
+                          if (mounted) {
+                            setState(() => _catalogContinuing = false);
+                          }
+                        }
+                        if (mounted && gen == _boardLoadGen) {
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
+                            if (!mounted || gen != _boardLoadGen) return;
+                            if (!_sections.any(
+                              (s) => s.pagingPaused && !s.exhausted,
+                            )) {
+                              if (!_focusHomeRailAt(0, 0)) {
+                                MainPageBridge.focusTvSidebar?.call();
+                              }
+                            }
+                          });
+                        }
+                      },
+                icon: const Icon(Icons.arrow_forward_rounded),
+                label: Text(busy ? 'Loading…' : 'Continue loading catalogs'),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildBoardContent() {
     if (_loading) {
       // The brand moment: DEBRIFY centred on the ink while catalogs load —
       // replaces the old skeleton-rail wall, which read as a broken app.
@@ -18439,6 +18527,9 @@ class _SearchScreenState extends State<SearchScreen>
     } else if (section.isMdblist) {
       screen = MdblistSeeAllScreen(
         initialList: section.mdblistList,
+        initialListIsPublic: section.rowId.startsWith(
+          HomeExtraRowIds.mdblistTopPrefix,
+        ),
         onOpen: (item) => _openItem(
           item,
           _addonForContinue(item.sourceAddon?.id),

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -6194,7 +6194,9 @@ class _SearchScreenState extends State<SearchScreen>
   /// [_focusCwRow], so DPAD wiring can defer the move instead of eating it.
   bool _focusRow(int row, int column) {
     if (row >= _rowNodes.length) {
-      // DPAD-down past the last loaded row on TV: pull the next board batch.
+      // Reach visible actions before starting another batch. When no action
+      // is mounted, retain the existing deferred move into the next row.
+      if (!_boardLoadingMore && _focusCatalogContinuation()) return true;
       if (_boardHasMore) _loadMoreBoard();
       return false;
     }
@@ -7637,6 +7639,7 @@ class _SearchScreenState extends State<SearchScreen>
       _leaveBoardTop();
       return;
     }
+    if (!_boardLoadingMore && _focusCatalogContinuation()) return;
     if (_boardHasMore) _loadMoreBoard();
     _deferDownMove(homeRowId: rowId, column: column);
   }
@@ -7787,6 +7790,9 @@ class _SearchScreenState extends State<SearchScreen>
     final current = _resolveCanvasRailIndex(rails);
     final next = (current + delta).clamp(0, rails.length - 1);
     if (next == current) {
+      if (delta > 0 && !_boardLoadingMore && _focusCatalogContinuation()) {
+        return;
+      }
       if (delta > 0 && _boardHasMore) {
         // Remember the move so it COMPLETES when the batch lands — otherwise
         // the keypress is silently eaten and the user has to press again.

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -3,6 +3,7 @@ import '../services/home_catalog_refresh.dart';
 import '../services/home_load_deadline.dart';
 import '../widgets/home/home_row_focus.dart';
 import '../widgets/home/home_continuation_focus.dart';
+import '../widgets/home/catalog_continuation_button.dart';
 import '../services/home_row_refresh.dart';
 import '../services/profiles/connection_resource_service.dart';
 import 'dart:async';
@@ -688,6 +689,7 @@ class _SearchScreenState extends State<SearchScreen>
   // is currently shown (homepage OR per-addon catalog search results). Both the
   // board and catalog search render through the same horizontal-row layout.
   final _catalogContinueNode = FocusNode(debugLabel: 'catalog_continue');
+  final _catalogMoreNode = FocusNode(debugLabel: 'catalog_more');
   FocusNode? _catalogReturnFocus;
   bool _catalogContinuing = false;
   int _catalogContinueCursor = 0;
@@ -2148,6 +2150,7 @@ class _SearchScreenState extends State<SearchScreen>
   @override
   void dispose() {
     _catalogContinueNode.dispose();
+    _catalogMoreNode.dispose();
     WidgetsBinding.instance.removeObserver(this);
     _mdblistRevisionRefreshToken++;
     _spotlightHeroNode.dispose();
@@ -3540,7 +3543,7 @@ class _SearchScreenState extends State<SearchScreen>
     String? homeRowId,
     required int column,
   }) {
-    if (_focusCatalogContinuation()) return;
+    if (!_boardHasMore && !_boardLoadingMore && _focusCatalogContinuation()) return;
     _pendingDownOrigin = FocusManager.instance.primaryFocus;
     if (_pendingDownOrigin == null) return;
     _pendingDownRowIndex = rowIndex;
@@ -17631,10 +17634,15 @@ class _SearchScreenState extends State<SearchScreen>
   }
 
   bool _focusCatalogContinuation() {
-    if (!(_catalogContinueNode.context?.mounted ?? false)) return false;
+    final target = [_catalogContinueNode, _catalogMoreNode]
+        .where(
+          (node) => node.parent != null && (node.context?.mounted ?? false),
+        )
+        .firstOrNull;
+    if (target == null) return false;
     final origin = FocusManager.instance.primaryFocus;
-    if (!identical(origin, _catalogContinueNode)) _catalogReturnFocus = origin;
-    _catalogContinueNode.requestFocus();
+    if (!identical(origin, target)) _catalogReturnFocus = origin;
+    target.requestFocus();
     return true;
   }
 
@@ -17647,6 +17655,51 @@ class _SearchScreenState extends State<SearchScreen>
       return;
     }
     MainPageBridge.focusTvSidebar?.call();
+  }
+
+  Future<void> _continueHomeCatalogs({required bool moreCatalogs}) async {
+    if (_catalogContinuing || _boardLoadingMore) return;
+    final pending = _sections
+        .where((s) => s.pagingPaused && !s.exhausted)
+        .toList();
+    if (pending.any((s) => s.loadingMore)) return;
+    final gen = _boardLoadGen;
+    final actionNode = moreCatalogs ? _catalogMoreNode : _catalogContinueNode;
+    final ownedFocus = actionNode.hasFocus;
+    setState(() => _catalogContinuing = true);
+    try {
+      if (moreCatalogs) {
+        if (_boardHasMore) await _loadMoreBoard();
+      } else if (pending.isNotEmpty) {
+        final offset = _catalogContinueCursor % pending.length;
+        final batch = [
+          ...pending.skip(offset),
+          ...pending.take(offset),
+        ].take(4);
+        _catalogContinueCursor = (offset + 4) % pending.length;
+        for (final section in batch) {
+          if (!mounted || gen != _boardLoadGen) return;
+          final i = _sections.indexOf(section);
+          if (i >= 0) await _loadMoreRow(i, resume: true);
+        }
+      }
+    } finally {
+      if (mounted) setState(() => _catalogContinuing = false);
+      if (mounted && gen == _boardLoadGen && ownedFocus) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted || gen != _boardLoadGen) return;
+          // Busy buttons retain focus. Restore only when the completed action
+          // disappeared, and do not override a user's move to another card.
+          if (actionNode.parent != null &&
+              (actionNode.context?.mounted ?? false)) {
+            return;
+          }
+          final focused = FocusManager.instance.primaryFocus;
+          if (focused != null && focused is! FocusScopeNode) return;
+          _restoreCatalogContinuationFocus();
+        });
+      }
+    }
   }
 
   Widget _buildBoard() {
@@ -17695,58 +17748,30 @@ class _SearchScreenState extends State<SearchScreen>
                 }
                 return KeyEventResult.ignored;
               },
-              child: TextButton.icon(
-                focusNode: _catalogContinueNode,
-                autofocus: _sections.every((s) => s.items.isEmpty),
-                onPressed: busy
-                    ? null
-                    : () async {
-                        final gen = _boardLoadGen;
-                        final wasEmpty = _sections.every(
-                          (s) => s.items.isEmpty,
-                        );
-                        setState(() => _catalogContinuing = true);
-                        try {
-                          // Vertical paging must remain independent of a
-                          // watched-only or failing row already on the board.
-                          if (_boardHasMore) {
-                            await _loadMoreBoard();
-                          } else if (pending.isNotEmpty) {
-                            final offset =
-                                _catalogContinueCursor % pending.length;
-                            final batch = [
-                              ...pending.skip(offset),
-                              ...pending.take(offset),
-                            ].take(4).map((i) => _sections[i]).toList();
-                            _catalogContinueCursor =
-                                (offset + batch.length) % pending.length;
-                            for (final section in batch) {
-                              if (!mounted || gen != _boardLoadGen) return;
-                              final i = _sections.indexOf(section);
-                              if (i >= 0) await _loadMoreRow(i, resume: true);
-                            }
-                          }
-                        } finally {
-                          if (mounted) {
-                            setState(() => _catalogContinuing = false);
-                          }
-                        }
-                        if (mounted && gen == _boardLoadGen) {
-                          WidgetsBinding.instance.addPostFrameCallback((_) {
-                            if (!mounted || gen != _boardLoadGen) return;
-                            if ((wasEmpty &&
-                                    _sections.any((s) => s.items.isNotEmpty)) ||
-                                (!_boardHasMore &&
-                                    !_sections.any(
-                                      (s) => s.pagingPaused && !s.exhausted,
-                                    ))) {
-                              _restoreCatalogContinuationFocus();
-                            }
-                          });
-                        }
-                      },
-                icon: const Icon(Icons.arrow_forward_rounded),
-                label: Text(busy ? 'Loading…' : 'Continue loading catalogs'),
+              child: Wrap(
+                alignment: WrapAlignment.center,
+                children: [
+                  if (pending.isNotEmpty)
+                    CatalogContinuationButton(
+                      focusNode: _catalogContinueNode,
+                      autofocus: _sections.every((s) => s.items.isEmpty),
+                      busy: busy,
+                      label: 'Continue paused rows',
+                      onPressed: () =>
+                          _continueHomeCatalogs(moreCatalogs: false),
+                    ),
+                  if (hasMoreCatalogs)
+                    CatalogContinuationButton(
+                      focusNode: _catalogMoreNode,
+                      autofocus:
+                          pending.isEmpty &&
+                          _sections.every((s) => s.items.isEmpty),
+                      busy: busy,
+                      label: 'Load more catalogs',
+                      onPressed: () =>
+                          _continueHomeCatalogs(moreCatalogs: true),
+                    ),
+                ],
               ),
             ),
           ),

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -30,6 +30,10 @@ import '../services/engine/settings_manager.dart';
 import '../services/episode_artwork_service.dart';
 import '../services/home_list_rows.dart';
 import '../services/home_row_order.dart';
+import '../services/filtered_catalog_pager.dart';
+import '../services/hide_watched_prefs.dart';
+import '../services/watched_filter.dart';
+import '../services/watched_status_service.dart';
 import '../services/iptv_cw_router.dart';
 import '../services/iptv_media_store.dart';
 import '../services/local_bound_source_service.dart';
@@ -703,6 +707,10 @@ class _SearchScreenState extends State<SearchScreen>
   // of the board in [_load]; `iptvlist:` ids drive the IPTV list favourites
   // rows. Refreshed by [_reloadForHomeSettings].
   List<HomeExtraRow> _homeExtras = const [];
+
+  /// The hide-watched switch as of the last board load. Flipping it changes
+  /// row membership, so [_reloadForHomeSettings] diffs it like a row toggle.
+  bool _hideWatched = HideWatchedPrefs.enabled;
 
   /// Stable ids in the user's global Home-row order. Rows not present append
   /// canonically; ids whose backing row is temporarily unavailable stay saved.
@@ -2448,6 +2456,8 @@ class _SearchScreenState extends State<SearchScreen>
     final rowOrder = await StorageService.getHomeRowOrder();
     final heroSource = await StorageService.getHomeHeroSource();
     if (!mounted) return;
+    final hideWatched = HideWatchedPrefs.enabled;
+    final hideWatchedUnchanged = hideWatched == _hideWatched;
     final disabledUnchanged =
         disabled.length == _homeDisabled.length &&
         disabled.containsAll(_homeDisabled);
@@ -2482,7 +2492,8 @@ class _SearchScreenState extends State<SearchScreen>
         boardExtrasUnchanged &&
         iptvExtrasUnchanged &&
         rowOrderUnchanged &&
-        heroSourceUnchanged) {
+        heroSourceUnchanged &&
+        hideWatchedUnchanged) {
       return;
     }
     setState(() {
@@ -2490,9 +2501,12 @@ class _SearchScreenState extends State<SearchScreen>
       _homeExtras = extras;
       _homeRowOrder = rowOrder;
       _heroSource = heroSource;
+      _hideWatched = hideWatched;
     });
+    // Hide-watched changes row MEMBERSHIP, so it takes the full reload path.
     if (!disabledUnchanged ||
         !boardExtrasUnchanged ||
+        !hideWatchedUnchanged ||
         (!rowOrderUnchanged && !widget.searchMode && !widget.discoverMode)) {
       _requestBoardReload();
     } else if (!heroSourceUnchanged &&
@@ -2559,6 +2573,7 @@ class _SearchScreenState extends State<SearchScreen>
       _homeExtras = extras;
       _homeRowOrder = rowOrder;
       _heroSource = heroSource;
+      _hideWatched = HideWatchedPrefs.enabled;
       // Opt-in Trakt/Simkl list rows, resolved IN PARALLEL with the first
       // catalog batch below. Home board only — the Search tab runs _load just
       // to warm the catalog refs for its search, and Discover never comes
@@ -2575,6 +2590,18 @@ class _SearchScreenState extends State<SearchScreen>
           : HomeListRowsService.instance
                 .resolve(_homeExtras, deadline: const Duration(seconds: 5))
                 .catchError((_) => const <HomeListSection>[]);
+      // With hide-watched on, wait briefly for the local watched snapshot so
+      // the first rows paint already filtered instead of losing titles a beat
+      // later. Tracker histories fold in asynchronously and apply from the
+      // next load; the timeout keeps a slow disk from stalling first paint.
+      if (HideWatchedPrefs.enabled) {
+        WatchedStatusService.instance.ensureStarted();
+        await WatchedStatusService.instance.firstSnapshot.timeout(
+          const Duration(milliseconds: 1500),
+          onTimeout: () {},
+        );
+        if (!mounted || gen != _boardLoadGen) return;
+      }
       final addons = await _stremio.getCatalogAddons();
       if (!mounted || gen != _boardLoadGen) return;
       // Enumerate every BROWSABLE catalog across all addons — no global row cap.
@@ -2676,22 +2703,29 @@ class _SearchScreenState extends State<SearchScreen>
       slice.map((ref) async {
         final (addon, catalog) = ref;
         try {
-          var rawCount = 0;
-          final items = await _stremio.fetchCatalog(
-            addon,
-            catalog,
-            onRawCount: (c) => rawCount = c,
+          // With hide-watched on, the pager tops the row up across windows so
+          // an all-watched first page doesn't read as an empty catalog.
+          final page = await fetchFilteredPage(
+            (skip, onRaw) => _stremio.fetchCatalog(
+              addon,
+              catalog,
+              skip: skip,
+              onRawCount: onRaw,
+            ),
+            skip: 0,
+            hides: WatchedFilter.predicate,
           );
-          if (items.isEmpty) return null;
+          if (page.items.isEmpty) return null;
           return CatalogSection(
             title: CatalogSection.rowTitle(catalog),
             addon: addon,
             catalog: catalog,
             // Keep the whole first page; more pages stream in on horizontal scroll.
-            items: items.toList(),
-            // Next page starts past the addon's raw first window (not the smaller
-            // post-filter count), keeping paging aligned from the very first fetch.
-            nextSkip: rawCount > 0 ? rawCount : items.length,
+            items: page.items.toList(),
+            // Past the addon's raw window(s), not the post-filter count, so
+            // paging is aligned from the very first fetch.
+            nextSkip: page.nextSkip,
+            exhausted: page.exhausted,
           );
         } catch (_) {
           return null;
@@ -2800,15 +2834,22 @@ class _SearchScreenState extends State<SearchScreen>
       setState(() => section.loadingMore = true);
     }
     try {
-      // Advance `skip` by the addon's RAW returned count (via onRawCount), not
-      // the post-filter `page.length`, so we stay aligned with the addon's own
-      // paging window and don't slowly under-advance into a false "exhausted".
-      var rawCount = 0;
-      final page = await _stremio.fetchCatalog(
-        section.addon,
-        section.catalog,
+      // Dedup against what we already have: some addons return valid ids but
+      // repeat entries, and some ignore `skip` entirely. The pager advances
+      // `skip` by the addon's RAW counts so paging never under-advances into a
+      // false "exhausted", and with hide-watched on it tops the window up so a
+      // page of watched titles doesn't end the row early.
+      final seen = section.items.map((m) => m.id).toSet();
+      final page = await fetchFilteredPage(
+        (skip, onRaw) => _stremio.fetchCatalog(
+          section.addon,
+          section.catalog,
+          skip: skip,
+          onRawCount: onRaw,
+        ),
         skip: section.nextSkip,
-        onRawCount: (c) => rawCount = c,
+        hides: WatchedFilter.predicate,
+        seenIds: seen,
       );
       if (!mounted) return;
       // The row may have been swapped out (a search started) while in flight.
@@ -2816,20 +2857,11 @@ class _SearchScreenState extends State<SearchScreen>
           !identical(_sections[rowIndex], section)) {
         return;
       }
-      if (page.isEmpty) {
-        section.exhausted = true;
-        return;
-      }
-      // Dedup against what we already have; some addons return valid ids but
-      // repeat entries, and some ignore `skip` entirely.
-      final seen = section.items.map((m) => m.id).toSet();
-      final fresh = page.where((m) => seen.add(m.id)).toList();
-      // Advance by the raw window size (falls back to the filtered count only
-      // if the addon somehow didn't report), so the next skip lands past what
-      // this window already covered.
-      section.nextSkip += rawCount > 0 ? rawCount : page.length;
+      section.nextSkip = page.nextSkip;
+      if (page.exhausted) section.exhausted = true;
+      final fresh = page.items;
       if (fresh.isEmpty) {
-        // Addon returned only duplicates (or ignores skip) — nothing new to add.
+        // Only duplicates, or the addon ignores skip — end of the row.
         section.exhausted = true;
         return;
       }
@@ -5458,6 +5490,9 @@ class _SearchScreenState extends State<SearchScreen>
           return null;
         }
         if (!mounted || token != _catalogSearchToken) return null;
+        // Search rows are single-shot (no top-up): a match that's been
+        // watched simply doesn't show.
+        items = WatchedFilter.apply(items);
         if (items.isEmpty) return null;
         final section = CatalogSection(
           title: CatalogSection.rowTitle(entry.catalog),
@@ -6709,21 +6744,26 @@ class _SearchScreenState extends State<SearchScreen>
         if (attempts++ >= maxAttempts) break;
         if (!mounted || gen != _heroSourceResolveGen) return;
         try {
-          var rawCount = 0;
-          final items = await _stremio.fetchCatalog(
-            addon,
-            catalog,
-            onRawCount: (c) => rawCount = c,
+          final page = await fetchFilteredPage(
+            (skip, onRaw) => _stremio.fetchCatalog(
+              addon,
+              catalog,
+              skip: skip,
+              onRawCount: onRaw,
+            ),
+            skip: 0,
+            hides: WatchedFilter.predicate,
+            minItems: 8,
           );
           if (!mounted || gen != _heroSourceResolveGen) return;
-          if (items.isEmpty) continue;
+          if (page.items.isEmpty) continue;
           setState(() {
             _spotlightHeroOverride = CatalogSection(
               title: CatalogSection.rowTitle(catalog),
               addon: addon,
               catalog: catalog,
-              items: items.toList(),
-              nextSkip: rawCount > 0 ? rawCount : items.length,
+              items: page.items.toList(),
+              nextSkip: page.nextSkip,
             );
           });
           _publishTopShelfSpotlight();

--- a/lib/screens/see_all/catalog_see_all_screen.dart
+++ b/lib/screens/see_all/catalog_see_all_screen.dart
@@ -31,6 +31,9 @@ import '../../widgets/see_all/stremio_dropdown.dart';
 /// `extra`. The addon itself is fixed to the originating rail.
 class CatalogSeeAllScreen extends StatefulWidget {
   final StremioAddon addon;
+
+  /// Optional catalog transport for deterministic pagination tests.
+  final PageFetch? fetchPage;
   final StremioAddonCatalog initialCatalog;
 
   /// When set, this See-All is a SEARCH result: reload / load-more query the
@@ -75,6 +78,7 @@ class CatalogSeeAllScreen extends StatefulWidget {
   const CatalogSeeAllScreen({
     super.key,
     required this.addon,
+    this.fetchPage,
     required this.initialCatalog,
     required this.onOpenItem,
     this.query,
@@ -121,6 +125,7 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
   bool _loadingInitial = true;
   bool _loadingMore = false;
   bool _exhausted = false;
+  bool _pagingPaused = false;
 
   // Random (Discover): true while the random-page probe is in flight — the
   // button shows a spinner and further presses are ignored.
@@ -162,8 +167,9 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
         _sort = saved!;
       }
     }
-    if (widget.seedItems.isNotEmpty) {
-      _items.addAll(widget.seedItems);
+    if (widget.seedItems.isNotEmpty || widget.seedNextSkip > 0) {
+      _items.addAll(WatchedFilter.apply(widget.seedItems));
+      _pagingPaused = _items.isEmpty;
       _nextSkip = widget.seedNextSkip;
       _loadingInitial = false;
       // Embedded (Discover): the host focuses the Source dropdown; a source swap
@@ -238,6 +244,8 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
     int skip,
     void Function(int rawCount) onRawCount,
   ) {
+    final fetch = widget.fetchPage;
+    if (fetch != null) return fetch(skip, onRawCount);
     if (_searching) {
       return _stremio.searchSingleCatalog(
         widget.addon,
@@ -267,6 +275,7 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
       _items.clear();
       _nextSkip = 0;
       _exhausted = false;
+      _pagingPaused = false;
       _loadingMore = false;
     });
     try {
@@ -280,6 +289,7 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
         _items.addAll(page.items);
         _nextSkip = page.nextSkip;
         _exhausted = page.exhausted;
+        _pagingPaused = !page.exhausted && page.items.isEmpty;
         _loadingInitial = false;
       });
       if (autoFocus && widget.isTelevision && page.items.isNotEmpty) {
@@ -296,7 +306,8 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
     }
   }
 
-  Future<void> _loadMore() async {
+  Future<void> _loadMore({bool resume = false}) async {
+    if (_pagingPaused && !resume) return;
     if (_loadingInitial || _loadingMore || _exhausted) return;
     final token = _reqToken;
     setState(() => _loadingMore = true);
@@ -312,11 +323,15 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
       setState(() {
         _nextSkip = page.nextSkip;
         _items.addAll(page.items);
-        // Nothing new (only duplicates, or the addon ignores skip) also ends
-        // the grid.
-        _exhausted = page.exhausted || page.items.isEmpty;
+        _exhausted = page.exhausted;
+        _pagingPaused = !page.exhausted && page.items.isEmpty;
         _loadingMore = false;
       });
+      if (resume && widget.isTelevision && page.items.isNotEmpty) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) _gridKey.currentState?.focusFirst();
+        });
+      }
     } catch (_) {
       if (!mounted || token != _reqToken) return;
       setState(() => _loadingMore = false);
@@ -348,7 +363,9 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
     StremioMeta? pick;
     try {
       for (final depth in const [400, 60]) {
-        final page = await _fetchPage(_random.nextInt(depth), (_) {});
+        final page = WatchedFilter.apply(
+          await _fetchPage(_random.nextInt(depth), (_) {}),
+        );
         // A filter changed mid-probe — the page (and any fallback below) no
         // longer matches what's on screen, so drop the press entirely.
         if (!mounted || token != _reqToken) return;
@@ -611,7 +628,9 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
               ),
               const SizedBox(height: 14),
               Text(
-                _searching
+                !_exhausted
+                    ? 'No new titles loaded yet'
+                    : _searching
                     ? 'No matches for “$_searchQuery”'
                     : 'Nothing in this catalog',
                 style: TextStyle(
@@ -625,7 +644,9 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
                 // fetch swallows errors and returns [], so an empty result can
                 // also be a transient failure — offer a retry rather than
                 // dead-ending (re-selecting the same filter is a no-op).
-                _searching
+                !_exhausted
+                    ? 'Continue browsing to check more titles.'
+                    : _searching
                     ? 'No results for this query — try another catalog or genre.'
                     : 'This may be empty, or the addon failed to respond.',
                 textAlign: TextAlign.center,
@@ -649,9 +670,19 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
                 },
                 child: OutlinedButton.icon(
                   focusNode: _retryNode,
-                  onPressed: () => _reload(autoFocus: true),
+                  onPressed: _loadingMore
+                      ? null
+                      : () => _exhausted
+                            ? _reload(autoFocus: true)
+                            : _loadMore(resume: true),
                   icon: const Icon(Icons.refresh_rounded, size: 18),
-                  label: const Text('Retry'),
+                  label: Text(
+                    _loadingMore
+                        ? 'Loading…'
+                        : _exhausted
+                        ? 'Retry'
+                        : 'Continue loading',
+                  ),
                   style: OutlinedButton.styleFrom(
                     foregroundColor: app.core.tx,
                     side: BorderSide(color: app.seeAll.accentBorder),
@@ -670,22 +701,47 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
         ),
       );
     }
-    return SeeAllPosterGrid(
+    final grid = SeeAllPosterGrid(
       key: _gridKey,
       items: _sortedItems,
       isTelevision: widget.isTelevision,
       loadingMore: _loadingMore,
-      exhausted: _exhausted,
+      exhausted: _exhausted || _pagingPaused,
       onOpen: widget.onOpenItem,
       onQuickPlay: widget.onQuickPlay,
       onItemFocused: widget.onItemFocused,
       isBound: widget.isBound,
-      onLoadMore: _loadMore,
+      onLoadMore: () => _loadMore(),
+      onExitBottom: _pagingPaused ? _retryNode.requestFocus : null,
       onExitTop: widget.isTelevision ? () => _typeNode.requestFocus() : null,
       // Embedded: Left at grid column 0 escapes to the TV sidebar.
       onExitLeft: widget.embedded
           ? () => MainPageBridge.focusTvSidebar?.call()
           : null,
+    );
+    return Column(
+      children: [
+        Expanded(child: grid),
+        if (_pagingPaused)
+          SafeArea(
+            top: false,
+            child: Focus(
+              onKeyEvent: (_, event) {
+                if (event is KeyDownEvent &&
+                    event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                  _gridKey.currentState?.focusFirst();
+                  return KeyEventResult.handled;
+                }
+                return KeyEventResult.ignored;
+              },
+              child: TextButton(
+                focusNode: _retryNode,
+                onPressed: _loadingMore ? null : () => _loadMore(resume: true),
+                child: Text(_loadingMore ? 'Loading…' : 'Continue loading'),
+              ),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/lib/screens/see_all/catalog_see_all_screen.dart
+++ b/lib/screens/see_all/catalog_see_all_screen.dart
@@ -7,7 +7,9 @@ import 'package:flutter/services.dart';
 import '../../models/stremio_addon.dart';
 import '../../services/analytics_service.dart';
 import '../../services/discover_prefs.dart';
+import '../../services/filtered_catalog_pager.dart';
 import '../../services/main_page_bridge.dart';
+import '../../services/watched_filter.dart';
 import '../../theme/app_theme_scope.dart';
 import '../../widgets/skeleton_poster.dart';
 import '../../services/stremio_service.dart';
@@ -261,16 +263,19 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
       _loadingMore = false;
     });
     try {
-      var rawCount = 0;
-      final page = await _fetchPage(0, (c) => rawCount = c);
+      final page = await fetchFilteredPage(
+        _fetchPage,
+        skip: 0,
+        hides: WatchedFilter.predicate,
+      );
       if (!mounted || token != _reqToken) return;
       setState(() {
-        _items.addAll(page);
-        _nextSkip = rawCount > 0 ? rawCount : page.length;
-        _exhausted = page.isEmpty;
+        _items.addAll(page.items);
+        _nextSkip = page.nextSkip;
+        _exhausted = page.exhausted;
         _loadingInitial = false;
       });
-      if (autoFocus && widget.isTelevision && page.isNotEmpty) {
+      if (autoFocus && widget.isTelevision && page.items.isNotEmpty) {
         WidgetsBinding.instance.addPostFrameCallback(
           (_) => _gridKey.currentState?.focusFirst(),
         );
@@ -289,25 +294,20 @@ class _CatalogSeeAllScreenState extends State<CatalogSeeAllScreen> {
     final token = _reqToken;
     setState(() => _loadingMore = true);
     try {
-      var rawCount = 0;
-      final page = await _fetchPage(_nextSkip, (c) => rawCount = c);
-      if (!mounted || token != _reqToken) return;
-      if (page.isEmpty) {
-        setState(() {
-          _exhausted = true;
-          _loadingMore = false;
-        });
-        return;
-      }
       final seen = _items.map((m) => m.id).toSet();
-      final fresh = page.where((m) => seen.add(m.id)).toList();
+      final page = await fetchFilteredPage(
+        _fetchPage,
+        skip: _nextSkip,
+        hides: WatchedFilter.predicate,
+        seenIds: seen,
+      );
+      if (!mounted || token != _reqToken) return;
       setState(() {
-        _nextSkip += rawCount > 0 ? rawCount : page.length;
-        if (fresh.isEmpty) {
-          _exhausted = true;
-        } else {
-          _items.addAll(fresh);
-        }
+        _nextSkip = page.nextSkip;
+        _items.addAll(page.items);
+        // Nothing new (only duplicates, or the addon ignores skip) also ends
+        // the grid.
+        _exhausted = page.exhausted || page.items.isEmpty;
         _loadingMore = false;
       });
     } catch (_) {

--- a/lib/screens/see_all/mdblist_see_all_screen.dart
+++ b/lib/screens/see_all/mdblist_see_all_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../../models/stremio_addon.dart';
 import '../../services/analytics_service.dart';
@@ -253,9 +254,18 @@ class _MdblistSeeAllScreenState extends State<MdblistSeeAllScreen> {
     super.dispose();
   }
 
+  bool get _canContinueEmpty =>
+      !_isCatalog &&
+      _group != MdblistDiscoverGroup.library &&
+      _selected != null &&
+      _visible.isEmpty &&
+      !_page.exhausted;
+
   void _focusEntry() {
     if (!mounted) return;
-    if (_visible.isEmpty) {
+    if (_canContinueEmpty) {
+      _moreNode.requestFocus();
+    } else if (_visible.isEmpty) {
       _backNode.requestFocus();
     } else {
       _gridKey.currentState?.focusFirst();
@@ -440,6 +450,7 @@ class _MdblistSeeAllScreenState extends State<MdblistSeeAllScreen> {
     final cursor = _page.nextCursor;
     if (choice == null || cursor == null || _loadingMore) return;
     final token = _fetchToken;
+    final restoreFocus = _moreNode.hasFocus;
     setState(() => _loadingMore = true);
     final next = await _source.loadChoice(choice, cursor: cursor);
     if (!mounted || choice != _selected || token != _fetchToken) return;
@@ -461,6 +472,18 @@ class _MdblistSeeAllScreenState extends State<MdblistSeeAllScreen> {
       );
       _recompute();
     });
+    if (restoreFocus && widget.isTelevision) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || token != _fetchToken) return;
+        if (_visible.isNotEmpty) {
+          _gridKey.currentState?.focusFirst();
+        } else if (_canContinueEmpty) {
+          _moreNode.requestFocus();
+        } else {
+          _gridExitNode.requestFocus();
+        }
+      });
+    }
   }
 
   void _acceptPage(MdblistDiscoverPage page) {
@@ -470,7 +493,12 @@ class _MdblistSeeAllScreenState extends State<MdblistSeeAllScreen> {
       _errorKind = page.isUsable ? null : page.kind;
       _recompute();
     });
-    if (widget.isTelevision && _visible.isEmpty) _gridExitNode.requestFocus();
+    if (widget.isTelevision && _visible.isEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        (_canContinueEmpty ? _moreNode : _gridExitNode).requestFocus();
+      });
+    }
   }
 
   bool get _hidesWatched {
@@ -924,7 +952,9 @@ class _MdblistSeeAllScreenState extends State<MdblistSeeAllScreen> {
     return handleSeeAllFilterArrows(
       event,
       _filterNodes,
-      onDown: () => _gridKey.currentState?.focusFirst(),
+      onDown: () => _canContinueEmpty
+          ? _moreNode.requestFocus()
+          : _gridKey.currentState?.focusFirst(),
       onUp: () {
         if (!widget.embedded) _backNode.requestFocus();
       },
@@ -1275,11 +1305,30 @@ class _MdblistSeeAllScreenState extends State<MdblistSeeAllScreen> {
         if (_page.kind == MdblistResultKind.partial)
           'Showing retained or partial MDBList results',
       ];
-      if (status.isEmpty) return _buildEmpty();
+      if (status.isEmpty && !_canContinueEmpty) return _buildEmpty();
       return Column(
         children: [
           for (final message in status) _statusStrip(message),
           Expanded(child: _buildEmpty()),
+          if (_canContinueEmpty)
+            SafeArea(
+              top: false,
+              child: Focus(
+                onKeyEvent: (_, event) {
+                  if (event is KeyDownEvent &&
+                      event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                    _gridExitNode.requestFocus();
+                    return KeyEventResult.handled;
+                  }
+                  return KeyEventResult.ignored;
+                },
+                child: TextButton(
+                  focusNode: _moreNode,
+                  onPressed: _loadingMore ? null : _loadMoreChoice,
+                  child: Text(_loadingMore ? 'Loading…' : 'Continue loading'),
+                ),
+              ),
+            ),
         ],
       );
     }

--- a/lib/screens/see_all/mdblist_see_all_screen.dart
+++ b/lib/screens/see_all/mdblist_see_all_screen.dart
@@ -40,6 +40,9 @@ class MdblistSeeAllScreen extends StatefulWidget {
   final FocusNode? leadingNode;
   final MdblistListChoice? initialList;
 
+  /// Preserve the source directory when opening a Home list directly.
+  final bool? initialListIsPublic;
+
   /// Injection seams used by contract/widget tests. Production callers leave
   /// both null and use the account-bound singletons.
   final MdblistDiscoverSource? source;
@@ -56,6 +59,7 @@ class MdblistSeeAllScreen extends StatefulWidget {
     this.leading,
     this.leadingNode,
     this.initialList,
+    this.initialListIsPublic,
     this.source,
     this.isAuthenticated,
   });
@@ -78,6 +82,7 @@ class _MdblistSeeAllScreenState extends State<MdblistSeeAllScreen> {
   List<MdblistDiscoverChoice> _choices = const [];
   MdblistDiscoverChoice? _selected;
   MdblistDiscoverChoice? _searchResult;
+  bool _searchResultIsPublic = false;
   bool _selectedLiked = false;
 
   MdblistDiscoverPage _page = const MdblistDiscoverPage();
@@ -211,6 +216,9 @@ class _MdblistSeeAllScreenState extends State<MdblistSeeAllScreen> {
         _group = MdblistDiscoverGroup.lists;
         _directory = MdblistListDirectory.searchResult;
         _searchResult = choice;
+        _searchResultIsPublic =
+            widget.initialListIsPublic ??
+            (initial.ownerName != null && !initial.liked);
         _choices = [choice];
         _selected = choice;
         _selectedLiked = choice.liked;
@@ -465,10 +473,19 @@ class _MdblistSeeAllScreenState extends State<MdblistSeeAllScreen> {
     if (widget.isTelevision && _visible.isEmpty) _gridExitNode.requestFocus();
   }
 
+  bool get _hidesWatched {
+    if (_isCatalog || _group == MdblistDiscoverGroup.forYou) return true;
+    if (_group == MdblistDiscoverGroup.library || _selectedLiked) return false;
+    return switch (_directory) {
+      MdblistListDirectory.mine || MdblistListDirectory.liked => false,
+      MdblistListDirectory.searchResult => _searchResultIsPublic,
+      _ => true,
+    };
+  }
+
   void _recompute() {
     Iterable<StremioMeta> items = _page.items;
-    // Public catalog browse only; the user's own and liked lists stay complete.
-    if (_isCatalog) items = items.where((m) => !WatchedFilter.hides(m));
+    if (_hidesWatched) items = items.where((m) => !WatchedFilter.hides(m));
     if (!_isCatalog) {
       if (_show == 'movie') {
         items = items.where((item) => item.type != 'series');

--- a/lib/screens/see_all/mdblist_see_all_screen.dart
+++ b/lib/screens/see_all/mdblist_see_all_screen.dart
@@ -11,6 +11,7 @@ import '../../services/mdblist/mdblist_discover_models.dart';
 import '../../services/mdblist/mdblist_discover_source.dart';
 import '../../services/mdblist/mdblist_list_source.dart';
 import '../../services/mdblist/mdblist_models.dart';
+import '../../services/watched_filter.dart';
 import '../../theme/app_theme_scope.dart';
 import '../../widgets/see_all/mdblist_save_button.dart';
 import '../../widgets/see_all/see_all_filter_bar.dart';
@@ -466,6 +467,8 @@ class _MdblistSeeAllScreenState extends State<MdblistSeeAllScreen> {
 
   void _recompute() {
     Iterable<StremioMeta> items = _page.items;
+    // Public catalog browse only; the user's own and liked lists stay complete.
+    if (_isCatalog) items = items.where((m) => !WatchedFilter.hides(m));
     if (!_isCatalog) {
       if (_show == 'movie') {
         items = items.where((item) => item.type != 'series');

--- a/lib/screens/see_all/trakt_see_all_screen.dart
+++ b/lib/screens/see_all/trakt_see_all_screen.dart
@@ -10,6 +10,7 @@ import '../../services/main_page_bridge.dart';
 import '../../widgets/see_all/see_all_filter_bar.dart';
 import '../../widgets/skeleton_poster.dart';
 import '../../services/trakt/trakt_list_source.dart';
+import '../../services/watched_filter.dart';
 import '../../widgets/see_all/see_all_filter_focus.dart';
 import '../../widgets/see_all/see_all_header.dart';
 import '../../widgets/see_all/see_all_poster_grid.dart';
@@ -389,6 +390,10 @@ class _TraktSeeAllScreenState extends State<TraktSeeAllScreen> {
       it = it.where(_isWatched);
     } else if (_showState && _watch == 'unwatched') {
       it = it.where((m) => !_isWatched(m));
+    }
+    // Discovery lists only; the account's own lists stay complete.
+    if (_list.builtin?.hidesWatched ?? false) {
+      it = it.where((m) => !WatchedFilter.hides(m));
     }
     final list = it.toList();
     switch (_effectiveSort) {

--- a/lib/screens/settings/tracking_settings_page.dart
+++ b/lib/screens/settings/tracking_settings_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../models/tracking_source.dart';
 import '../../services/analytics_service.dart';
+import '../../services/hide_watched_prefs.dart';
 import '../../services/main_page_bridge.dart';
 import '../../services/mdblist/mdblist_service.dart';
 import '../../services/simkl/simkl_service.dart';
@@ -23,6 +24,7 @@ class _TrackingSettingsPageState extends State<TrackingSettingsPage> {
   WatchProgressSource _progress = WatchProgressSource.smart;
   Set<TrackingSource> _ticks = Set<TrackingSource>.of(TrackingSource.values);
   Set<TrackingSource> _connected = {};
+  bool _hideWatched = HideWatchedPrefs.enabled;
   int _selectedSection = 0;
 
   @override
@@ -41,6 +43,7 @@ class _TrackingSettingsPageState extends State<TrackingSettingsPage> {
       SimklService.instance.isAuthenticated(),
       MdblistService.instance.isAuthenticated(),
       StorageService.takeTrackingProgressFallbackNotice(),
+      HideWatchedPrefs.read(),
     ]);
     if (!mounted) return;
     final connected = <TrackingSource>{
@@ -64,6 +67,7 @@ class _TrackingSettingsPageState extends State<TrackingSettingsPage> {
       _progress = progress;
       _ticks = Set<TrackingSource>.of(values[2] as Set<TrackingSource>);
       _connected = connected;
+      _hideWatched = values[7] as bool;
       _loading = false;
     });
     if (fellBack || values[6] as bool) {
@@ -126,6 +130,13 @@ class _TrackingSettingsPageState extends State<TrackingSettingsPage> {
     enabled ? next.add(source) : next.remove(source);
     setState(() => _ticks = next);
     await StorageService.setHomeTickSources(next);
+    MainPageBridge.notifyHomeSettingsChanged();
+  }
+
+  Future<void> _setHideWatched(bool enabled) async {
+    setState(() => _hideWatched = enabled);
+    await HideWatchedPrefs.setEnabled(enabled);
+    // Membership change: Home rebuilds its rows through the board reload.
     MainPageBridge.notifyHomeSettingsChanged();
   }
 
@@ -237,6 +248,25 @@ class _TrackingSettingsPageState extends State<TrackingSettingsPage> {
     ],
   );
 
+  Widget _hideWatchedSection() => SettingsSection(
+    title: 'Hide watched',
+    blurb:
+        'Remove finished movies and shows from Home rows, Search, Discover '
+        'and See All. Uses the same histories as the ✓ ticks above. Continue '
+        'Watching and your own lists are never hidden.',
+    children: [
+      SettingsToggleTile(
+        icon: Icons.visibility_off_rounded,
+        title: 'Hide watched titles',
+        subtitle: _hideWatched
+            ? 'Watched movies and finished shows are hidden from catalogs'
+            : 'Watched titles stay visible with a ✓',
+        value: _hideWatched,
+        onChanged: _setHideWatched,
+      ),
+    ],
+  );
+
   Widget _mobileBody() => ListView(
     padding: const EdgeInsets.all(16),
     children: [
@@ -245,21 +275,30 @@ class _TrackingSettingsPageState extends State<TrackingSettingsPage> {
       _progressSection(),
       const SizedBox(height: 18),
       _ticksSection(),
+      const SizedBox(height: 18),
+      _hideWatchedSection(),
       const SizedBox(height: 24),
     ],
   );
 
   Widget _tvBody() {
-    const labels = ['Scrobble', 'Progress source', 'Watched ticks'];
+    const labels = [
+      'Scrobble',
+      'Progress source',
+      'Watched ticks',
+      'Hide watched',
+    ];
     const icons = [
       Icons.sync_alt_rounded,
       Icons.play_circle_outline_rounded,
       Icons.check_circle_outline_rounded,
+      Icons.visibility_off_rounded,
     ];
     final selected = switch (_selectedSection) {
       0 => _scrobbleSection(),
       1 => _progressSection(),
-      _ => _ticksSection(),
+      2 => _ticksSection(),
+      _ => _hideWatchedSection(),
     };
     return Row(
       children: [

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -3259,6 +3259,20 @@ class _SettingsScreenState extends State<SettingsScreen> {
         const ['hide', 'titles', 'ratings', 'cards', 'clean artwork'],
       ),
       leaf(
+        'Tracking',
+        'Hide watched titles',
+        'Remove finished movies and shows from Home, Search and Discover',
+        const [
+          'hide',
+          'watched',
+          'seen',
+          'finished',
+          'completed',
+          'already watched',
+          'filter',
+        ],
+      ),
+      leaf(
         'Home Screen',
         'Hide Catalog Add-on Names',
         'Remove source labels beside Home row headings',

--- a/lib/services/collection_catalog_pager.dart
+++ b/lib/services/collection_catalog_pager.dart
@@ -18,12 +18,14 @@ class CollectionCatalogPager {
     required this.catalog,
     required this.fetch,
     this.genre,
+    this.hides,
   });
   static const int maxEmptyWindows = 8;
   final StremioAddon addon;
   final StremioAddonCatalog catalog;
   final CatalogFetch fetch;
   final String? genre;
+  final bool Function(StremioMeta)? hides;
   final Set<String> _seen = {};
   int skip = 0;
   bool exhausted = false;
@@ -67,7 +69,7 @@ class CollectionCatalogPager {
         skip += count;
         final fresh = [
           for (final m in items)
-            if (_seen.add(itemKey(m)))
+            if (_seen.add(itemKey(m)) && !(hides?.call(m) ?? false))
               m.sourceAddon == null ? m.withSourceAddon(addon) : m,
         ];
         if (fresh.isNotEmpty) return fresh;

--- a/lib/services/collection_folder_loader.dart
+++ b/lib/services/collection_folder_loader.dart
@@ -75,8 +75,9 @@ class CollectionFolderLoader {
   bool get exhausted => _sources.every((s) => s.exhausted);
   // A source can have an empty/overlapping window while its siblings advance.
   // Only the shared budget exhausting makes no-progress an All-view error.
-  bool get hasErrors =>
-      _stalled || _sources.any((s) => s.error != null && !s.noProgress);
+  bool get hasLoadFailures =>
+      _sources.any((s) => s.error != null && !s.noProgress);
+  bool get hasErrors => _stalled || hasLoadFailures;
 
   void reset() {
     _seen.clear();

--- a/lib/services/collection_folder_loader.dart
+++ b/lib/services/collection_folder_loader.dart
@@ -5,6 +5,7 @@ import '../models/stremio_addon.dart';
 import 'collection_catalog_pager.dart';
 import 'home_collections_store.dart';
 import 'stremio_service.dart';
+import 'watched_filter.dart';
 export 'collection_catalog_pager.dart' show CatalogFetch;
 
 /// Pages every catalog with bounded concurrency and retains per-source raw
@@ -16,6 +17,7 @@ class CollectionFolderLoader {
     StremioService? stremio,
     CatalogFetch? fetch,
     bool forceRefresh = false,
+    bool Function(StremioMeta)? hides,
   }) {
     final load =
         fetch ??
@@ -56,6 +58,7 @@ class CollectionFolderLoader {
           catalog: catalog,
           genre: source.genre,
           fetch: load,
+          hides: hides ?? WatchedFilter.predicate,
         ),
       );
     }

--- a/lib/services/filtered_catalog_pager.dart
+++ b/lib/services/filtered_catalog_pager.dart
@@ -56,19 +56,21 @@ Future<FilteredPage> fetchFilteredPage(
   var fetches = 0;
   var exhausted = false;
   final out = <StremioMeta>[];
+  final seen = seenIds ?? <String>{};
   while (true) {
-    var rawCount = 0;
+    int? rawCount;
     final page = await fetch(cursor, (c) => rawCount = c);
     fetches++;
-    if (page.isEmpty) {
-      exhausted = true;
+    final count = rawCount ?? page.length;
+    if (count == 0) {
+      exhausted = rawCount == 0;
       break;
     }
     // Raw window, not the post-filter count: keeps skip aligned with what
     // the addon actually served.
-    cursor += rawCount > 0 ? rawCount : page.length;
+    cursor += count;
     for (final m in page) {
-      if (seenIds != null && !seenIds.add(m.id)) continue;
+      if (!seen.add(m.id)) continue;
       if (hides != null && hides(m)) continue;
       out.add(m);
     }

--- a/lib/services/filtered_catalog_pager.dart
+++ b/lib/services/filtered_catalog_pager.dart
@@ -1,0 +1,84 @@
+import '../models/stremio_addon.dart';
+
+/// Fetches one raw window of a paged catalog starting at `skip`. The addon's
+/// RAW item count (before anything was dropped upstream) must be reported
+/// through [onRawCount] so `skip` can advance in step with the addon's own
+/// paging.
+typedef PageFetch =
+    Future<List<StremioMeta>> Function(
+      int skip,
+      void Function(int rawCount) onRawCount,
+    );
+
+/// The result of [fetchFilteredPage].
+class FilteredPage {
+  /// Surviving items in addon order, de-duplicated against `seenIds`.
+  final List<StremioMeta> items;
+
+  /// Where the next page starts: the sum of the raw windows consumed.
+  final int nextSkip;
+
+  /// True only when the addon served a RAW-empty window, i.e. the catalog is
+  /// genuinely at its end. A window that was entirely filtered away is not
+  /// exhaustion.
+  final bool exhausted;
+
+  /// Number of windows pulled. Tests only.
+  final int fetches;
+
+  const FilteredPage({
+    required this.items,
+    required this.nextSkip,
+    required this.exhausted,
+    required this.fetches,
+  });
+}
+
+/// Fetch from [skip], drop items [hides] rejects, and keep pulling windows
+/// until at least [minItems] survive, the addon serves a raw-empty window, or
+/// [maxFetches] windows were consumed.
+///
+/// With [hides] null this is exactly one fetch, so surfaces that don't filter
+/// behave as before. With a predicate, a page that happened to be all watched
+/// no longer looks like an empty catalog: [FilteredPage.exhausted] is defined
+/// by the addon running dry, never by the filter. [seenIds], when given,
+/// collects every id encountered — filtered or not — so the caller's
+/// de-duplication and paging stay aligned across calls.
+Future<FilteredPage> fetchFilteredPage(
+  PageFetch fetch, {
+  required int skip,
+  bool Function(StremioMeta item)? hides,
+  int minItems = 12,
+  int maxFetches = 4,
+  Set<String>? seenIds,
+}) async {
+  var cursor = skip;
+  var fetches = 0;
+  var exhausted = false;
+  final out = <StremioMeta>[];
+  while (true) {
+    var rawCount = 0;
+    final page = await fetch(cursor, (c) => rawCount = c);
+    fetches++;
+    if (page.isEmpty) {
+      exhausted = true;
+      break;
+    }
+    // Raw window, not the post-filter count: keeps skip aligned with what
+    // the addon actually served.
+    cursor += rawCount > 0 ? rawCount : page.length;
+    for (final m in page) {
+      if (seenIds != null && !seenIds.add(m.id)) continue;
+      if (hides != null && hides(m)) continue;
+      out.add(m);
+    }
+    if (hides == null) break;
+    if (out.length >= minItems || fetches >= maxFetches) break;
+  }
+  return FilteredPage(
+    items: out,
+    nextSkip: cursor,
+    exhausted: exhausted,
+    fetches: fetches,
+  );
+}

--- a/lib/services/filtered_catalog_pager.dart
+++ b/lib/services/filtered_catalog_pager.dart
@@ -18,9 +18,9 @@ class FilteredPage {
   /// Where the next page starts: the sum of the raw windows consumed.
   final int nextSkip;
 
-  /// True only when the addon served a RAW-empty window, i.e. the catalog is
-  /// genuinely at its end. A window that was entirely filtered away is not
-  /// exhaustion.
+  /// With filtering enabled, true only after a RAW-empty window. With the
+  /// switch off, preserves legacy empty/duplicate termination. A window that
+  /// was entirely filtered away is not exhaustion.
   final bool exhausted;
 
   /// Number of windows pulled. Tests only.
@@ -52,6 +52,21 @@ Future<FilteredPage> fetchFilteredPage(
   int maxFetches = 4,
   Set<String>? seenIds,
 }) async {
+  // The disabled feature preserves the original single-page termination rules.
+  if (hides == null) {
+    var rawCount = 0;
+    final page = await fetch(skip, (count) => rawCount = count);
+    final seen = seenIds ?? <String>{};
+    final fresh = page.where((item) => seen.add(item.id)).toList();
+    return FilteredPage(
+      items: fresh,
+      nextSkip: page.isEmpty
+          ? skip
+          : skip + (rawCount > 0 ? rawCount : page.length),
+      exhausted: fresh.isEmpty,
+      fetches: 1,
+    );
+  }
   var cursor = skip;
   var fetches = 0;
   var exhausted = false;
@@ -71,10 +86,9 @@ Future<FilteredPage> fetchFilteredPage(
     cursor += count;
     for (final m in page) {
       if (!seen.add(m.id)) continue;
-      if (hides != null && hides(m)) continue;
+      if (hides(m)) continue;
       out.add(m);
     }
-    if (hides == null) break;
     if (out.length >= minItems || fetches >= maxFetches) break;
   }
   return FilteredPage(

--- a/lib/services/hide_watched_prefs.dart
+++ b/lib/services/hide_watched_prefs.dart
@@ -12,7 +12,7 @@ class HideWatchedPrefs {
   HideWatchedPrefs._();
 
   // Profile-scoped. Persisted, so never rename without a migration.
-  static const String _key = 'hide_watched_titles';
+  static const String key = 'hide_watched_titles';
 
   static bool _enabled = false;
   static bool _warmed = false;
@@ -28,7 +28,7 @@ class HideWatchedPrefs {
     _warmed = true;
     try {
       final prefs = await ProfilePreferences.instance();
-      _enabled = prefs.getBool(_key) ?? false;
+      _enabled = prefs.getBool(key) ?? false;
     } catch (_) {
       // Storage unavailable — stay off for this session.
     }
@@ -38,11 +38,22 @@ class HideWatchedPrefs {
   static Future<bool> read() async {
     try {
       final prefs = await ProfilePreferences.instance();
-      _enabled = prefs.getBool(_key) ?? false;
+      _enabled = prefs.getBool(key) ?? false;
     } catch (_) {
       // Keep the cached value.
     }
     return _enabled;
+  }
+
+  static Future<void> refreshFromPreferences({
+    required void Function() authorizationBarrier,
+  }) async {
+    authorizationBarrier();
+    final prefs = await ProfilePreferences.instance();
+    final enabled = prefs.getBool(key) ?? false;
+    authorizationBarrier();
+    _enabled = enabled;
+    _warmed = true;
   }
 
   /// Cache-first: [enabled] reflects [value] before the write lands.
@@ -51,7 +62,7 @@ class HideWatchedPrefs {
     _warmed = true;
     try {
       final prefs = await ProfilePreferences.instance();
-      await prefs.setBool(_key, value);
+      await prefs.setBool(key, value);
     } catch (_) {
       // Best-effort: the choice still holds for this session.
     }

--- a/lib/services/hide_watched_prefs.dart
+++ b/lib/services/hide_watched_prefs.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
+import 'profiles/profile_preferences.dart';
+
+/// Synchronously cached "Hide watched titles" switch (Settings › Tracking).
+///
+/// Same shape as `DiscoverPrefs`: a static cache warmed in `main()` and again
+/// on profile switch, because the filter that honours it runs inside list
+/// construction and cannot await storage. Setters are cache-first so a flip is
+/// visible on the very next build while the disk write is still in flight.
+class HideWatchedPrefs {
+  HideWatchedPrefs._();
+
+  // Profile-scoped. Persisted, so never rename without a migration.
+  static const String _key = 'hide_watched_titles';
+
+  static bool _enabled = false;
+  static bool _warmed = false;
+
+  /// Whether watched movies and finished shows are hidden from catalog
+  /// surfaces. Off until the user asks.
+  static bool get enabled => _enabled;
+
+  /// Load the switch into the cache. Repeat calls are no-ops until
+  /// [resetProfileScope].
+  static Future<void> warmUp() async {
+    if (_warmed) return;
+    _warmed = true;
+    try {
+      final prefs = await ProfilePreferences.instance();
+      _enabled = prefs.getBool(_key) ?? false;
+    } catch (_) {
+      // Storage unavailable — stay off for this session.
+    }
+  }
+
+  /// Re-read from storage, bypassing the cache (backup, settings page).
+  static Future<bool> read() async {
+    try {
+      final prefs = await ProfilePreferences.instance();
+      _enabled = prefs.getBool(_key) ?? false;
+    } catch (_) {
+      // Keep the cached value.
+    }
+    return _enabled;
+  }
+
+  /// Cache-first: [enabled] reflects [value] before the write lands.
+  static Future<void> setEnabled(bool value) async {
+    _enabled = value;
+    _warmed = true;
+    try {
+      final prefs = await ProfilePreferences.instance();
+      await prefs.setBool(_key, value);
+    } catch (_) {
+      // Best-effort: the choice still holds for this session.
+    }
+  }
+
+  /// Forget the current profile's value so the next [warmUp] reloads it.
+  static void resetProfileScope() {
+    _enabled = false;
+    _warmed = false;
+  }
+
+  /// Tests only — stands in for an app restart.
+  @visibleForTesting
+  static void debugReset() => resetProfileScope();
+}

--- a/lib/services/home_catalog_refresh.dart
+++ b/lib/services/home_catalog_refresh.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import '../models/stremio_addon.dart';
+import 'filtered_catalog_pager.dart';
 
 /// Reuses unchanged rows, including their paging state and any in-flight page.
 /// Changed definitions reload the old raw paging extent before replacing a row.
@@ -13,6 +14,7 @@ Future<CatalogSection?> loadHomeCatalogSection({
   )
   fetch,
   required bool Function() isCurrent,
+  bool Function(StremioMeta)? hides,
 }) async {
   final sameIdentity =
       previous != null &&
@@ -35,24 +37,25 @@ Future<CatalogSection?> loadHomeCatalogSection({
   final seen = <String>{};
   var skip = 0;
   var exhausted = false;
+  var paused = false;
   do {
     if (!isCurrent()) return null;
-    var rawCount = 0;
-    final page = await fetch(skip, (count) => rawCount = count);
+    final page = await fetchFilteredPage(
+      (cursor, raw) => isCurrent()
+          ? fetch(cursor, raw)
+          : Future.value(const <StremioMeta>[]),
+      skip: skip,
+      hides: hides,
+      seenIds: seen,
+    );
     if (!isCurrent()) return null;
-    if (page.isEmpty) {
-      exhausted = true;
-      break;
-    }
-    skip += rawCount > 0 ? rawCount : page.length;
-    final fresh = page.where((item) => seen.add(item.id)).toList();
-    items.addAll(fresh);
-    if (fresh.isEmpty) {
-      exhausted = true;
-      break;
-    }
+    skip = page.nextSkip;
+    exhausted = page.exhausted;
+    items.addAll(page.items);
+    paused = !exhausted && page.items.isEmpty;
+    if (exhausted || paused) break;
   } while (skip < targetSkip);
-  if (items.isEmpty) return null;
+  if (items.isEmpty && exhausted) return null;
   return CatalogSection(
     title: CatalogSection.rowTitle(catalog),
     addon: addon,
@@ -60,5 +63,6 @@ Future<CatalogSection?> loadHomeCatalogSection({
     items: items,
     nextSkip: skip,
     exhausted: exhausted,
+    pagingPaused: paused,
   );
 }

--- a/lib/services/home_list_rows.dart
+++ b/lib/services/home_list_rows.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import '../models/stremio_addon.dart';
 import 'storage_service.dart';
 import 'trakt/trakt_list_source.dart';
+import 'watched_filter.dart';
 import 'simkl/simkl_list_source.dart';
 import 'mdblist/mdblist_list_source.dart';
 
@@ -220,11 +221,14 @@ class HomeListRowsService {
       traktPool.add(() async {
         final choice = TraktListChoice.builtin(list);
         final r = await _traktLoad(choice);
-        if (r.items.isEmpty) return;
+        final items = list.hidesWatched
+            ? WatchedFilter.apply(List.of(r.items))
+            : List.of(r.items);
+        if (items.isEmpty) return;
         slot.section = HomeListSection(
           rowId: id,
           title: list.label,
-          items: List.of(r.items),
+          items: items,
           traktChoice: choice,
         );
       });
@@ -354,13 +358,20 @@ class HomeListRowsService {
           slot.withinRank = order++;
           mdblistPool.add(() async {
             final result = await _mdblistLoad(entry.value);
-            if (!result.complete || result.items.isEmpty) return;
+            if (!result.complete) return;
+            // Public "top" lists hide watched titles; the user's own and
+            // liked lists never do.
+            final items =
+                entry.key.startsWith(HomeExtraRowIds.mdblistTopPrefix)
+                ? WatchedFilter.apply(List.of(result.items))
+                : List.of(result.items);
+            if (items.isEmpty) return;
             slot.section = HomeListSection(
               rowId: entry.key,
               title: byId[entry.key]!.title.isNotEmpty
                   ? byId[entry.key]!.title
                   : entry.value.label,
-              items: List.of(result.items),
+              items: items,
               mdblistList: entry.value,
             );
           });

--- a/lib/services/home_list_rows.dart
+++ b/lib/services/home_list_rows.dart
@@ -362,7 +362,8 @@ class HomeListRowsService {
             // Public "top" lists hide watched titles; the user's own and
             // liked lists never do.
             final items =
-                entry.key.startsWith(HomeExtraRowIds.mdblistTopPrefix)
+                entry.key.startsWith(HomeExtraRowIds.mdblistTopPrefix) &&
+                    !entry.value.liked
                 ? WatchedFilter.apply(List.of(result.items))
                 : List.of(result.items);
             if (items.isEmpty) return;

--- a/lib/services/profiles/profile_app_lifecycle_participant.dart
+++ b/lib/services/profiles/profile_app_lifecycle_participant.dart
@@ -5,6 +5,7 @@ import '../../theme/app_theme_controller.dart';
 import '../account_service.dart';
 import '../alldebrid_account_service.dart';
 import '../discover_prefs.dart';
+import '../hide_watched_prefs.dart';
 import '../debrify_tv_database.dart';
 import '../download_service.dart';
 import '../iptv_catalog_db.dart';
@@ -67,6 +68,7 @@ class ProfileAppLifecycleParticipant implements ProfileLifecycleParticipant {
     IptvService.instance.clearCache();
     XtreamCodesService.instance.clearCache();
     DiscoverPrefs.resetProfileScope();
+    HideWatchedPrefs.resetProfileScope();
     SubtitleFontService.instance.resetProfileScope();
     SubtitleSettingsService.instance.resetProfileScope();
     AccountService.clearUserInfo();
@@ -124,6 +126,7 @@ class ProfileAppLifecycleParticipant implements ProfileLifecycleParticipant {
       _warmed('IPTV', scope, IptvService.instance.clearCache);
       _warmed('Xtream', scope, XtreamCodesService.instance.clearCache);
       _warmed('DiscoverPrefs', scope, DiscoverPrefs.resetProfileScope);
+      _warmed('HideWatchedPrefs', scope, HideWatchedPrefs.resetProfileScope);
       _warmed(
         'SubtitleFont',
         scope,
@@ -174,6 +177,7 @@ class ProfileAppLifecycleParticipant implements ProfileLifecycleParticipant {
       await AppThemeController.warm();
       await TvHeroArtworkQualityController.warm();
       await DiscoverPrefs.warmUp();
+      await HideWatchedPrefs.warmUp();
       // Do not open credentials here. ProfileGate intentionally keeps the
       // candidate locked until switchTo returns; the newly mounted profile UI
       // refreshes provider authentication immediately after unlock.

--- a/lib/services/remote_control/remote_command_router.dart
+++ b/lib/services/remote_control/remote_command_router.dart
@@ -3414,6 +3414,7 @@ class RemoteCommandRouter {
       final decoded = jsonDecode(data);
       if (decoded is! Map) throw const FormatException();
       await StorageService.applyTrackingPreferencesPayload(decoded);
+      MainPageBridge.notifyHomeSettingsChanged();
       final requested = decoded['progress_source']?.toString();
       final effective = await TrackingSourcePolicy.load();
       final fellBack =

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:synchronized/synchronized.dart';
 import 'dart:convert';
 import 'debrid_service.dart';
+import 'hide_watched_prefs.dart';
 import 'iptv_channel_order.dart';
 import 'iptv_media_store.dart';
 import 'profiles/profile_preferences.dart';
@@ -6244,6 +6245,7 @@ class StorageService {
       'home_tick_sources': ticks
           .map((source) => source.storageName)
           .toList(growable: false),
+      'hide_watched': await HideWatchedPrefs.read(),
     };
   }
 
@@ -6284,6 +6286,8 @@ class StorageService {
           if (TrackingSourceStorageName.parse(value) case final source?) source,
       });
     }
+    final hideWatched = payload['hide_watched'];
+    if (hideWatched is bool) await HideWatchedPrefs.setEnabled(hideWatched);
   }
 
   static Future<String?> getRedditLastSubreddit() async {

--- a/lib/services/trakt/trakt_list_source.dart
+++ b/lib/services/trakt/trakt_list_source.dart
@@ -72,6 +72,12 @@ extension TraktSeeAllListX on TraktSeeAllList {
       this == TraktSeeAllList.popular ||
       this == TraktSeeAllList.anticipated;
 
+  /// Discovery lists, where the "Hide watched titles" switch applies. The
+  /// rest (Continue Watching, Watchlist, History, Collection, Ratings) are the
+  /// user's own lists and stay complete.
+  bool get hidesWatched =>
+      isPublic || this == TraktSeeAllList.recommendations;
+
   /// Lists whose natural order is a genuine cross-type timeline (watched_at /
   /// rated_at / collected_at recency), so merging movies + shows must sort by
   /// that timestamp rather than interleave. Excludes Watchlist (user-curated

--- a/lib/services/watched_filter.dart
+++ b/lib/services/watched_filter.dart
@@ -1,0 +1,57 @@
+import '../models/stremio_addon.dart';
+import 'hide_watched_prefs.dart';
+import 'watched_status_service.dart';
+
+/// Drops already-watched titles from catalog lists while the "Hide watched
+/// titles" switch is on.
+///
+/// "Watched" is [WatchedStatusService]'s answer — the same tick-source-masked
+/// union of local completion, Trakt, Simkl and MDBList that draws the ✓ on
+/// posters — so the tick and the hiding never disagree. For shows it means
+/// the whole show is finished, never "saw one episode".
+///
+/// Only movies and series with an IMDb id can be matched; everything else
+/// passes. Nothing is hidden until the first watched snapshot has been
+/// published, so a cold start paints the same list as before rather than
+/// losing items a beat later.
+class WatchedFilter {
+  WatchedFilter._();
+
+  /// True while the switch is on; callers can skip work entirely otherwise.
+  static bool get enabled => HideWatchedPrefs.enabled;
+
+  /// [hides] as a nullable predicate for `fetchFilteredPage`: null when the
+  /// switch is off, which makes the pager a single plain fetch.
+  static bool Function(StremioMeta)? get predicate => enabled ? hides : null;
+
+  /// Whether [m] should be left out of a catalog surface.
+  static bool hides(StremioMeta m) {
+    if (!enabled) return false;
+    final status = WatchedStatusService.instance;
+    if (!status.hasSnapshot) {
+      // Kick off the first refresh so the next load is filtered; this one
+      // paints unfiltered rather than flashing.
+      status.ensureStarted();
+      return false;
+    }
+    if (!_matchable(m)) return false;
+    return status.isWatchedForTicks(m.effectiveImdbId!, m.type);
+  }
+
+  /// [items] without the hidden ones. Returns [items] itself when the switch
+  /// is off, so unfiltered callers pay nothing.
+  static List<StremioMeta> apply(List<StremioMeta> items) {
+    if (!enabled) return items;
+    return [
+      for (final m in items)
+        if (!hides(m)) m,
+    ];
+  }
+
+  static bool _matchable(StremioMeta m) {
+    final type = m.type.toLowerCase();
+    if (type != 'movie' && type != 'series') return false;
+    final imdb = m.effectiveImdbId;
+    return imdb != null && imdb.isNotEmpty;
+  }
+}

--- a/lib/services/watched_snapshot_retry.dart
+++ b/lib/services/watched_snapshot_retry.dart
@@ -1,0 +1,15 @@
+/// Retry transient local-storage failures without repeating tracker requests.
+/// Exhaustion remains an error so the caller can log it and retry on activation.
+Future<T> readWatchedSnapshotWithRetry<T>(
+  Future<T> Function() read, {
+  Duration retryDelay = const Duration(milliseconds: 200),
+}) async {
+  for (var attempt = 0; ; attempt++) {
+    try {
+      return await read();
+    } catch (_) {
+      if (attempt == 2) rethrow;
+      await Future<void>.delayed(retryDelay * (attempt + 1));
+    }
+  }
+}

--- a/lib/services/watched_snapshot_retry.dart
+++ b/lib/services/watched_snapshot_retry.dart
@@ -13,3 +13,26 @@ Future<T> readWatchedSnapshotWithRetry<T>(
     }
   }
 }
+
+/// Stores an asynchronous error until the consumer is ready to handle it.
+/// The capture future itself never fails, even when awaited after local retries.
+Future<CapturedWatchedRead<T>> captureWatchedRead<T>(Future<T> read) =>
+    read.then(
+      (value) => CapturedWatchedRead<T>._(value, null, null),
+      onError: (Object error, StackTrace stack) =>
+          CapturedWatchedRead<T>._(null, error, stack),
+    );
+
+class CapturedWatchedRead<T> {
+  CapturedWatchedRead._(this._value, this._error, this._stack);
+
+  final T? _value;
+  final Object? _error;
+  final StackTrace? _stack;
+
+  T unwrap() {
+    final error = _error;
+    if (error != null) Error.throwWithStackTrace(error, _stack!);
+    return _value as T;
+  }
+}

--- a/lib/services/watched_status_service.dart
+++ b/lib/services/watched_status_service.dart
@@ -279,6 +279,16 @@ class WatchedStatusService extends ChangeNotifier {
     final mdblistFuture = MdblistService.instance.fetchCompletedTitleIds();
     final calendarFuture = LocalSeriesCompletionService.instance
         .refreshCalendarIfDue();
+    // Capture errors immediately, while local reads may still be retrying.
+    // Unwrap after local publication so tracker latency cannot delay it.
+    final parallelReads = captureWatchedRead(
+      Future.wait<Object?>([
+        traktFuture,
+        simklFuture,
+        calendarFuture,
+        mdblistFuture,
+      ]),
+    );
     List<Set<String>>? local;
     try {
       local = await readWatchedSnapshotWithRetry(
@@ -305,12 +315,7 @@ class WatchedStatusService extends ChangeNotifier {
     // Always join the requests this pass started, even if invalidated. That
     // keeps the coalescer honest: the follow-up cannot overlap abandoned page
     // loops from the superseded pass.
-    final results = await Future.wait<Object?>([
-      traktFuture,
-      simklFuture,
-      calendarFuture,
-      mdblistFuture,
-    ]);
+    final results = (await parallelReads).unwrap();
     if (generation != _generation) return;
     final trakt =
         results[0] as ({Map<String, double>? movies, Set<String>? series});

--- a/lib/services/watched_status_service.dart
+++ b/lib/services/watched_status_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'simkl/simkl_service.dart';
 import 'local_series_completion_service.dart';
 import 'storage_service.dart';
+import 'watched_snapshot_retry.dart';
 import 'trakt/trakt_service.dart';
 import 'mdblist/mdblist_service.dart';
 import '../models/tracking_source.dart';
@@ -206,51 +207,65 @@ class WatchedStatusService extends ChangeNotifier {
 
   void _refreshLocal() {
     final generation = ++_localGeneration;
-    unawaited(() async {
-      final results = await Future.wait([
-        StorageService.getFinishedMovieIds(),
-        LocalSeriesCompletionService.instance.caughtUpIds(),
-        StorageService.getExplicitlyWatchedSeriesIds(),
-      ]);
-      if (generation != _localGeneration) return;
-      _localMovies = results[0];
-      _localSeries = <String>{...results[1], ...results[2]};
-      _markSnapshot();
-      notifyListeners();
+    unawaited(
+      () async {
+        final results = await readWatchedSnapshotWithRetry(
+          () => Future.wait([
+            StorageService.getFinishedMovieIds(),
+            LocalSeriesCompletionService.instance.caughtUpIds(),
+            StorageService.getExplicitlyWatchedSeriesIds(),
+          ]),
+        );
+        if (generation != _localGeneration) return;
+        _localMovies = results[0];
+        _localSeries = <String>{...results[1], ...results[2]};
+        _markSnapshot();
+        notifyListeners();
 
-      // Calendar reconciliation may involve network requests. Keep it behind
-      // the immediate local snapshot so card rendering never waits on Simkl.
-      final calendarSeries = await LocalSeriesCompletionService.instance
-          .refreshCalendarIfDue();
-      final explicitSeries =
-          await StorageService.getExplicitlyWatchedSeriesIds();
-      final combinedSeries = <String>{...calendarSeries, ...explicitSeries};
-      if (generation != _localGeneration ||
-          setEquals(_localSeries, combinedSeries)) {
-        return;
-      }
-      _localSeries = combinedSeries;
-      notifyListeners();
-    }());
+        // Calendar reconciliation may involve network requests. Keep it behind
+        // the immediate local snapshot so card rendering never waits on Simkl.
+        final calendarSeries = await LocalSeriesCompletionService.instance
+            .refreshCalendarIfDue();
+        final explicitSeries =
+            await StorageService.getExplicitlyWatchedSeriesIds();
+        final combinedSeries = <String>{...calendarSeries, ...explicitSeries};
+        if (generation != _localGeneration ||
+            setEquals(_localSeries, combinedSeries)) {
+          return;
+        }
+        _localSeries = combinedSeries;
+        notifyListeners();
+      }().catchError((Object error) {
+        debugPrint('WatchedStatusService: local snapshot read failed ($error)');
+        if (generation == _localGeneration && !_hasSnapshot) _started = false;
+      }),
+    );
   }
 
   void _startRefresh() {
     _refreshing = true;
     final generation = _generation;
     unawaited(
-      _refresh(generation).whenComplete(() {
-        _refreshing = false;
-        if (_refreshPending) {
-          _refreshPending = false;
-          _startRefresh();
-        } else if (_mdblistDirty && _mdblistDirtyAt != null) {
-          // A watched mutation can land while this pass is in flight. Badge
-          // rebuilds happen before `_refreshing` is cleared, so hand the dirty
-          // state off here rather than waiting for an unrelated future build.
-          // API failures leave dirtyAt null and deliberately do not auto-loop.
-          _consumeMdblistDirty();
-        }
-      }),
+      _refresh(generation)
+          .catchError((Object error) {
+            debugPrint(
+              'WatchedStatusService: snapshot refresh failed ($error)',
+            );
+          })
+          .whenComplete(() {
+            if (generation == _generation && !_hasSnapshot) _started = false;
+            _refreshing = false;
+            if (_refreshPending) {
+              _refreshPending = false;
+              _startRefresh();
+            } else if (_mdblistDirty && _mdblistDirtyAt != null) {
+              // A watched mutation can land while this pass is in flight. Badge
+              // rebuilds happen before `_refreshing` is cleared, so hand the dirty
+              // state off here rather than waiting for an unrelated future build.
+              // API failures leave dirtyAt null and deliberately do not auto-loop.
+              _consumeMdblistDirty();
+            }
+          }),
     );
   }
 
@@ -262,20 +277,27 @@ class WatchedStatusService extends ChangeNotifier {
     final traktFuture = _fetchTrakt();
     final simklFuture = SimklService.instance.fetchCompletedTitleIds();
     final mdblistFuture = MdblistService.instance.fetchCompletedTitleIds();
-    final localSeriesFuture = LocalSeriesCompletionService.instance
-        .caughtUpIds();
-    final explicitSeriesFuture = StorageService.getExplicitlyWatchedSeriesIds();
     final calendarFuture = LocalSeriesCompletionService.instance
         .refreshCalendarIfDue();
-
-    final localMovies = await StorageService.getFinishedMovieIds();
-    final localSeries = <String>{
-      ...await localSeriesFuture,
-      ...await explicitSeriesFuture,
-    };
-    if (generation == _generation && localGeneration == _localGeneration) {
-      _localMovies = localMovies;
-      _localSeries = localSeries;
+    List<Set<String>>? local;
+    try {
+      local = await readWatchedSnapshotWithRetry(
+        () => Future.wait([
+          StorageService.getFinishedMovieIds(),
+          LocalSeriesCompletionService.instance.caughtUpIds(),
+          StorageService.getExplicitlyWatchedSeriesIds(),
+        ]),
+      );
+    } catch (error) {
+      // Still join the tracker work below. A later activation may retry a
+      // failed first snapshot; do not latch ensureStarted permanently.
+      debugPrint('WatchedStatusService: local snapshot read failed ($error)');
+    }
+    if (local != null &&
+        generation == _generation &&
+        localGeneration == _localGeneration) {
+      _localMovies = local[0];
+      _localSeries = {...local[1], ...local[2]};
       _markSnapshot();
       notifyListeners();
     }

--- a/lib/services/watched_status_service.dart
+++ b/lib/services/watched_status_service.dart
@@ -35,6 +35,8 @@ class WatchedStatusService extends ChangeNotifier {
   Set<String> _mdblistSeries = const {};
   int _generation = 0;
   bool _started = false;
+  bool _hasSnapshot = false;
+  final List<Completer<void>> _snapshotWaiters = [];
   bool _refreshing = false;
   bool _refreshPending = false;
   int _localGeneration = 0;
@@ -44,6 +46,28 @@ class WatchedStatusService extends ChangeNotifier {
   Set<TrackingSource> _tickSources = Set<TrackingSource>.of(
     TrackingSource.values,
   );
+
+  /// True once the local snapshot has been published this profile session.
+  /// The hide-watched filter hides nothing before that, so a cold start never
+  /// paints a list that then loses items a beat later.
+  bool get hasSnapshot => _hasSnapshot;
+
+  /// Completes once [hasSnapshot] is true (immediately if it already is).
+  Future<void> get firstSnapshot {
+    if (_hasSnapshot) return Future.value();
+    final c = Completer<void>();
+    _snapshotWaiters.add(c);
+    return c.future;
+  }
+
+  void _markSnapshot() {
+    if (_hasSnapshot) return;
+    _hasSnapshot = true;
+    for (final c in _snapshotWaiters) {
+      if (!c.isCompleted) c.complete();
+    }
+    _snapshotWaiters.clear();
+  }
 
   bool isWatched(String imdbId, String contentType) {
     final id = imdbId.trim().toLowerCase();
@@ -123,6 +147,7 @@ class WatchedStatusService extends ChangeNotifier {
     _mdblistDirtyAt = null;
     _mdblistRefreshTimer?.cancel();
     _mdblistRefreshTimer = null;
+    _hasSnapshot = false;
     _localMovies = const {};
     _localSeries = const {};
     _traktMovies = const {};
@@ -190,6 +215,7 @@ class WatchedStatusService extends ChangeNotifier {
       if (generation != _localGeneration) return;
       _localMovies = results[0];
       _localSeries = <String>{...results[1], ...results[2]};
+      _markSnapshot();
       notifyListeners();
 
       // Calendar reconciliation may involve network requests. Keep it behind
@@ -250,6 +276,7 @@ class WatchedStatusService extends ChangeNotifier {
     if (generation == _generation && localGeneration == _localGeneration) {
       _localMovies = localMovies;
       _localSeries = localSeries;
+      _markSnapshot();
       notifyListeners();
     }
 

--- a/lib/services/webdav_sync/webdav_sync_active_profile_refresh.dart
+++ b/lib/services/webdav_sync/webdav_sync_active_profile_refresh.dart
@@ -1,5 +1,6 @@
 import '../../theme/app_theme_controller.dart';
 import '../discover_prefs.dart';
+import '../hide_watched_prefs.dart';
 import '../engine/engine_profile_lifecycle.dart';
 import '../engine/local_engine_storage.dart';
 import '../main_page_bridge.dart';
@@ -94,6 +95,11 @@ final class DefaultWebDavSyncActiveProfileRefresher
       await guarded(StreamBadgesService.instance.refreshFromPreferences);
     }
 
+    if (changedKeys.contains(HideWatchedPrefs.key)) {
+      await HideWatchedPrefs.refreshFromPreferences(
+        authorizationBarrier: authorizationBarrier,
+      );
+    }
     final discoverChanged = changedKeys.any(
       (key) => key.startsWith('discover_'),
     );

--- a/lib/services/webdav_sync/webdav_sync_ui_refresh.dart
+++ b/lib/services/webdav_sync/webdav_sync_ui_refresh.dart
@@ -1,4 +1,5 @@
 import '../home_row_refresh.dart';
+import '../hide_watched_prefs.dart';
 import '../iptv_channel_order.dart';
 import '../iptv_media_store.dart';
 import '../main_page_bridge.dart';
@@ -31,6 +32,7 @@ enum _WebDavSyncUiRefreshTarget {
 /// awaited `notifyPlaylistChanged` path in the active-profile refresher.
 abstract final class WebDavSyncUiRefresh {
   static const Map<String, Set<_WebDavSyncUiRefreshTarget>> _targetsByKey = {
+    HideWatchedPrefs.key: {_WebDavSyncUiRefreshTarget.homeSettings},
     'tv/ch': {_WebDavSyncUiRefreshTarget.debrifyTvLibrary},
     'tv/pool': {_WebDavSyncUiRefreshTarget.debrifyTvLibrary},
     'catalog/hidden': {_WebDavSyncUiRefreshTarget.iptvCatalog},

--- a/lib/widgets/home/catalog_continuation_button.dart
+++ b/lib/widgets/home/catalog_continuation_button.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// Keeps the remote's focus on a pending action while suppressing repeat presses.
+class CatalogContinuationButton extends StatelessWidget {
+  const CatalogContinuationButton({
+    super.key,
+    required this.focusNode,
+    required this.busy,
+    required this.label,
+    required this.onPressed,
+    this.autofocus = false,
+  });
+
+  final FocusNode focusNode;
+  final bool busy;
+  final String label;
+  final VoidCallback onPressed;
+  final bool autofocus;
+
+  @override
+  Widget build(BuildContext context) => TextButton.icon(
+    focusNode: focusNode,
+    autofocus: autofocus,
+    onPressed: () {
+      if (!busy) onPressed();
+    },
+    icon: const Icon(Icons.arrow_forward_rounded),
+    label: Text(busy ? '$label · Loading…' : label),
+  );
+}

--- a/lib/widgets/home/home_continuation_focus.dart
+++ b/lib/widgets/home/home_continuation_focus.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/widgets.dart';
+
+/// Restores focus without requesting an offstage or disposed rail's nodes.
+/// Candidates are ordered by preference: the origin, active stage, then any
+/// other mounted Home card. False lets the caller fall back to the sidebar.
+bool focusMountedHomeNode(Iterable<FocusNode?> candidates) {
+  for (final node in candidates) {
+    if (node == null ||
+        node.parent == null ||
+        !(node.context?.mounted ?? false) ||
+        !node.canRequestFocus) {
+      continue;
+    }
+    node.requestFocus();
+    return true;
+  }
+  return false;
+}

--- a/lib/widgets/see_all/see_all_poster_grid.dart
+++ b/lib/widgets/see_all/see_all_poster_grid.dart
@@ -382,6 +382,8 @@ class SeeAllPosterGridState extends State<SeeAllPosterGrid> {
         _nodes[target].requestFocus();
         // Prefetch when stepping into the last two rows.
         if (target >= last - cols) widget.onLoadMore();
+      } else {
+        widget.onExitBottom?.call();
       }
       return KeyEventResult.handled;
     }

--- a/test/catalog_continuation_button_test.dart
+++ b/test/catalog_continuation_button_test.dart
@@ -1,0 +1,41 @@
+import 'package:debrify/widgets/home/catalog_continuation_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('DPAD focus survives busy and repeated Enter cannot queue work', (
+    tester,
+  ) async {
+    final node = FocusNode();
+    addTearDown(node.dispose);
+    var calls = 0;
+    Widget board(bool busy) => MaterialApp(
+      home: Scaffold(
+        body: CatalogContinuationButton(
+          focusNode: node,
+          busy: busy,
+          label: 'Continue paused rows',
+          onPressed: () => calls++,
+        ),
+      ),
+    );
+    await tester.pumpWidget(board(false));
+    node.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    expect(calls, 1);
+    await tester.pumpWidget(board(true));
+    await tester.pump();
+    expect(node.hasFocus, isTrue);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    expect(calls, 1);
+    // A watched-only batch leaves the action present and ready for another try.
+    await tester.pumpWidget(board(false));
+    await tester.pump();
+    expect(node.hasFocus, isTrue);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    expect(calls, 2);
+    await tester.pumpWidget(const SizedBox());
+  });
+}

--- a/test/collection_catalog_pager_test.dart
+++ b/test/collection_catalog_pager_test.dart
@@ -23,6 +23,56 @@ void main() {
     fetch: fetch,
   );
   test(
+    'watched-only collection windows remain resumable in rails and All',
+    () async {
+      Future<List<StremioMeta>> fetch(
+        StremioAddon a,
+        StremioAddonCatalog c, {
+        int skip = 0,
+        String? genre,
+        void Function(int)? onRawCount,
+      }) async {
+        onRawCount?.call(skip < 10 ? 1 : 0);
+        return skip < 10 ? [meta('$skip')] : [];
+      }
+
+      bool hides(StremioMeta m) => int.parse(m.id) < 8;
+      final rail = CollectionCatalogPager(
+        addon: addon,
+        catalog: addon.catalogs.single,
+        fetch: fetch,
+        hides: hides,
+      );
+      expect(await rail.nextPage(), isEmpty);
+      expect(rail.exhausted, isFalse);
+      expect(rail.skip, 8);
+      expect((await rail.nextPage()).single.id, '8');
+      final folder = HomeCollectionFolder(
+        id: 'filtered',
+        title: 'Filtered',
+        sources: [
+          CollectionCatalogSource(
+            addonId: addon.id,
+            catalogId: addon.catalogs.single.id,
+            type: 'movie',
+          ),
+        ],
+      );
+      final all = CollectionFolderLoader(
+        folder: folder,
+        installedAddons: [addon],
+        fetch: fetch,
+        hides: hides,
+      );
+      expect(await all.nextPage(), isEmpty);
+      expect(all.exhausted, isFalse);
+      expect(all.hasErrors, isTrue);
+      expect((await all.nextPage()).single.id, '8');
+      expect(all.hasErrors, isFalse);
+    },
+  );
+
+  test(
     'transport failure preserves cursor and successful retry preserves source',
     () async {
       var failed = true;

--- a/test/collection_catalog_pager_test.dart
+++ b/test/collection_catalog_pager_test.dart
@@ -67,6 +67,7 @@ void main() {
       expect(await all.nextPage(), isEmpty);
       expect(all.exhausted, isFalse);
       expect(all.hasErrors, isTrue);
+      expect(all.hasLoadFailures, isFalse);
       expect((await all.nextPage()).single.id, '8');
       expect(all.hasErrors, isFalse);
     },
@@ -207,6 +208,7 @@ void main() {
     );
     expect(await loader.nextPage(), isEmpty);
     expect(loader.hasErrors, true);
+    expect(loader.hasLoadFailures, true);
     expect(loader.exhausted, false);
   });
 

--- a/test/filtered_catalog_pager_regression_test.dart
+++ b/test/filtered_catalog_pager_regression_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:debrify/models/stremio_addon.dart';
+import 'package:debrify/services/filtered_catalog_pager.dart';
+
+void main() {
+  test(
+    'transport failure retains its cursor without declaring exhaustion',
+    () async {
+      final page = await fetchFilteredPage(
+        (skip, raw) async => [],
+        skip: 40,
+        hides: (_) => false,
+      );
+      expect(page.items, isEmpty);
+      expect(page.nextSkip, 40);
+      expect(page.exhausted, isFalse);
+      expect(page.fetches, 1);
+    },
+  );
+
+  test('initial top-up deduplicates addons that ignore skip', () async {
+    final page = await fetchFilteredPage(
+      (skip, onRaw) async {
+        onRaw(2);
+        return [
+          StremioMeta(id: 'tt1', type: 'movie', name: 'One'),
+          StremioMeta(id: 'tt2', type: 'movie', name: 'Two'),
+        ];
+      },
+      skip: 0,
+      hides: (m) => m.id == 'tt2',
+    );
+    expect(page.items.map((m) => m.id).toList(), ['tt1']);
+  });
+
+  test('raw nonempty window with no valid metas is not exhaustion', () async {
+    final page = await fetchFilteredPage(
+      (skip, onRaw) async {
+        onRaw(10);
+        if (skip == 0) return <StremioMeta>[];
+        return [StremioMeta(id: 'tt1', type: 'movie', name: 'One')];
+      },
+      skip: 0,
+      hides: (_) => false,
+      minItems: 1,
+    );
+    expect(page.items.map((m) => m.id).toList(), ['tt1']);
+    expect(page.exhausted, isFalse);
+  });
+
+  test(
+    'four watched windows still leave a later unwatched page reachable',
+    () async {
+      Future<List<StremioMeta>> fetch(
+        int skip,
+        void Function(int) onRaw,
+      ) async {
+        onRaw(10);
+        return [
+          for (var i = skip; i < skip + 10; i++)
+            StremioMeta(id: 'tt$i', type: 'movie', name: '$i'),
+        ];
+      }
+
+      final page = await fetchFilteredPage(
+        fetch,
+        skip: 0,
+        hides: (m) => int.parse(m.id.substring(2)) < 40,
+      );
+      expect(page.items, isEmpty);
+      expect(page.exhausted, isFalse);
+      expect(page.nextSkip, 40);
+      final next = await fetchFilteredPage(
+        fetch,
+        skip: page.nextSkip,
+        hides: (m) => int.parse(m.id.substring(2)) < 40,
+      );
+      expect(next.items, isNotEmpty);
+    },
+  );
+}

--- a/test/filtered_catalog_pager_regression_test.dart
+++ b/test/filtered_catalog_pager_regression_test.dart
@@ -4,6 +4,35 @@ import 'package:debrify/services/filtered_catalog_pager.dart';
 
 void main() {
   test(
+    'switch off ends failed fetches without a retryable paused page',
+    () async {
+      var calls = 0;
+      final page = await fetchFilteredPage((skip, raw) async {
+        calls++;
+        return [];
+      }, skip: 40);
+      expect(page.exhausted, isTrue);
+      expect(page.nextSkip, 40);
+      expect(calls, 1);
+    },
+  );
+
+  test('switch off terminates addons repeating already seen titles', () async {
+    final page = await fetchFilteredPage(
+      (skip, raw) async {
+        raw(20);
+        return [StremioMeta(id: 'tt1', type: 'movie', name: 'One')];
+      },
+      skip: 20,
+      seenIds: {'tt1'},
+    );
+    expect(page.items, isEmpty);
+    expect(page.exhausted, isTrue);
+    expect(page.nextSkip, 40);
+    expect(page.fetches, 1);
+  });
+
+  test(
     'transport failure retains its cursor without declaring exhaustion',
     () async {
       final page = await fetchFilteredPage(

--- a/test/hide_watched_surfaces_test.dart
+++ b/test/hide_watched_surfaces_test.dart
@@ -1,0 +1,180 @@
+import 'dart:convert';
+
+import 'package:debrify/models/stremio_addon.dart';
+import 'package:debrify/screens/see_all/catalog_see_all_screen.dart';
+import 'package:debrify/screens/see_all/mdblist_see_all_screen.dart';
+import 'package:debrify/services/hide_watched_prefs.dart';
+import 'package:debrify/services/mdblist/mdblist_discover_source.dart';
+import 'package:debrify/services/mdblist/mdblist_list_source.dart';
+import 'package:debrify/services/mdblist/mdblist_service.dart';
+import 'package:debrify/services/watched_status_service.dart';
+import 'package:debrify/theme/app_theme.dart';
+import 'package:debrify/theme/app_theme_scope.dart';
+import 'package:debrify/widgets/see_all/see_all_poster_grid.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget host(Widget child) => MaterialApp(
+  home: AppThemeScope(theme: AppThemes.legacy, child: child),
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({
+      HideWatchedPrefs.key: true,
+      'finished_movies_v1': [for (var i = 0; i < 50; i++) 'tt$i'],
+    });
+    HideWatchedPrefs.debugReset();
+    await HideWatchedPrefs.warmUp();
+    WatchedStatusService.instance.resetProfileScope();
+    WatchedStatusService.instance.ensureStarted();
+    await WatchedStatusService.instance.firstSnapshot;
+  });
+
+  tearDown(() => HideWatchedPrefs.debugReset());
+
+  for (final seeded in [false, true]) {
+    testWidgets(
+      'See All resumes watched-only ${seeded ? "later" : "initial"} pages',
+      (tester) async {
+        tester.view.physicalSize = const Size(1280, 900);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+        const catalog = StremioAddonCatalog(
+          id: 'test',
+          type: 'movie',
+          name: 'Test',
+        );
+        final addon = StremioAddon(
+          id: 'test',
+          name: 'Test',
+          manifestUrl: 'https://example.invalid/manifest.json',
+          baseUrl: 'https://example.invalid',
+          catalogs: [catalog],
+        );
+        final skips = <int>[];
+        await tester.pumpWidget(
+          host(
+            CatalogSeeAllScreen(
+              isTelevision: seeded,
+              addon: addon,
+              initialCatalog: catalog,
+              onOpenItem: (_) {},
+              seedItems: seeded
+                  ? [StremioMeta(id: 'seed', type: 'movie', name: 'Seed')]
+                  : [],
+              seedNextSkip: seeded ? 10 : 0,
+              fetchPage: (skip, raw) async {
+                skips.add(skip);
+                raw(skip < 60 ? 10 : 0);
+                return [
+                  if (skip < 60)
+                    for (var i = skip; i < skip + 10; i++)
+                      StremioMeta(
+                        id: 'tt$i',
+                        imdbId: 'tt$i',
+                        type: 'movie',
+                        name: 'Title $i',
+                      ),
+                ];
+              },
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(skips, seeded ? [10, 20, 30, 40] : [0, 10, 20, 30]);
+        expect(find.text('Continue loading'), findsOneWidget);
+        final countBefore = skips.length;
+        await tester.pump(const Duration(seconds: 2));
+        expect(skips.length, countBefore); // No unbounded automatic retry.
+        if (seeded) {
+          final state = tester.state<SeeAllPosterGridState>(
+            find.byType(SeeAllPosterGrid),
+          );
+          state.focusFirst();
+          await tester.pump();
+          await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+          await tester.pump();
+          expect(
+            FocusManager.instance.primaryFocus?.debugLabel,
+            'seeall_retry',
+          );
+          await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        } else {
+          await tester.tap(find.text('Continue loading'));
+        }
+        await tester.pumpAndSettle();
+        expect(
+          skips,
+          seeded ? [10, 20, 30, 40, 50, 60] : [0, 10, 20, 30, 40, 50, 60],
+        );
+        final grid = tester.widget<SeeAllPosterGrid>(
+          find.byType(SeeAllPosterGrid),
+        );
+        expect(grid.items.any((m) => m.id == 'tt50'), isTrue);
+        expect(grid.items.any((m) => m.id == 'tt0'), isFalse);
+      },
+    );
+  }
+
+  for (final public in [false, true]) {
+    for (final liked in [false, true]) {
+      testWidgets('MDBList initial list public=$public liked=$liked', (
+        tester,
+      ) async {
+        tester.view.physicalSize = const Size(1600, 900);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+        final service = MdblistService.forTesting(
+          client: MockClient(
+            (_) async => http.Response(
+              jsonEncode({
+                'movies': [
+                  {
+                    'imdb_id': 'tt1',
+                    'title': 'Watched title',
+                    'mediatype': 'movie',
+                  },
+                  {
+                    'imdb_id': 'tt99',
+                    'title': 'New title',
+                    'mediatype': 'movie',
+                  },
+                ],
+              }),
+              200,
+            ),
+          ),
+          apiKeyProvider: () async => 'test-key',
+        );
+        await tester.pumpWidget(
+          host(
+            MdblistSeeAllScreen(
+              initialList: MdblistListChoice(
+                id: 1,
+                name: 'A list',
+                liked: liked,
+              ),
+              initialListIsPublic: public,
+              source: MdblistDiscoverSource.forTesting(service),
+              isAuthenticated: () async => true,
+              onOpen: (_) {},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        final grid = tester.widget<SeeAllPosterGrid>(
+          find.byType(SeeAllPosterGrid),
+        );
+        expect(grid.items.any((m) => m.id == 'tt1'), !public || liked);
+        expect(grid.items.any((m) => m.id == 'tt99'), isTrue);
+      });
+    }
+  }
+}

--- a/test/hide_watched_surfaces_test.dart
+++ b/test/hide_watched_surfaces_test.dart
@@ -1,3 +1,5 @@
+import 'package:debrify/services/mdblist/mdblist_discover_models.dart';
+import 'package:debrify/widgets/see_all/stremio_dropdown.dart';
 import 'dart:convert';
 
 import 'package:debrify/models/stremio_addon.dart';
@@ -177,4 +179,74 @@ void main() {
       });
     }
   }
+  testWidgets(
+    'watched recommendation pages remain resumable with the TV remote',
+    (tester) async {
+      tester.view.physicalSize = const Size(1600, 900);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      final requests = <String>[];
+      final service = MdblistService.forTesting(
+        client: MockClient((request) async {
+          requests.add(request.url.toString());
+          if (request.url.path == '/lists/recommended') {
+            return http.Response(
+              jsonEncode({
+                'sections': [
+                  {'section': 'rising', 'name': 'Rising'},
+                ],
+              }),
+              200,
+            );
+          }
+          if (request.url.path == '/lists/recommended/rising/items') {
+            final second = request.url.queryParameters['cursor'] == 'next';
+            return http.Response(
+              jsonEncode({
+                'movies': [
+                  {
+                    'imdb_id': second ? 'tt99' : 'tt1',
+                    'title': second ? 'Unseen next page' : 'Watched first page',
+                    'mediatype': 'movie',
+                  },
+                ],
+                'pagination': {'next_cursor': second ? null : 'next'},
+              }),
+              200,
+            );
+          }
+          return http.Response(jsonEncode({'movies': []}), 200);
+        }),
+        apiKeyProvider: () async => 'test-key',
+      );
+      await tester.pumpWidget(
+        host(
+          MdblistSeeAllScreen(
+            source: MdblistDiscoverSource.forTesting(service),
+            isAuthenticated: () async => true,
+            isTelevision: true,
+            onOpen: (_) {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(StremioDropdown<MdblistDiscoverGroup>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('For You').last);
+      await tester.pumpAndSettle();
+      expect(find.text('Nothing matches these filters'), findsOneWidget);
+      expect(requests.where((r) => r.contains('/rising/items')), hasLength(1));
+      expect(find.text('Continue loading'), findsOneWidget);
+      expect(FocusManager.instance.primaryFocus?.debugLabel, 'msa_more');
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+      expect(requests.where((r) => r.contains('/rising/items')), hasLength(2));
+      expect(requests.last, contains('cursor=next'));
+      final grid = tester.widget<SeeAllPosterGrid>(
+        find.byType(SeeAllPosterGrid),
+      );
+      expect(grid.items.map((m) => m.id), ['tt99']);
+      expect(find.text('Continue loading'), findsNothing);
+    },
+  );
 }

--- a/test/hide_watched_test.dart
+++ b/test/hide_watched_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:debrify/models/stremio_addon.dart';
+import 'package:debrify/services/filtered_catalog_pager.dart';
+import 'package:debrify/services/hide_watched_prefs.dart';
+import 'package:debrify/services/watched_filter.dart';
+
+StremioMeta _meta(String id, {String type = 'movie', String? imdb}) =>
+    StremioMeta(id: id, type: type, name: id, imdbId: imdb);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    HideWatchedPrefs.debugReset();
+  });
+
+  group('HideWatchedPrefs', () {
+    test('defaults to off', () async {
+      await HideWatchedPrefs.warmUp();
+      expect(HideWatchedPrefs.enabled, isFalse);
+    });
+
+    test('setEnabled is cache-first and survives a re-warm', () async {
+      await HideWatchedPrefs.warmUp();
+      final pending = HideWatchedPrefs.setEnabled(true);
+      expect(HideWatchedPrefs.enabled, isTrue);
+      await pending;
+      HideWatchedPrefs.debugReset();
+      expect(HideWatchedPrefs.enabled, isFalse);
+      await HideWatchedPrefs.warmUp();
+      expect(HideWatchedPrefs.enabled, isTrue);
+      expect(await HideWatchedPrefs.read(), isTrue);
+    });
+  });
+
+  group('WatchedFilter', () {
+    test('is the identity when the switch is off', () {
+      final items = [_meta('a', imdb: 'tt1'), _meta('b')];
+      expect(WatchedFilter.enabled, isFalse);
+      expect(identical(WatchedFilter.apply(items), items), isTrue);
+      expect(WatchedFilter.predicate, isNull);
+      expect(WatchedFilter.hides(items.first), isFalse);
+    });
+
+    test('hides nothing before the first watched snapshot', () async {
+      await HideWatchedPrefs.setEnabled(true);
+      expect(WatchedFilter.enabled, isTrue);
+      expect(WatchedFilter.predicate, isNotNull);
+      // No snapshot has been published in this test process, so even a
+      // matchable title passes through rather than flashing away later.
+      expect(WatchedFilter.hides(_meta('tt1', imdb: 'tt1')), isFalse);
+      expect(WatchedFilter.apply([_meta('x', imdb: 'tt9')]), hasLength(1));
+    });
+  });
+
+  group('fetchFilteredPage', () {
+    List<StremioMeta> window(int skip, int size, int total) => [
+      for (var i = skip; i < skip + size && i < total; i++)
+        _meta('tt$i', imdb: 'tt$i'),
+    ];
+
+    test('without a predicate it is one plain fetch', () async {
+      final calls = <int>[];
+      final page = await fetchFilteredPage((skip, onRaw) async {
+        calls.add(skip);
+        final w = window(skip, 10, 100);
+        onRaw(w.length);
+        return w;
+      }, skip: 0);
+      expect(calls, [0]);
+      expect(page.items, hasLength(10));
+      expect(page.nextSkip, 10);
+      expect(page.exhausted, isFalse);
+      expect(page.fetches, 1);
+    });
+
+    test('tops up across windows until minItems survive', () async {
+      final calls = <int>[];
+      // Even-numbered titles are "watched".
+      bool hides(StremioMeta m) => int.parse(m.id.substring(2)).isEven;
+      final page = await fetchFilteredPage(
+        (skip, onRaw) async {
+          calls.add(skip);
+          final w = window(skip, 10, 100);
+          onRaw(w.length);
+          return w;
+        },
+        skip: 0,
+        hides: hides,
+        minItems: 12,
+      );
+      // 5 survivors per window → three windows to reach 12.
+      expect(calls, [0, 10, 20]);
+      expect(page.items.length, greaterThanOrEqualTo(12));
+      expect(page.items.every((m) => !hides(m)), isTrue);
+      expect(page.nextSkip, 30);
+      expect(page.exhausted, isFalse);
+    });
+
+    test(
+      'a raw-empty window is exhaustion; an all-filtered one is not',
+      () async {
+        final calls = <int>[];
+        final page = await fetchFilteredPage(
+          (skip, onRaw) async {
+            calls.add(skip);
+            final w = window(skip, 10, 25); // 25 titles total
+            onRaw(w.length);
+            return w;
+          },
+          skip: 0,
+          hides: (_) => true, // everything watched
+          minItems: 12,
+          maxFetches: 10,
+        );
+        expect(page.items, isEmpty);
+        expect(page.exhausted, isTrue);
+        expect(calls, [0, 10, 20, 25]);
+        expect(page.nextSkip, 25);
+      },
+    );
+
+    test('honours maxFetches and advances skip by raw counts', () async {
+      final page = await fetchFilteredPage(
+        (skip, onRaw) async {
+          // The addon reports a raw window bigger than what it returns
+          // (some ids were invalid and dropped upstream).
+          onRaw(20);
+          return window(skip, 10, 1000);
+        },
+        skip: 40,
+        hides: (_) => true,
+        minItems: 5,
+        maxFetches: 2,
+      );
+      expect(page.fetches, 2);
+      expect(page.nextSkip, 80);
+      expect(page.exhausted, isFalse);
+    });
+
+    test('de-duplicates against seenIds across calls', () async {
+      final seen = <String>{'tt1', 'tt2'};
+      final page = await fetchFilteredPage(
+        (skip, onRaw) async {
+          final w = window(0, 5, 5);
+          onRaw(w.length);
+          return w;
+        },
+        skip: 0,
+        hides: (_) => false,
+        minItems: 1,
+      );
+      expect(page.items.map((m) => m.id), ['tt0', 'tt1', 'tt2', 'tt3', 'tt4']);
+      final again = await fetchFilteredPage(
+        (skip, onRaw) async {
+          final w = window(0, 5, 5);
+          onRaw(w.length);
+          return w;
+        },
+        skip: 0,
+        hides: (_) => false,
+        minItems: 1,
+        seenIds: seen,
+      );
+      expect(again.items.map((m) => m.id), ['tt0', 'tt3', 'tt4']);
+      expect(seen, containsAll(['tt0', 'tt3', 'tt4']));
+    });
+  });
+}

--- a/test/home_catalog_refresh_test.dart
+++ b/test/home_catalog_refresh_test.dart
@@ -1,6 +1,5 @@
 import 'package:debrify/models/stremio_addon.dart';
 import 'package:debrify/services/home_catalog_refresh.dart';
-import 'package:debrify/services/filtered_catalog_pager.dart';
 import 'package:debrify/widgets/home/home_row_focus.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -36,24 +35,35 @@ void main() {
       catalog: catalog,
       previous: previous(addon('https://old.invalid')),
       isCurrent: () => true,
-      fetch: (skip, onRawCount) async {
-        final page = await fetchFilteredPage(
-          (cursor, raw) async {
-            skips.add(cursor);
-            raw(25);
-            return List.generate(25, (i) => item(cursor + i));
-          },
-          skip: skip,
-          hides: (meta) => int.parse(meta.id) % 5 != 0,
-        );
-        onRawCount(page.nextSkip - skip);
-        return page.items;
+      hides: (meta) => int.parse(meta.id) % 5 != 0,
+      fetch: (cursor, raw) async {
+        skips.add(cursor);
+        raw(25);
+        return List.generate(25, (i) => item(cursor + i));
       },
     );
     expect(skips, [0, 25, 50, 75, 100, 125]);
     expect(refreshed!.nextSkip, 150);
     expect(refreshed.items, hasLength(30));
     expect(refreshed.items.every((m) => int.parse(m.id) % 5 == 0), isTrue);
+  });
+
+  test('an all-watched first batch preserves a resumable Home row', () async {
+    final row = await loadHomeCatalogSection(
+      addon: addon('https://filtered.invalid'),
+      catalog: catalog,
+      isCurrent: () => true,
+      hides: (_) => true,
+      fetch: (skip, raw) async {
+        raw(10);
+        return List.generate(10, (i) => item(skip + i));
+      },
+    );
+    expect(row, isNotNull);
+    expect(row!.items, isEmpty);
+    expect(row.nextSkip, 40);
+    expect(row.exhausted, isFalse);
+    expect(row.pagingPaused, isTrue);
   });
 
   testWidgets('addon refresh preserves focus beyond the first page', (
@@ -143,7 +153,7 @@ void main() {
     expect(calls, 1);
   });
 
-  test('duplicate pages stop a catalog which ignores skip', () async {
+  test('duplicate pages pause a catalog which ignores skip', () async {
     var calls = 0;
     final result = await loadHomeCatalogSection(
       addon: addon('https://new.invalid'),
@@ -157,7 +167,8 @@ void main() {
       },
     );
     expect(calls, 2);
-    expect(result!.exhausted, isTrue);
+    expect(result!.exhausted, isFalse);
+    expect(result.pagingPaused, isTrue);
     expect(result.items, hasLength(1));
   });
 }

--- a/test/home_catalog_refresh_test.dart
+++ b/test/home_catalog_refresh_test.dart
@@ -153,22 +153,25 @@ void main() {
     expect(calls, 1);
   });
 
-  test('duplicate pages pause a catalog which ignores skip', () async {
-    var calls = 0;
-    final result = await loadHomeCatalogSection(
-      addon: addon('https://new.invalid'),
-      catalog: catalog,
-      previous: previous(addon('https://old.invalid')),
-      isCurrent: () => true,
-      fetch: (skip, raw) async {
-        calls++;
-        raw(1);
-        return [item(1)];
-      },
-    );
-    expect(calls, 2);
-    expect(result!.exhausted, isFalse);
-    expect(result.pagingPaused, isTrue);
-    expect(result.items, hasLength(1));
-  });
+  test(
+    'switch-off duplicate pages terminate a catalog which ignores skip',
+    () async {
+      var calls = 0;
+      final result = await loadHomeCatalogSection(
+        addon: addon('https://new.invalid'),
+        catalog: catalog,
+        previous: previous(addon('https://old.invalid')),
+        isCurrent: () => true,
+        fetch: (skip, raw) async {
+          calls++;
+          raw(1);
+          return [item(1)];
+        },
+      );
+      expect(calls, 2);
+      expect(result!.exhausted, isTrue);
+      expect(result.pagingPaused, isFalse);
+      expect(result.items, hasLength(1));
+    },
+  );
 }

--- a/test/home_continuation_focus_test.dart
+++ b/test/home_continuation_focus_test.dart
@@ -1,0 +1,72 @@
+import 'package:debrify/widgets/home/home_continuation_focus.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'continuation skips an unmounted first rail and restores the active rail',
+    (tester) async {
+      final firstRail = FocusNode(debugLabel: 'first');
+      final activeRail = FocusNode(debugLabel: 'active');
+      final continuation = FocusNode(debugLabel: 'continue');
+      addTearDown(() {
+        firstRail.dispose();
+        activeRail.dispose();
+        continuation.dispose();
+      });
+      Widget board(bool showFirst) => MaterialApp(
+        home: Column(
+          children: [
+            if (showFirst)
+              Focus(focusNode: firstRail, child: const Text('First rail')),
+            Focus(focusNode: activeRail, child: const Text('Active rail')),
+            TextButton(
+              focusNode: continuation,
+              onPressed: () {},
+              child: const Text('Continue'),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpWidget(board(true));
+      firstRail.requestFocus();
+      await tester.pump();
+      // Canvas replaces the previously displayed rail while keeping its nodes.
+      await tester.pumpWidget(board(false));
+      continuation.requestFocus();
+      await tester.pump();
+      expect(focusMountedHomeNode([firstRail, activeRail]), isTrue);
+      await tester.pump();
+      expect(activeRail.hasFocus, isTrue);
+      expect(continuation.hasFocus, isFalse);
+      await tester.pumpWidget(const SizedBox());
+      expect(focusMountedHomeNode([firstRail, activeRail]), isFalse);
+    },
+  );
+
+  testWidgets('a mounted origin takes precedence over other visible cards', (
+    tester,
+  ) async {
+    final origin = FocusNode();
+    final other = FocusNode();
+    addTearDown(() {
+      origin.dispose();
+      other.dispose();
+    });
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Column(
+          children: [
+            Focus(focusNode: origin, child: const Text('Origin')),
+            Focus(focusNode: other, child: const Text('Other')),
+          ],
+        ),
+      ),
+    );
+    other.requestFocus();
+    await tester.pump();
+    expect(focusMountedHomeNode([origin, other]), isTrue);
+    await tester.pump();
+    expect(origin.hasFocus, isTrue);
+  });
+}

--- a/test/remote_tracking_preferences_refresh_test.dart
+++ b/test/remote_tracking_preferences_refresh_test.dart
@@ -1,0 +1,33 @@
+import 'dart:convert';
+import 'package:debrify/services/hide_watched_prefs.dart';
+import 'package:debrify/services/main_page_bridge.dart';
+import 'package:debrify/services/remote_control/remote_command_router.dart';
+import 'package:debrify/services/remote_control/remote_constants.dart';
+import 'package:debrify/services/remote_control/remote_session.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  test(
+    'direct remote tracking push refreshes Home after updating the cache',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      await HideWatchedPrefs.setEnabled(false);
+      final observed = <bool>[];
+      void refreshed() => observed.add(HideWatchedPrefs.enabled);
+      MainPageBridge.addHomeSettingsListener(refreshed);
+      addTearDown(() {
+        MainPageBridge.removeHomeSettingsListener(refreshed);
+        RemoteCommandRouter().clearProfileSessionState();
+      });
+      await RemoteCommandRouter().receiveTransferCommand(
+        RemoteAction.config,
+        ConfigCommand.trackingPreferences,
+        jsonEncode({'hide_watched': true}),
+        const RemoteCommandContext(encrypted: true, authorized: true),
+      );
+      expect(observed, [true]);
+    },
+  );
+}

--- a/test/services/webdav_sync/webdav_sync_active_profile_refresh_test.dart
+++ b/test/services/webdav_sync/webdav_sync_active_profile_refresh_test.dart
@@ -1,3 +1,6 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:debrify/services/hide_watched_prefs.dart';
+import 'package:debrify/services/webdav_sync/webdav_sync_ui_refresh.dart';
 import 'package:debrify/services/main_page_bridge.dart';
 import 'package:debrify/services/storage_service.dart';
 import 'package:debrify/services/webdav_sync/webdav_sync_active_profile_refresh.dart';
@@ -7,6 +10,54 @@ import 'package:debrify/services/stremio_service.dart';
 
 void main() {
   const refresher = DefaultWebDavSyncActiveProfileRefresher();
+
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('synced hide-watched is refreshed before Home is notified', () async {
+    SharedPreferences.setMockInitialValues({});
+    HideWatchedPrefs.debugReset();
+    await HideWatchedPrefs.warmUp();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(HideWatchedPrefs.key, true);
+    expect(HideWatchedPrefs.enabled, isFalse);
+    final observed = <bool>[];
+    void listener() => observed.add(HideWatchedPrefs.enabled);
+    MainPageBridge.addHomeSettingsListener(listener);
+    addTearDown(() {
+      MainPageBridge.removeHomeSettingsListener(listener);
+      HideWatchedPrefs.debugReset();
+    });
+    await refresher.refresh({
+      HideWatchedPrefs.key,
+    }, authorizationBarrier: () {});
+    WebDavSyncUiRefresh.dispatch({HideWatchedPrefs.key});
+    expect(observed, [true]);
+    await prefs.remove(HideWatchedPrefs.key);
+    await refresher.refresh({
+      HideWatchedPrefs.key,
+    }, authorizationBarrier: () {});
+    WebDavSyncUiRefresh.dispatch({HideWatchedPrefs.key});
+    expect(observed, [true, false]);
+  });
+
+  test(
+    'profile switch during hide-watched read prevents cache publication',
+    () async {
+      SharedPreferences.setMockInitialValues({HideWatchedPrefs.key: true});
+      HideWatchedPrefs.debugReset();
+      var barriers = 0;
+      await expectLater(
+        refresher.refresh(
+          {HideWatchedPrefs.key},
+          authorizationBarrier: () {
+            if (++barriers == 2) throw StateError('profile switched');
+          },
+        ),
+        throwsStateError,
+      );
+      expect(HideWatchedPrefs.enabled, isFalse);
+    },
+  );
 
   test('unrelated keys and stale sessions cannot notify addon views', () async {
     var calls = 0;

--- a/test/watched_snapshot_retry_test.dart
+++ b/test/watched_snapshot_retry_test.dart
@@ -1,0 +1,26 @@
+import 'package:debrify/services/watched_snapshot_retry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('transient storage failures recover the watched snapshot', () async {
+    var attempts = 0;
+    final result = await readWatchedSnapshotWithRetry(() async {
+      if (++attempts < 3) throw StateError('Storage unavailable');
+      return {'tt1'};
+    }, retryDelay: Duration.zero);
+    expect(result, {'tt1'});
+    expect(attempts, 3);
+  });
+
+  test('persistent failure is bounded and remains observable', () async {
+    var attempts = 0;
+    await expectLater(
+      readWatchedSnapshotWithRetry(() async {
+        attempts++;
+        throw StateError('Storage unavailable');
+      }, retryDelay: Duration.zero),
+      throwsStateError,
+    );
+    expect(attempts, 3);
+  });
+}

--- a/test/watched_snapshot_retry_test.dart
+++ b/test/watched_snapshot_retry_test.dart
@@ -1,7 +1,38 @@
+import 'dart:async';
+
 import 'package:debrify/services/watched_snapshot_retry.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('parallel failure is handled while local storage retries', () async {
+    final calendar = Completer<int>();
+    final tracker = Completer<int>();
+    final failure = StateError('Calendar storage unavailable');
+    final captured = captureWatchedRead(
+      Future.wait([calendar.future, tracker.future]),
+    );
+    calendar.completeError(failure);
+    // Leave the captured result unawaited across real async turns, as the
+    // local retry backoff does. An unhandled error would fail this test.
+    var attempts = 0;
+    await readWatchedSnapshotWithRetry(() async {
+      if (++attempts == 1) throw StateError('Retry local storage');
+      return {'tt1'};
+    }, retryDelay: const Duration(milliseconds: 1));
+    var joined = false;
+    unawaited(captured.then((_) => joined = true));
+    await Future<void>.delayed(Duration.zero);
+    expect(joined, isFalse);
+    tracker.complete(1);
+    final result = await captured;
+    expect(result.unwrap, throwsA(same(failure)));
+  });
+
+  test('captured successful reads retain their result', () async {
+    final result = await captureWatchedRead(Future.value({'tt1'}));
+    expect(result.unwrap(), {'tt1'});
+  });
+
   test('transient storage failures recover the watched snapshot', () async {
     var attempts = 0;
     final result = await readWatchedSnapshotWithRetry(() async {


### PR DESCRIPTION
## Summary

Adds a **Hide watched titles** switch (Settings → Tracking). When on, movies the user has finished and shows they have completed are left out of catalog surfaces: Home rows and their horizontal paging, the Spotlight hero reel, catalog search, See All / Discover, Trakt's discovery lists and MDBList public lists. Continue Watching, Watchlist, Favorites and every personal tracker list stay complete. Off by default, per profile, included in Backup & Restore.

## Motivation

Catalog rows such as Popular and Trending are dominated by titles a long-time user has already seen. The ✓ badge marks them, but the rows still have to be scrolled past. This switch turns the information the badge already has into a filter, without touching the user's own lists.

## Design

- **One definition of "watched".** The filter asks `WatchedStatusService`, the same synchronous, profile-scoped union of local completion, Trakt history, Simkl and MDBList "completed" that draws the ✓ on posters, masked by the existing Watched-ticks source selection on the same settings page. The tick and the hiding therefore always agree, and the series threshold is inherited: the whole show finished, never "saw one episode". Only movies and series with an IMDb id are matched; everything else passes through.
- **Sync preference** (`lib/services/hide_watched_prefs.dart`): a cached flag warmed in `main()` and on profile switch, following `DiscoverPrefs`, because the filter runs inside list construction and cannot await storage.
- **Filter** (`lib/services/watched_filter.dart`): `hides(meta)` / `apply(list)`; a no-op (returns the same list instance) while the switch is off. Nothing is hidden until the first watched snapshot has been published, so a cold start never paints a list that then loses items a beat later. `WatchedStatusService` gains `hasSnapshot` / `firstSnapshot` for this; `_startRefresh` is untouched.
- **Paging** (`lib/services/filtered_catalog_pager.dart`): filtering a window can leave it short or empty, and every paged surface previously treated an empty page as "catalog exhausted". `fetchFilteredPage` keeps pulling windows until enough titles survive (12, at most 4 windows), advances `skip` by the addon's raw counts (the existing `onRawCount` contract), and treats only a raw-empty window as exhaustion. With the switch off it is exactly one fetch, so unfiltered behaviour is unchanged.
- **Wiring**: Home board first page and row paging, the hero source, catalog search results, `CatalogSeeAllScreen` (which is also Discover's catalog source), Trakt/MDBList list rows on Home and their See All screens. Which Trakt lists filter is declared beside the enum (`TraktSeeAllList.hidesWatched`: trending, popular, anticipated, recommendations); history, watchlist, collection, ratings and custom/liked lists are exempt, as are all Simkl lists and the user's own or liked MDBList lists.
- **Settings**: a fourth "Hide watched" section on the Tracking page (mobile and TV layouts), a settings-search entry, and the flag rides the tracking-preferences backup payload as `hide_watched`. Flipping the switch takes the Home board's full reload path, since it changes row membership.
- **Timing**: decisions are pinned at fetch time; finishing a movie removes it on the next board load rather than mid-scroll. On a cold start the board waits at most 1.5 s for the local snapshot before fetching; tracker histories fold in asynchronously and apply from the next load.

## Compatibility

- Inert until enabled; no stored keys change. Existing tests that read `watched_status_service.dart` as text still pass.
- `SeeAllPosterGrid`, `HomeListSection` and the tracker See All screens keep their APIs; the only new public surface is the three services, `TraktSeeAllList.hidesWatched`, and the two snapshot members on `WatchedStatusService`.

## Testing

- `flutter analyze`: clean for all touched files (vendored `packages/media_kit_*` diagnostics excluded).
- `flutter test test/hide_watched_test.dart test/movie_watched_badge_test.dart test/home_extra_rows_test.dart`: preference defaults and re-warm, filter identity/snapshot behaviour, pager top-up, raw-empty vs all-filtered exhaustion, `maxFetches`, skip alignment and de-duplication.
- Manual on Windows desktop: toggle on/off with Home reloading, watched titles absent from rows, hero, See All paging and search; Continue Watching and Watchlist untouched; tracker histories applying after sync.

## Documentation

`docs/hide-watched.md` describes the behaviour, exemptions, paging and design decisions; `CODEMAP.md` gained a routing entry.

## Follow-up

The collections feature (#54) has its own multi-catalog loader; once it lands, routing that loader through `fetchFilteredPage` extends the switch to collection folders.
