### PR TITLE
Extract download destination preferences behind StorageService

### DIFF
--- a/lib/services/storage/download_destination_prefs.dart
+++ b/lib/services/storage/download_destination_prefs.dart
@@ -1,0 +1,59 @@
+import '../profiles/profile_preferences.dart';
+
+/// Profile-scoped destination strings; OS grants remain with the callers.
+class DownloadDestinationPrefs {
+  DownloadDestinationPrefs._();
+
+  static const String _downloadTreeUriKey = 'download_tree_uri_v1';
+  static const String _downloadTreeNameKey = 'download_tree_display_name_v1';
+  static const String _downloadDirPathKey = 'download_dir_path_v1';
+
+  static const Set<String> ownedKeys = {
+    _downloadTreeUriKey,
+    _downloadTreeNameKey,
+    _downloadDirPathKey,
+  };
+
+  static Future<String?> getDownloadTreeUri() async {
+    final prefs = await ProfilePreferences.instance();
+    final v = prefs.getString(_downloadTreeUriKey);
+    return (v == null || v.isEmpty) ? null : v;
+  }
+
+  static Future<String?> getDownloadTreeDisplayName() async {
+    final prefs = await ProfilePreferences.instance();
+    final v = prefs.getString(_downloadTreeNameKey);
+    return (v == null || v.isEmpty) ? null : v;
+  }
+
+  static Future<void> setDownloadTreeUri(
+    String treeUri,
+    String displayName,
+  ) async {
+    final prefs = await ProfilePreferences.instance();
+    await prefs.setString(_downloadTreeUriKey, treeUri);
+    await prefs.setString(_downloadTreeNameKey, displayName);
+  }
+
+  static Future<void> clearDownloadTreeUri() async {
+    final prefs = await ProfilePreferences.instance();
+    await prefs.remove(_downloadTreeUriKey);
+    await prefs.remove(_downloadTreeNameKey);
+  }
+
+  static Future<String?> getDownloadDirPath() async {
+    final prefs = await ProfilePreferences.instance();
+    final v = prefs.getString(_downloadDirPathKey);
+    return (v == null || v.isEmpty) ? null : v;
+  }
+
+  static Future<void> setDownloadDirPath(String dirPath) async {
+    final prefs = await ProfilePreferences.instance();
+    await prefs.setString(_downloadDirPathKey, dirPath);
+  }
+
+  static Future<void> clearDownloadDirPath() async {
+    final prefs = await ProfilePreferences.instance();
+    await prefs.remove(_downloadDirPathKey);
+  }
+}

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -7,6 +7,7 @@ import 'package:synchronized/synchronized.dart';
 import 'dart:convert';
 import 'debrid_service.dart';
 import 'hide_watched_prefs.dart';
+import 'storage/download_destination_prefs.dart';
 import 'iptv_channel_order.dart';
 import 'iptv_media_store.dart';
 import 'profiles/profile_preferences.dart';
@@ -2421,60 +2422,45 @@ class StorageService {
   }
 
   // ── Custom download location (Android SAF tree) ─────────────────────────
-  static const String _downloadTreeUriKey = 'download_tree_uri_v1';
-  static const String _downloadTreeNameKey = 'download_tree_display_name_v1';
 
   /// The persisted SAF tree URI for the user-chosen download folder, or null
   /// when downloads go to the default location (Downloads/Debrify).
-  static Future<String?> getDownloadTreeUri() async {
-    final prefs = await ProfilePreferences.instance();
-    final v = prefs.getString(_downloadTreeUriKey);
-    return (v == null || v.isEmpty) ? null : v;
+  static Future<String?> getDownloadTreeUri() {
+    return DownloadDestinationPrefs.getDownloadTreeUri();
   }
 
-  static Future<String?> getDownloadTreeDisplayName() async {
-    final prefs = await ProfilePreferences.instance();
-    final v = prefs.getString(_downloadTreeNameKey);
-    return (v == null || v.isEmpty) ? null : v;
+  static Future<String?> getDownloadTreeDisplayName() {
+    return DownloadDestinationPrefs.getDownloadTreeDisplayName();
   }
 
   static Future<void> setDownloadTreeUri(
     String treeUri,
     String displayName,
-  ) async {
-    final prefs = await ProfilePreferences.instance();
-    await prefs.setString(_downloadTreeUriKey, treeUri);
-    await prefs.setString(_downloadTreeNameKey, displayName);
+  ) {
+    return DownloadDestinationPrefs.setDownloadTreeUri(treeUri, displayName);
   }
 
-  static Future<void> clearDownloadTreeUri() async {
-    final prefs = await ProfilePreferences.instance();
-    await prefs.remove(_downloadTreeUriKey);
-    await prefs.remove(_downloadTreeNameKey);
+  static Future<void> clearDownloadTreeUri() {
+    return DownloadDestinationPrefs.clearDownloadTreeUri();
   }
 
   // ── Custom download location (desktop: plain filesystem path) ───────────
   // Windows/Linux only. macOS is deliberately excluded: the app is sandboxed
   // with a read-only user-selected-files entitlement, so a picked folder
   // needs security-scoped bookmarks to survive relaunch — separate feature.
-  static const String _downloadDirPathKey = 'download_dir_path_v1';
 
   /// The persisted absolute directory for the user-chosen download folder on
   /// desktop, or null when downloads go to the platform default.
-  static Future<String?> getDownloadDirPath() async {
-    final prefs = await ProfilePreferences.instance();
-    final v = prefs.getString(_downloadDirPathKey);
-    return (v == null || v.isEmpty) ? null : v;
+  static Future<String?> getDownloadDirPath() {
+    return DownloadDestinationPrefs.getDownloadDirPath();
   }
 
-  static Future<void> setDownloadDirPath(String dirPath) async {
-    final prefs = await ProfilePreferences.instance();
-    await prefs.setString(_downloadDirPathKey, dirPath);
+  static Future<void> setDownloadDirPath(String dirPath) {
+    return DownloadDestinationPrefs.setDownloadDirPath(dirPath);
   }
 
-  static Future<void> clearDownloadDirPath() async {
-    final prefs = await ProfilePreferences.instance();
-    await prefs.remove(_downloadDirPathKey);
+  static Future<void> clearDownloadDirPath() {
+    return DownloadDestinationPrefs.clearDownloadDirPath();
   }
 
   // ── Continue Watching (recently watched items for home screen) ──────────

--- a/test/download_destination_prefs_origin_test.dart
+++ b/test/download_destination_prefs_origin_test.dart
@@ -1,0 +1,361 @@
+import 'dart:async';
+
+import 'package:debrify/services/profiles/profile_runtime.dart';
+import 'package:debrify/services/profiles/profile_scope.dart';
+import 'package:debrify/services/storage_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+// Public StorageService contract on upstream/webdav-sync 077f2e79.
+// Adapted from 067cb6a2; run unchanged before and after extraction.
+// Preference transport only: no picker, SAF grant, filesystem or native proof.
+const _limit = Duration(seconds: 5);
+const _uri = 'download_tree_uri_v1';
+const _name = 'download_tree_display_name_v1';
+const _path = 'download_dir_path_v1';
+const _keys = [_uri, _name, _path];
+const _initial = {_uri: 'old-uri', _name: 'old-name', _path: 'old-path'};
+const _updated = {
+  _uri: '  synthetic-uri  ',
+  _name: '  synthetic-name  ',
+  _path: '  synthetic-path  ',
+};
+
+class _DestinationBackend extends InMemorySharedPreferencesStore {
+  _DestinationBackend(super.data) : super.withData();
+
+  final attempts = <String>[];
+  final entered = Completer<void>();
+  final release = Completer<void>();
+  final failure = StateError('synthetic destination transport failure');
+  int? holdAt;
+  int? failAt;
+  bool returnFalse = false;
+
+  Future<bool> _attempt(
+    String operation,
+    Future<bool> Function() persist,
+  ) async {
+    final index = attempts.length;
+    attempts.add(operation);
+    if (index == holdAt) {
+      entered.complete();
+      await release.future.timeout(_limit);
+    }
+    if (index == failAt) {
+      if (returnFalse) return false;
+      throw failure;
+    }
+    return persist();
+  }
+
+  @override
+  Future<bool> setValue(String type, String key, Object value) =>
+      _attempt('set:$key', () => super.setValue(type, key, value));
+
+  @override
+  Future<bool> remove(String key) =>
+      _attempt('remove:$key', () => super.remove(key));
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late SharedPreferencesStorePlatform previous;
+  late _DestinationBackend backend;
+  final a = ProfileScope(
+    profileId: 'destination-a',
+    dataGeneration: 1,
+    sessionEpoch: 1,
+  );
+  final b = ProfileScope(
+    profileId: 'destination-b',
+    dataGeneration: 1,
+    sessionEpoch: 2,
+  );
+  final oldGeneration = ProfileScope(
+    profileId: 'destination-a',
+    dataGeneration: 2,
+    sessionEpoch: 3,
+  );
+  final readers = <String, Future<String?> Function()>{
+    _uri: StorageService.getDownloadTreeUri,
+    _name: StorageService.getDownloadTreeDisplayName,
+    _path: StorageService.getDownloadDirPath,
+  };
+  final operations =
+      <
+        ({
+          String label,
+          List<String> keys,
+          Future<void> Function() run,
+          bool clear,
+        })
+      >[
+        (
+          label: 'set tree',
+          keys: [_uri, _name],
+          run: () => StorageService.setDownloadTreeUri(
+            _updated[_uri]!,
+            _updated[_name]!,
+          ),
+          clear: false,
+        ),
+        (
+          label: 'clear tree',
+          keys: [_uri, _name],
+          run: StorageService.clearDownloadTreeUri,
+          clear: true,
+        ),
+        (
+          label: 'set path',
+          keys: [_path],
+          run: () => StorageService.setDownloadDirPath(_updated[_path]!),
+          clear: false,
+        ),
+        (
+          label: 'clear path',
+          keys: [_path],
+          run: StorageService.clearDownloadDirPath,
+          clear: true,
+        ),
+      ];
+
+  void install(Map<String, Object> values) {
+    SharedPreferences.resetStatic();
+    backend = _DestinationBackend({
+      for (final e in values.entries) 'flutter.${e.key}': e.value,
+      'flutter.destination_sentinel': 'untouched',
+    });
+    SharedPreferencesStorePlatform.instance = backend;
+  }
+
+  setUp(() {
+    previous = SharedPreferencesStorePlatform.instance;
+    ProfileRuntime.debugReset();
+    ProfileRuntime.initializeLegacy();
+    install(_initial);
+  });
+
+  tearDown(() {
+    if (!backend.release.isCompleted) backend.release.complete();
+    SharedPreferences.resetStatic();
+    SharedPreferencesStorePlatform.instance = previous;
+    ProfileRuntime.debugReset();
+  });
+
+  for (final entry in readers.entries) {
+    test(
+      '${entry.key}: absent/empty only normalize; raw whitespace and wrong types remain observable',
+      () async {
+        for (final value in <Object?>[
+          null,
+          '',
+          ' ',
+          '\t\n',
+          '  synthetic value  ',
+          7,
+          false,
+          <String>['not a String'],
+        ]) {
+          install({if (value != null) entry.key: value});
+          final before = await backend.getAll();
+          if (value != null && value is! String) {
+            await expectLater(entry.value(), throwsA(isA<TypeError>()));
+          } else {
+            expect(await entry.value(), value == '' ? null : value);
+          }
+          expect(await backend.getAll(), before);
+          expect(backend.attempts, isEmpty);
+        }
+      },
+    );
+  }
+
+  test('empty strings are physically written rather than removed', () async {
+    await StorageService.setDownloadTreeUri('', '');
+    await StorageService.setDownloadDirPath('');
+    final prefs = await SharedPreferences.getInstance();
+    for (final key in _keys) {
+      expect(prefs.containsKey(key), isTrue);
+      expect(prefs.get(key), '');
+      expect(await readers[key]!(), isNull);
+    }
+  });
+
+  test(
+    'committed defaults never fall back to legacy destination strings',
+    () async {
+      ProfileRuntime.initializeCommitted(a);
+      for (final reader in readers.values) {
+        expect(await reader(), isNull);
+      }
+      expect(backend.attempts, isEmpty);
+    },
+  );
+
+  test(
+    'normal reads, writes and clears isolate profiles and generations',
+    () async {
+      install({
+        ..._initial,
+        for (final scope in [a, b, oldGeneration])
+          for (final entry in _initial.entries)
+            scope.preferenceKey(entry.key): entry.value,
+      });
+      ProfileRuntime.initializeCommitted(a);
+      await StorageService.setDownloadTreeUri(
+        _updated[_uri]!,
+        _updated[_name]!,
+      );
+      await StorageService.setDownloadDirPath(_updated[_path]!);
+      for (final entry in readers.entries) {
+        expect(await entry.value(), _updated[entry.key]);
+      }
+      await StorageService.clearDownloadTreeUri();
+      await StorageService.clearDownloadDirPath();
+      final persisted = await backend.getAll();
+      for (final entry in readers.entries) {
+        expect(await entry.value(), isNull);
+        expect(
+          persisted.containsKey('flutter.${a.preferenceKey(entry.key)}'),
+          isFalse,
+        );
+        expect(persisted['flutter.${entry.key}'], _initial[entry.key]);
+        for (final scope in [b, oldGeneration]) {
+          expect(
+            persisted['flutter.${scope.preferenceKey(entry.key)}'],
+            _initial[entry.key],
+          );
+        }
+      }
+      for (final scope in [b, oldGeneration]) {
+        ProfileRuntime.publish(scope);
+        for (final entry in readers.entries) {
+          expect(await entry.value(), _initial[entry.key]);
+        }
+      }
+    },
+  );
+
+  for (final op in operations) {
+    for (var position = 0; position < op.keys.length; position++) {
+      for (final outcome in ['ok', 'false', 'throw']) {
+        test(
+          '${op.label}: held operation $position/$outcome preserves order, cache and durable differences',
+          () async {
+            final prefs = await SharedPreferences.getInstance();
+            backend.holdAt = position;
+            backend.failAt = outcome == 'ok' ? null : position;
+            backend.returnFalse = outcome == 'false';
+            final future = op.run();
+            final observed = expectLater(
+              future,
+              outcome == 'throw' ? throwsA(same(backend.failure)) : completes,
+            );
+            await backend.entered.future.timeout(_limit);
+            final attempted = op.keys.take(position + 1).toList();
+            final prefix = op.clear ? 'remove' : 'set';
+            expect(
+              backend.attempts,
+              attempted.map((k) => '$prefix:flutter.$k'),
+            );
+            // The SDK cache changes before its platform write completes.
+            for (final key in attempted) {
+              expect(prefs.get(key), op.clear ? null : _updated[key]);
+            }
+            final held = await backend.getAll();
+            expect(
+              held['flutter.${op.keys[position]}'],
+              _initial[op.keys[position]],
+            );
+            backend.release.complete();
+            await observed;
+            final count = outcome == 'throw' ? position + 1 : op.keys.length;
+            expect(
+              backend.attempts,
+              op.keys.take(count).map((k) => '$prefix:flutter.$k'),
+            );
+            final persisted = await backend.getAll();
+            for (final key in _keys) {
+              final index = op.keys.indexOf(key);
+              final attemptedKey = index >= 0 && index < count;
+              final committed =
+                  attemptedKey && (outcome == 'ok' || index != position);
+              expect(
+                prefs.get(key),
+                attemptedKey
+                    ? (op.clear ? null : _updated[key])
+                    : _initial[key],
+              );
+              expect(
+                persisted['flutter.$key'],
+                committed ? (op.clear ? null : _updated[key]) : _initial[key],
+              );
+            }
+            expect(persisted['flutter.destination_sentinel'], 'untouched');
+          },
+        );
+      }
+    }
+
+    for (var position = 0; position < op.keys.length; position++) {
+      test(
+        '${op.label}: profile switch at held operation $position keeps in-flight old write and rejects later stale use',
+        () async {
+          install({
+            ..._initial,
+            for (final scope in [a, b, oldGeneration])
+              for (final e in _initial.entries)
+                scope.preferenceKey(e.key): e.value,
+          });
+          ProfileRuntime.initializeCommitted(a);
+          final prefs = await SharedPreferences.getInstance();
+          backend.holdAt = position;
+          final future = op.run();
+          final hasLater = position + 1 < op.keys.length;
+          final observed = expectLater(
+            future,
+            hasLater ? throwsA(isA<StateError>()) : completes,
+          );
+          await backend.entered.future.timeout(_limit);
+          ProfileRuntime.publish(b);
+          backend.release.complete();
+          await observed;
+          final changed = op.keys.take(position + 1).toSet();
+          final prefix = op.clear ? 'remove' : 'set';
+          expect(
+            backend.attempts,
+            op.keys
+                .take(position + 1)
+                .map((k) => '$prefix:flutter.${a.preferenceKey(k)}'),
+          );
+          final persisted = await backend.getAll();
+          for (final key in _keys) {
+            expect(
+              prefs.get(a.preferenceKey(key)),
+              changed.contains(key)
+                  ? (op.clear ? null : _updated[key])
+                  : _initial[key],
+            );
+            expect(
+              persisted['flutter.${a.preferenceKey(key)}'],
+              changed.contains(key)
+                  ? (op.clear ? null : _updated[key])
+                  : _initial[key],
+            );
+            for (final scope in [b, oldGeneration]) {
+              expect(
+                persisted['flutter.${scope.preferenceKey(key)}'],
+                _initial[key],
+              );
+            }
+            expect(persisted['flutter.$key'], _initial[key]);
+            expect(await readers[key]!(), _initial[key]);
+          }
+          expect(persisted['flutter.destination_sentinel'], 'untouched');
+        },
+      );
+    }
+  }
+}


### PR DESCRIPTION
Move download-destination persistence into `DownloadDestinationPrefs`, retaining all seven `StorageService` APIs. The three existing keys, captured preference instance, URI-before-display-name ordering, and partial-failure behavior remain unchanged. OS folder grants stay with their existing callers.

Based independently on `webdav-sync` at `077f2e79`. This does not depend on the catalog preference extraction and does not rearrange settings or retire callers.

Validation with Flutter 3.44.8 / Dart 3.12.2: 30 public-API tests pass before and after extraction; the final run including existing profile-isolation coverage passes 34 tests. Final changed-file analysis reports no issues. Tests cover held operations, profile changes, false writes, exceptions and partial persistence. Two broader profile source-guard failures reproduce on clean upstream. Native folder-picker and SAF grant behavior were not changed or device-tested.

Independent review found no actionable issues. Across this extraction and the separate catalog-search extraction, all 12 deliberate behavioral mutations were caught; restored suites passed again.

Combined validation with the other ten proposed slices: **304 focused/integration tests passed** and an Android release build succeeded with Flutter 3.44.8 / Dart 3.12.2 / JDK 17. The test and build source trees match. The existing Windows Spotlight golden is excluded from that selection. A separate clean upstream full-suite run has 6,044 passes, 12 skips, 55 failing user tests and one failing teardown hook; this is not a full-suite or GitHub CI pass. Physical-device validation of the upstream ports remains outstanding.
