### PR TITLE
Fix Windows profile path containment

### DIFF
--- a/lib/services/profiles/profile_scope.dart
+++ b/lib/services/profiles/profile_scope.dart
@@ -67,10 +67,22 @@ class ProfileScope {
     final normalized = p.normalize(relativePath);
     if (p.isAbsolute(normalized) ||
         normalized == '..' ||
-        normalized.startsWith('../')) {
+        normalized.startsWith('../') ||
+        // package:path considers Windows drive-relative paths (C:file) relative.
+        (Platform.isWindows && RegExp(r'^[A-Za-z]:').hasMatch(normalized))) {
       throw ArgumentError.value(relativePath, 'relativePath', 'Unsafe path');
     }
-    return File(p.join(storageDirectory(root, area).path, normalized));
+    final scopedRoot = storageDirectory(root, area).path;
+    final target = p.join(scopedRoot, normalized);
+    final absoluteRoot = p.normalize(p.absolute(scopedRoot));
+    final absoluteTarget = p.normalize(p.absolute(target));
+    // Compare components, not a prefix that also matches sibling names.
+    // This is lexical containment; it does not resolve filesystem links.
+    if (!p.equals(absoluteRoot, absoluteTarget) &&
+        !p.isWithin(absoluteRoot, absoluteTarget)) {
+      throw ArgumentError.value(relativePath, 'relativePath', 'Unsafe path');
+    }
+    return File(target);
   }
 
   @override

--- a/test/profiles/profile_scope_test.dart
+++ b/test/profiles/profile_scope_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:debrify/services/profiles/profile_scope.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
 
 void main() {
   test('scope produces stable generation-aware keys and paths', () {
@@ -14,8 +15,17 @@ void main() {
     expect(scope.preferencePrefix, 'p.profile-abc_123.g.7.');
     expect(scope.preferenceKey('theme'), 'p.profile-abc_123.g.7.theme');
     expect(
-      scope.file(Directory('/tmp/root'), 'db/catalog.sqlite').path,
-      contains('profiles/profile-abc_123/g/7/data/db/catalog.sqlite'),
+      scope.file(Directory.systemTemp, 'db/catalog.sqlite').path,
+      p.join(
+        Directory.systemTemp.path,
+        'profiles',
+        'profile-abc_123',
+        'g',
+        '7',
+        'data',
+        'db',
+        'catalog.sqlite',
+      ),
     );
   });
 
@@ -37,5 +47,106 @@ void main() {
       () => scope.file(Directory('/tmp/root'), '../escape'),
       throwsArgumentError,
     );
+  });
+
+  group('scoped file containment', () {
+    final scope = ProfileScope(
+      profileId: 'path-pin',
+      dataGeneration: 7,
+      sessionEpoch: 2,
+    );
+    final root = Directory(p.join(Directory.systemTemp.path, 'profile paths'));
+    final unsafePaths = <String>[
+      '..',
+      '../escape',
+      'nested/../../escape',
+      '../data-sibling/escape',
+      p.absolute('outside.sqlite'),
+      // Even an absolute path inside the scope is not a relative input.
+      p.join(scope.storageDirectory(root, 'data').path, 'inside.sqlite'),
+      if (Platform.isWindows) ...[
+        r'..\escape',
+        r'nested\..\..\escape',
+        r'nested/..\..\escape',
+        r'\escape',
+        r'C:\escape',
+        r'C:escape',
+        r'C:..\escape',
+        r'.\C:escape',
+        r'nested\..\C:escape',
+        r'E:escape',
+        r'\\server\share\escape',
+        '//server/share/escape',
+      ],
+    ];
+    for (final path in unsafePaths) {
+      test('rejects $path through both APIs', () {
+        expect(() => scope.file(root, path), throwsArgumentError);
+        expect(
+          () => scope.fileIn(root, 'documents', path),
+          throwsArgumentError,
+        );
+      });
+    }
+
+    final safePaths = <String, String>{
+      'db/catalog.sqlite': p.join('db', 'catalog.sqlite'),
+      './db/catalog.sqlite': p.join('db', 'catalog.sqlite'),
+      'cache/../db/catalog.sqlite': p.join('db', 'catalog.sqlite'),
+      'db/./catalog.sqlite': p.join('db', 'catalog.sqlite'),
+      'db/../catalog.sqlite': 'catalog.sqlite',
+      '.../report..txt': p.join('...', 'report..txt'),
+      'db/my file [1].sqlite': p.join('db', 'my file [1].sqlite'),
+      'db/café_日本語.txt': p.join('db', 'café_日本語.txt'),
+      if (Platform.isWindows)
+        r'cache\..\db\catalog.sqlite': p.join('db', 'catalog.sqlite'),
+      // POSIX permits these literal filenames; do not impose Windows syntax.
+      if (!Platform.isWindows) ...{
+        'C:notes.txt': 'C:notes.txt',
+        r'db\literal.sqlite': r'db\literal.sqlite',
+        r'..\escape': r'..\escape',
+      },
+    };
+    for (final entry in safePaths.entries) {
+      test('preserves contained path ${entry.key}', () {
+        for (final area in ['data', 'documents', 'cache']) {
+          final directory = scope.storageDirectory(root, area).path;
+          final actual = scope.fileIn(root, area, entry.key).path;
+          expect(actual, p.join(directory, entry.value));
+          expect(p.isWithin(directory, actual), isTrue);
+        }
+      });
+    }
+
+    test('preserves relative-root spelling and scope identity', () {
+      final relativeRoot = Directory(p.join('relative root', 'storage'));
+      expect(
+        scope.file(relativeRoot, 'db/catalog.sqlite').path,
+        p.join(
+          relativeRoot.path,
+          'profiles',
+          'path-pin',
+          'g',
+          '7',
+          'data',
+          'db',
+          'catalog.sqlite',
+        ),
+      );
+      expect(scope.preferenceKey('theme'), 'p.path-pin.g.7.theme');
+      expect(scope.cacheKey, 'p.path-pin.g.7.e.2');
+    });
+
+    test('retains root-equal paths', () {
+      for (final path in ['', '.', 'nested/..']) {
+        expect(
+          p.equals(
+            p.normalize(scope.file(root, path).path),
+            scope.storageDirectory(root, 'data').path,
+          ),
+          isTrue,
+        );
+      }
+    });
   });
 }


### PR DESCRIPTION
Windows backslash traversal and drive-relative paths could escape the profile directory through `ProfileScope.fileIn`. Reject drive-relative paths and verify normalized path-component containment before returning the file, while retaining the existing API and valid root-relative behavior.

Based independently on `webdav-sync` at `077f2e79`; no storage refactor or settings UI changes are included.

Validation with Flutter 3.44.8 / Dart 3.12.2 on Windows: 12 regression cases fail on the unchanged upstream code; all 31 focused tests pass with the fix. Changed-file analysis is clean. POSIX-host execution remains outstanding. The check is lexical containment and does not resolve filesystem links.

Independent adversarial review passed the 31 native Windows tests and 32 additional explicit path-context checks, including rejection of mutations to traversal and drive-relative handling. Explicit POSIX path contexts supplement coverage but do not replace native POSIX CI.

Combined validation with the other ten proposed slices: **304 focused/integration tests passed** and an Android release build succeeded with Flutter 3.44.8 / Dart 3.12.2 / JDK 17. The test and build source trees match. The existing Windows Spotlight golden is excluded from that selection. A separate clean upstream full-suite run has 6,044 passes, 12 skips, 55 failing user tests and one failing teardown hook; this is not a full-suite or GitHub CI pass. Physical-device validation of the upstream ports remains outstanding.
