### PR TITLE
Share Real-Debrid and TorBox folder sorting

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -45,6 +45,7 @@ right code instead of re-discovering it. Flutter app; code under `lib/{screens,s
   AllDebrid is the newest = the template for adding a provider.
 - File-tree browse (per provider, post-add): `debrid_service.getTorrentFolderTree`,
   `utils/{rd,torbox}_folder_tree_builder.dart`, `screens/playlist_content_view_screen.dart`.
+  Real-Debrid/TorBox folder ordering: `services/cloud/cloud_folder_sort.dart` (`CloudFolderSort`).
 - Cloud/downloads screens: `screens/{debrid_downloads,torbox/torbox_downloads,pikpak/pikpak_files,`
   `premiumize/premiumize_files,alldebrid/alldebrid_files}_screen.dart`, `screens/cloud_screen.dart`.
 - WebDAV: `services/webdav_service.dart` (read/browse only — no upload yet).

--- a/lib/screens/debrid_downloads_screen.dart
+++ b/lib/screens/debrid_downloads_screen.dart
@@ -1,3 +1,4 @@
+import '../services/cloud/cloud_folder_sort.dart';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -1960,7 +1961,7 @@ class _DebridDownloadsScreenState extends State<DebridDownloadsScreen> {
           transformedNodes = rootNodes;
           break;
         case _FolderViewMode.sortedAZ:
-          transformedNodes = _applySortedView(rootNodes);
+          transformedNodes = CloudFolderSort.sortedView(rootNodes);
           break;
         case _FolderViewMode.seriesArrange:
           transformedNodes = _applySeriesArrangedView(rootNodes);
@@ -2003,14 +2004,14 @@ class _DebridDownloadsScreenState extends State<DebridDownloadsScreen> {
 
     if (mode == _FolderViewMode.seriesArrange) {
       // Inside a folder with Series Arrange mode: show files sorted by name
-      transformedChildren = _applySortedView(folder.children);
+      transformedChildren = CloudFolderSort.sortedView(folder.children);
     } else {
       switch (mode) {
         case _FolderViewMode.raw:
           transformedChildren = folder.children;
           break;
         case _FolderViewMode.sortedAZ:
-          transformedChildren = _applySortedView(folder.children);
+          transformedChildren = CloudFolderSort.sortedView(folder.children);
           break;
         case _FolderViewMode.seriesArrange:
           // Should never reach here
@@ -2078,7 +2079,7 @@ class _DebridDownloadsScreenState extends State<DebridDownloadsScreen> {
                 transformedNodes = rawNodes;
                 break;
               case _FolderViewMode.sortedAZ:
-                transformedNodes = _applySortedView(rawNodes);
+                transformedNodes = CloudFolderSort.sortedView(rawNodes);
                 break;
               case _FolderViewMode.seriesArrange:
                 transformedNodes = _applySeriesArrangedView(rawNodes);
@@ -2101,14 +2102,14 @@ class _DebridDownloadsScreenState extends State<DebridDownloadsScreen> {
 
       if (mode == _FolderViewMode.seriesArrange && _folderPath.isNotEmpty) {
         // Still inside a folder after going up - use sorted view
-        transformedNodes = _applySortedView(rawNodes);
+        transformedNodes = CloudFolderSort.sortedView(rawNodes);
       } else {
         switch (mode) {
           case _FolderViewMode.raw:
             transformedNodes = rawNodes;
             break;
           case _FolderViewMode.sortedAZ:
-            transformedNodes = _applySortedView(rawNodes);
+            transformedNodes = CloudFolderSort.sortedView(rawNodes);
             break;
           case _FolderViewMode.seriesArrange:
             transformedNodes = _applySeriesArrangedView(rawNodes);
@@ -2159,101 +2160,6 @@ class _DebridDownloadsScreenState extends State<DebridDownloadsScreen> {
     }
 
     return videoFiles;
-  }
-
-  /// Apply sorted view (folders first A-Z, then files A-Z)
-  /// Special handling for numbered folders and files to sort numerically
-  List<RDFileNode> _applySortedView(List<RDFileNode> nodes) {
-    final folders = nodes.where((n) => n.isFolder).toList();
-    final files = nodes.where((n) => !n.isFolder).toList();
-
-    // Sort folders with special handling for numbered folders
-    folders.sort((a, b) {
-      // Extract numbers if folders are named "Season X", "Chapter X", etc.
-      final aNum = _extractSeasonNumber(a.name);
-      final bNum = _extractSeasonNumber(b.name);
-
-      // If both have numbers, sort numerically
-      if (aNum != null && bNum != null) {
-        return aNum.compareTo(bNum);
-      }
-
-      // If only one has a number, numbered folders come first
-      if (aNum != null) return -1;
-      if (bNum != null) return 1;
-
-      // Otherwise sort alphabetically
-      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
-    });
-
-    // Sort files with special handling for files starting with numbers
-    files.sort((a, b) {
-      // Extract leading numbers from filenames (e.g., "10. Video.mp4" -> 10)
-      final aNum = _extractLeadingNumber(a.name);
-      final bNum = _extractLeadingNumber(b.name);
-
-      // If both start with numbers, sort numerically
-      if (aNum != null && bNum != null) {
-        return aNum.compareTo(bNum);
-      }
-
-      // If only one starts with a number, numbered files come first
-      if (aNum != null) return -1;
-      if (bNum != null) return 1;
-
-      // Otherwise sort alphabetically
-      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
-    });
-
-    return [...folders, ...files];
-  }
-
-  /// Extract number from folder name for numerical sorting
-  /// Handles: "1. Introduction", "10. Chapter", "Season 10", "Chapter_12", "Episode 5", "Part 3", etc.
-  /// Returns null if no number pattern found
-  int? _extractSeasonNumber(String folderName) {
-    // Try multiple patterns in order of specificity
-    final patterns = [
-      // Leading numbers: "1. ", "10-", "5_", etc.
-      RegExp(r'^(\d+)[\s._-]'),
-      // Season X, Season_X, Season-X
-      RegExp(r'season[\s_-]*(\d+)', caseSensitive: false),
-      // Chapter X, Chapter_X, Chapter-X
-      RegExp(r'chapter[\s_-]*(\d+)', caseSensitive: false),
-      // Episode X, Episode_X, Episode-X
-      RegExp(r'episode[\s_-]*(\d+)', caseSensitive: false),
-      // Part X, Part_X, Part-X
-      RegExp(r'part[\s_-]*(\d+)', caseSensitive: false),
-      // Any word followed by number at the start (e.g., "Lesson_5", "Module-3")
-      RegExp(r'^[a-z]+[\s_-]*(\d+)', caseSensitive: false),
-    ];
-
-    final lowerName = folderName.toLowerCase();
-
-    for (final pattern in patterns) {
-      final match = pattern.firstMatch(lowerName);
-      if (match != null && match.groupCount >= 1) {
-        return int.tryParse(match.group(1)!);
-      }
-    }
-
-    return null;
-  }
-
-  /// Extract leading number from filename for numerical sorting
-  /// Handles: "10. Video.mp4", "9 - Title.mkv", "05_Episode.mp4", etc.
-  /// Returns null if filename doesn't start with a number
-  int? _extractLeadingNumber(String filename) {
-    // Match numbers at the start of filename (before any separator like . - _ space)
-    // Examples: "10.", "9 -", "05_", "123-"
-    final pattern = RegExp(r'^(\d+)[\s._-]');
-    final match = pattern.firstMatch(filename);
-
-    if (match != null && match.groupCount >= 1) {
-      return int.tryParse(match.group(1)!);
-    }
-
-    return null;
   }
 
   /// Apply series arranged view (create virtual Season folders)
@@ -2320,7 +2226,7 @@ class _DebridDownloadsScreenState extends State<DebridDownloadsScreen> {
       return [...folders, ...seasonFolders, ...nonVideoFiles];
     } catch (e) {
       debugPrint('Series arrangement failed: $e');
-      return _applySortedView(nodes); // Fallback to sorted view
+      return CloudFolderSort.sortedView(nodes); // Fallback to sorted view
     }
   }
 
@@ -2380,7 +2286,7 @@ class _DebridDownloadsScreenState extends State<DebridDownloadsScreen> {
         // Switch to sorted view instead
         setState(() {
           _torrentViewModes[_currentTorrentId!] = _FolderViewMode.sortedAZ;
-          _currentViewNodes = _applySortedView(rawNodes);
+          _currentViewNodes = CloudFolderSort.sortedView(rawNodes);
         });
         return;
       }
@@ -2395,7 +2301,7 @@ class _DebridDownloadsScreenState extends State<DebridDownloadsScreen> {
           _currentViewNodes = rawNodes;
           break;
         case _FolderViewMode.sortedAZ:
-          _currentViewNodes = _applySortedView(rawNodes);
+          _currentViewNodes = CloudFolderSort.sortedView(rawNodes);
           break;
         case _FolderViewMode.seriesArrange:
           _currentViewNodes = _applySeriesArrangedView(rawNodes);

--- a/lib/screens/torbox/torbox_downloads_screen.dart
+++ b/lib/screens/torbox/torbox_downloads_screen.dart
@@ -1,3 +1,4 @@
+import '../../services/cloud/cloud_folder_sort.dart';
 import 'dart:convert';
 import 'dart:ui';
 
@@ -5119,7 +5120,7 @@ class _TorboxDownloadsScreenState extends State<TorboxDownloadsScreen> {
         transformedNodes = tree.children;
         break;
       case _FolderViewMode.sortedAZ:
-        transformedNodes = _applySortedView(tree.children);
+        transformedNodes = CloudFolderSort.sortedView(tree.children);
         break;
       case _FolderViewMode.seriesArrange:
         transformedNodes = _applySeriesArrangedView(tree.children);
@@ -5171,7 +5172,7 @@ class _TorboxDownloadsScreenState extends State<TorboxDownloadsScreen> {
         transformedNodes = tree.children;
         break;
       case _FolderViewMode.sortedAZ:
-        transformedNodes = _applySortedView(tree.children);
+        transformedNodes = CloudFolderSort.sortedView(tree.children);
         break;
       case _FolderViewMode.seriesArrange:
         transformedNodes = _applySeriesArrangedView(tree.children);
@@ -5218,11 +5219,11 @@ class _TorboxDownloadsScreenState extends State<TorboxDownloadsScreen> {
         transformedChildren = folderNode.children;
         break;
       case _FolderViewMode.sortedAZ:
-        transformedChildren = _applySortedView(folderNode.children);
+        transformedChildren = CloudFolderSort.sortedView(folderNode.children);
         break;
       case _FolderViewMode.seriesArrange:
         // Inside a folder with Series Arrange mode: show files sorted by name
-        transformedChildren = _applySortedView(folderNode.children);
+        transformedChildren = CloudFolderSort.sortedView(folderNode.children);
         break;
     }
 
@@ -5291,14 +5292,14 @@ class _TorboxDownloadsScreenState extends State<TorboxDownloadsScreen> {
       // NOTE: Series Arrange only applies at root level
       if (mode == _FolderViewMode.seriesArrange && previous.path.isNotEmpty) {
         // Still inside a folder after going up - use sorted view
-        transformedNodes = _applySortedView(rawNodes);
+        transformedNodes = CloudFolderSort.sortedView(rawNodes);
       } else {
         switch (mode) {
           case _FolderViewMode.raw:
             transformedNodes = rawNodes;
             break;
           case _FolderViewMode.sortedAZ:
-            transformedNodes = _applySortedView(rawNodes);
+            transformedNodes = CloudFolderSort.sortedView(rawNodes);
             break;
           case _FolderViewMode.seriesArrange:
             transformedNodes = _applySeriesArrangedView(rawNodes);
@@ -5356,101 +5357,6 @@ class _TorboxDownloadsScreenState extends State<TorboxDownloadsScreen> {
     }
 
     return videoFiles;
-  }
-
-  /// Apply sorted view (folders first A-Z, then files A-Z)
-  /// Special handling for numbered folders and files to sort numerically
-  List<RDFileNode> _applySortedView(List<RDFileNode> nodes) {
-    final folders = nodes.where((n) => n.isFolder).toList();
-    final files = nodes.where((n) => !n.isFolder).toList();
-
-    // Sort folders with special handling for numbered folders
-    folders.sort((a, b) {
-      // Extract numbers if folders are named "Season X", "Chapter X", etc.
-      final aNum = _extractSeasonNumber(a.name);
-      final bNum = _extractSeasonNumber(b.name);
-
-      // If both have numbers, sort numerically
-      if (aNum != null && bNum != null) {
-        return aNum.compareTo(bNum);
-      }
-
-      // If only one has a number, numbered folders come first
-      if (aNum != null) return -1;
-      if (bNum != null) return 1;
-
-      // Otherwise sort alphabetically
-      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
-    });
-
-    // Sort files with special handling for files starting with numbers
-    files.sort((a, b) {
-      // Extract leading numbers from filenames (e.g., "10. Video.mp4" -> 10)
-      final aNum = _extractLeadingNumber(a.name);
-      final bNum = _extractLeadingNumber(b.name);
-
-      // If both start with numbers, sort numerically
-      if (aNum != null && bNum != null) {
-        return aNum.compareTo(bNum);
-      }
-
-      // If only one starts with a number, numbered files come first
-      if (aNum != null) return -1;
-      if (bNum != null) return 1;
-
-      // Otherwise sort alphabetically
-      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
-    });
-
-    return [...folders, ...files];
-  }
-
-  /// Extract number from folder name for numerical sorting
-  /// Handles: "1. Introduction", "10. Chapter", "Season 10", "Chapter_12", "Episode 5", "Part 3", etc.
-  /// Returns null if no number pattern found
-  int? _extractSeasonNumber(String folderName) {
-    // Try multiple patterns in order of specificity
-    final patterns = [
-      // Leading numbers: "1. ", "10-", "5_", etc.
-      RegExp(r'^(\d+)[\s._-]'),
-      // Season X, Season_X, Season-X
-      RegExp(r'season[\s_-]*(\d+)', caseSensitive: false),
-      // Chapter X, Chapter_X, Chapter-X
-      RegExp(r'chapter[\s_-]*(\d+)', caseSensitive: false),
-      // Episode X, Episode_X, Episode-X
-      RegExp(r'episode[\s_-]*(\d+)', caseSensitive: false),
-      // Part X, Part_X, Part-X
-      RegExp(r'part[\s_-]*(\d+)', caseSensitive: false),
-      // Any word followed by number at the start (e.g., "Lesson_5", "Module-3")
-      RegExp(r'^[a-z]+[\s_-]*(\d+)', caseSensitive: false),
-    ];
-
-    final lowerName = folderName.toLowerCase();
-
-    for (final pattern in patterns) {
-      final match = pattern.firstMatch(lowerName);
-      if (match != null && match.groupCount >= 1) {
-        return int.tryParse(match.group(1)!);
-      }
-    }
-
-    return null;
-  }
-
-  /// Extract leading number from filename for numerical sorting
-  /// Handles: "10. Video.mp4", "9 - Title.mkv", "05_Episode.mp4", etc.
-  /// Returns null if filename doesn't start with a number
-  int? _extractLeadingNumber(String filename) {
-    // Match numbers at the start of filename (before any separator like . - _ space)
-    // Examples: "10.", "9 -", "05_", "123-"
-    final pattern = RegExp(r'^(\d+)[\s._-]');
-    final match = pattern.firstMatch(filename);
-
-    if (match != null && match.groupCount >= 1) {
-      return int.tryParse(match.group(1)!);
-    }
-
-    return null;
   }
 
   /// Apply series arranged view (create virtual Season folders)
@@ -5517,7 +5423,7 @@ class _TorboxDownloadsScreenState extends State<TorboxDownloadsScreen> {
       return [...folders, ...seasonFolders, ...nonVideoFiles];
     } catch (e) {
       debugPrint('Series arrangement failed: $e');
-      return _applySortedView(nodes); // Fallback to sorted view
+      return CloudFolderSort.sortedView(nodes); // Fallback to sorted view
     }
   }
 
@@ -5605,7 +5511,7 @@ class _TorboxDownloadsScreenState extends State<TorboxDownloadsScreen> {
             _webDownloadViewModes[_currentWebDownload!.id] =
                 _FolderViewMode.sortedAZ;
           }
-          _currentViewNodes = _applySortedView(rawNodes);
+          _currentViewNodes = CloudFolderSort.sortedView(rawNodes);
         });
         return;
       }
@@ -5624,7 +5530,7 @@ class _TorboxDownloadsScreenState extends State<TorboxDownloadsScreen> {
           _currentViewNodes = rawNodes;
           break;
         case _FolderViewMode.sortedAZ:
-          _currentViewNodes = _applySortedView(rawNodes);
+          _currentViewNodes = CloudFolderSort.sortedView(rawNodes);
           break;
         case _FolderViewMode.seriesArrange:
           _currentViewNodes = _applySeriesArrangedView(rawNodes);

--- a/lib/services/cloud/cloud_folder_sort.dart
+++ b/lib/services/cloud/cloud_folder_sort.dart
@@ -1,0 +1,102 @@
+import '../../models/rd_file_node.dart';
+
+/// Shared ordering for Real-Debrid and TorBox folder views.
+/// Returns a new list of the existing nodes; raw order and children stay intact.
+class CloudFolderSort {
+  CloudFolderSort._();
+
+  /// Apply sorted view (folders first A-Z, then files A-Z)
+  /// Special handling for numbered folders and files to sort numerically
+  static List<RDFileNode> sortedView(List<RDFileNode> nodes) {
+    final folders = nodes.where((n) => n.isFolder).toList();
+    final files = nodes.where((n) => !n.isFolder).toList();
+
+    // Sort folders with special handling for numbered folders
+    folders.sort((a, b) {
+      // Extract numbers if folders are named "Season X", "Chapter X", etc.
+      final aNum = _extractSeasonNumber(a.name);
+      final bNum = _extractSeasonNumber(b.name);
+
+      // If both have numbers, sort numerically
+      if (aNum != null && bNum != null) {
+        return aNum.compareTo(bNum);
+      }
+
+      // If only one has a number, numbered folders come first
+      if (aNum != null) return -1;
+      if (bNum != null) return 1;
+
+      // Otherwise sort alphabetically
+      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+    });
+
+    // Sort files with special handling for files starting with numbers
+    files.sort((a, b) {
+      // Extract leading numbers from filenames (e.g., "10. Video.mp4" -> 10)
+      final aNum = _extractLeadingNumber(a.name);
+      final bNum = _extractLeadingNumber(b.name);
+
+      // If both start with numbers, sort numerically
+      if (aNum != null && bNum != null) {
+        return aNum.compareTo(bNum);
+      }
+
+      // If only one starts with a number, numbered files come first
+      if (aNum != null) return -1;
+      if (bNum != null) return 1;
+
+      // Otherwise sort alphabetically
+      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+    });
+
+    return [...folders, ...files];
+  }
+
+  /// Extract number from folder name for numerical sorting
+  /// Handles: "1. Introduction", "10. Chapter", "Season 10", "Chapter_12", "Episode 5", "Part 3", etc.
+  /// Returns null if no number pattern found
+  static int? _extractSeasonNumber(String folderName) {
+    // Try multiple patterns in order of specificity
+    final patterns = [
+      // Leading numbers: "1. ", "10-", "5_", etc.
+      RegExp(r'^(\d+)[\s._-]'),
+      // Season X, Season_X, Season-X
+      RegExp(r'season[\s_-]*(\d+)', caseSensitive: false),
+      // Chapter X, Chapter_X, Chapter-X
+      RegExp(r'chapter[\s_-]*(\d+)', caseSensitive: false),
+      // Episode X, Episode_X, Episode-X
+      RegExp(r'episode[\s_-]*(\d+)', caseSensitive: false),
+      // Part X, Part_X, Part-X
+      RegExp(r'part[\s_-]*(\d+)', caseSensitive: false),
+      // Any word followed by number at the start (e.g., "Lesson_5", "Module-3")
+      RegExp(r'^[a-z]+[\s_-]*(\d+)', caseSensitive: false),
+    ];
+
+    final lowerName = folderName.toLowerCase();
+
+    for (final pattern in patterns) {
+      final match = pattern.firstMatch(lowerName);
+      if (match != null && match.groupCount >= 1) {
+        return int.tryParse(match.group(1)!);
+      }
+    }
+
+    return null;
+  }
+
+  /// Extract leading number from filename for numerical sorting
+  /// Handles: "10. Video.mp4", "9 - Title.mkv", "05_Episode.mp4", etc.
+  /// Returns null if filename doesn't start with a number
+  static int? _extractLeadingNumber(String filename) {
+    // Match numbers at the start of filename (before any separator like . - _ space)
+    // Examples: "10.", "9 -", "05_", "123-"
+    final pattern = RegExp(r'^(\d+)[\s._-]');
+    final match = pattern.firstMatch(filename);
+
+    if (match != null && match.groupCount >= 1) {
+      return int.tryParse(match.group(1)!);
+    }
+
+    return null;
+  }
+}

--- a/test/cloud_folder_sort_test.dart
+++ b/test/cloud_folder_sort_test.dart
@@ -1,0 +1,460 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:debrify/models/rd_torrent.dart';
+import 'package:debrify/models/torbox_torrent.dart';
+import 'package:debrify/screens/debrid_downloads_screen.dart';
+import 'package:debrify/screens/torbox/torbox_downloads_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Public-screen contract for the folder-view "Sort (A-Z)" ordering that the
+/// Real-Debrid and TorBox files screens each implement privately
+/// (`_applySortedView`, `_extractSeasonNumber`, `_extractLeadingNumber`).
+///
+/// The pin drives the real screens: a deep-linked torrent is opened, the
+/// view-mode dropdown is switched, and the rendered row order is asserted.
+/// Network is answered by a canned `HttpOverrides`; no other seam is used.
+///
+/// Quirks pinned here (keep, do not "fix"):
+/// * Raw view keeps the API's file order, folders and files interleaved.
+/// * Sorted view puts folders first. Folders whose name carries a number
+///   ("Season 2", "Chapter 10", "Lesson_5") sort numerically and ahead of
+///   folders without one; the rest sort case-insensitively.
+/// * Files that start with a number followed by a separator ("2. x", "10 -",
+///   "05_") sort numerically and ahead of the rest, which sort
+///   case-insensitively. "Alpha.mkv" is not numbered; "2. Alpha.mkv" is.
+/// * The dropdown offers only "Raw" and "Sort (A-Z)".
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Scrambled on purpose: the raw view must keep this order.
+  const rawOrder = <String>[
+    'Season 10',
+    'zeta.mkv',
+    'Extras',
+    '10. Zulu.mkv',
+    'Season 2',
+    '2. Alpha.mkv',
+    'Alpha.mkv',
+    'Lesson_5',
+    'chapter-3',
+    'Season_01',
+    '05_Episode.mkv',
+    '3no-separator.mkv',
+  ];
+  const sortedOrder = <String>[
+    'Season_01',
+    'Season 2',
+    'chapter-3',
+    'Lesson_5',
+    'Season 10',
+    'Extras',
+    '2. Alpha.mkv',
+    '05_Episode.mkv',
+    '10. Zulu.mkv',
+    '3no-separator.mkv',
+    'Alpha.mkv',
+    'zeta.mkv',
+  ];
+
+  /// Relative paths in raw order; folders get one file each so they render.
+  const rawPaths = <String>[
+    'Season 10/s10e01.mkv',
+    'zeta.mkv',
+    'Extras/making-of.mkv',
+    '10. Zulu.mkv',
+    'Season 2/s02e01.mkv',
+    '2. Alpha.mkv',
+    'Alpha.mkv',
+    'Lesson_5/lesson.mkv',
+    'chapter-3/chapter.mkv',
+    'Season_01/s01e01.mkv',
+    '05_Episode.mkv',
+    '3no-separator.mkv',
+  ];
+
+  late HttpOverrides? previousOverrides;
+  late _CannedHttp http;
+
+  setUp(() {
+    previousOverrides = HttpOverrides.current;
+  });
+
+  tearDown(() {
+    HttpOverrides.global = previousOverrides;
+  });
+
+  Future<void> useLargeViewport(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 2000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+  }
+
+  /// Opens [screen] on the real clock. The credential vault's AES and the
+  /// hosts' key-poll loops never settle under the widget-test fake clock, so
+  /// the open runs inside [WidgetTester.runAsync]; the dropdown interaction
+  /// that follows is synchronous and runs on the fake clock as usual.
+  Future<void> openOnRealClock(
+    WidgetTester tester,
+    Widget screen,
+    List<String> names,
+  ) async {
+    await tester.runAsync(() async {
+      await tester.pumpWidget(MaterialApp(home: screen));
+      for (var i = 0; i < 60; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        await tester.pump();
+        if (names.every((n) => find.text(n).evaluate().isNotEmpty)) return;
+      }
+    });
+    await tester.pump();
+    final missing = names.where((n) => find.text(n).evaluate().isEmpty);
+    expect(
+      missing,
+      isEmpty,
+      reason:
+          'Rows never rendered. Requests: ${http.requests.join(', ')}. '
+          'Visible: ${tester.widgetList<Text>(find.byType(Text)).map((t) => t.data).whereType<String>().join(' | ')}',
+    );
+  }
+
+  List<String> renderedOrder(WidgetTester tester, List<String> names) {
+    final rows = <(String, double)>[
+      for (final n in names) (n, tester.getTopLeft(find.text(n)).dy),
+    ]..sort((a, b) => a.$2.compareTo(b.$2));
+    return [for (final r in rows) r.$1];
+  }
+
+  Future<void> chooseView(WidgetTester tester, String mode) async {
+    final dropdown = find.byWidgetPredicate(
+      (w) => w is DropdownButtonFormField,
+    );
+    expect(dropdown, findsOneWidget, reason: 'view-mode dropdown');
+    await tester.tap(dropdown);
+    await tester.pumpAndSettle();
+    // Only two choices are offered; the series arrangement is not exposed.
+    expect(find.text('Series Arrange'), findsNothing);
+    await tester.tap(find.text(mode).last);
+    await tester.pumpAndSettle();
+  }
+
+  /// Both hosts arm a 10s deep-link timeout when opened with a target; it
+  /// must stay silent because the torrent did open.
+  Future<void> drainDeepLinkTimer(WidgetTester tester) async {
+    await tester.pump(const Duration(seconds: 11));
+  }
+
+  group('TorBox TorboxDownloadsScreen', () {
+    TorboxTorrent torrent() => TorboxTorrent.fromJson({
+      'id': 7,
+      'hash': 'pinhash',
+      'name': 'Sort Pin',
+      'created_at': '2026-01-01T00:00:00.000Z',
+      'updated_at': '2026-01-01T00:00:00.000Z',
+      'download_state': 'completed',
+      'download_finished': true,
+      'download_present': true,
+      'cached': true,
+      'files': [
+        for (var i = 0; i < rawPaths.length; i++)
+          {
+            'id': i + 1,
+            'name': rawPaths[i],
+            'short_name': rawPaths[i].split('/').last,
+            'size': 100 + i,
+          },
+      ],
+    });
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({'torbox_api_key': 'pin-key'});
+      http = _CannedHttp({
+        '/v1/api/torrents/mylist': jsonEncode({'success': true, 'data': []}),
+        '/v1/api/webdl/mylist': jsonEncode({'success': true, 'data': []}),
+      });
+      HttpOverrides.global = http;
+    });
+
+    testWidgets('raw view keeps API order; Sort (A-Z) reorders the tree', (
+      tester,
+    ) async {
+      await useLargeViewport(tester);
+      await openOnRealClock(
+        tester,
+        TorboxDownloadsScreen(
+          isPushedRoute: true,
+          initialTorrentToOpen: torrent(),
+        ),
+        rawOrder,
+      );
+      expect(renderedOrder(tester, rawOrder), rawOrder);
+
+      await chooseView(tester, 'Sort (A-Z)');
+      expect(renderedOrder(tester, sortedOrder), sortedOrder);
+
+      // Sorting must not mutate the API order retained for Raw view.
+      await chooseView(tester, 'Raw');
+      expect(renderedOrder(tester, rawOrder), rawOrder);
+
+      await drainDeepLinkTimer(tester);
+      expect(
+        find.text('Failed to open torrent. Please try again.'),
+        findsNothing,
+      );
+    });
+  });
+
+  group('Real-Debrid DebridDownloadsScreen', () {
+    const rdBase = '/rest/1.0';
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({
+        'real_debrid_api_key': 'pin-key',
+      });
+      http = _CannedHttp({
+        '$rdBase/torrents': '[]',
+        '$rdBase/downloads': '[]',
+        '$rdBase/torrents/info/t1': jsonEncode({
+          'id': 't1',
+          'filename': 'Sort Pin',
+          'status': 'downloaded',
+          'files': [
+            for (var i = 0; i < rawPaths.length; i++)
+              {
+                'id': i + 1,
+                'path': '/${rawPaths[i]}',
+                'bytes': 100 + i,
+                'selected': 1,
+              },
+          ],
+          // One link per selected file so this is not read as a RAR archive.
+          'links': [
+            for (var i = 0; i < rawPaths.length; i++)
+              'https://real-debrid.invalid/d/$i',
+          ],
+        }),
+      });
+      HttpOverrides.global = http;
+    });
+
+    testWidgets('raw view keeps API order; Sort (A-Z) reorders the tree', (
+      tester,
+    ) async {
+      await useLargeViewport(tester);
+      final torrent = RDTorrent(
+        id: 't1',
+        filename: 'Sort Pin',
+        hash: 'pinhash',
+        bytes: 700,
+        host: 'real-debrid.com',
+        split: 0,
+        progress: 100,
+        status: 'downloaded',
+        added: '2026-01-01',
+        links: [
+          for (var i = 0; i < rawPaths.length; i++)
+            'https://real-debrid.invalid/d/$i',
+        ],
+      );
+      await openOnRealClock(
+        tester,
+        DebridDownloadsScreen(
+          isPushedRoute: true,
+          initialTorrentForOptions: torrent,
+        ),
+        rawOrder,
+      );
+      expect(renderedOrder(tester, rawOrder), rawOrder);
+
+      await chooseView(tester, 'Sort (A-Z)');
+      expect(renderedOrder(tester, sortedOrder), sortedOrder);
+
+      // Sorting must not mutate the API order retained for Raw view.
+      await chooseView(tester, 'Raw');
+      expect(renderedOrder(tester, rawOrder), rawOrder);
+
+      await drainDeepLinkTimer(tester);
+      expect(
+        find.text('Failed to open torrent. Please try again.'),
+        findsNothing,
+      );
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Canned dart:io HTTP. package:http's IOClient goes through HttpClient(), which
+// honours HttpOverrides, so this answers the screens' real service calls.
+// ---------------------------------------------------------------------------
+
+class _CannedHttp extends HttpOverrides {
+  _CannedHttp(this.routesByPath);
+
+  /// URL path → JSON body. Anything else is an error, not a silent 400.
+  final Map<String, String> routesByPath;
+  final List<String> requests = [];
+
+  @override
+  HttpClient createHttpClient(SecurityContext? context) => _CannedClient(this);
+}
+
+class _CannedClient implements HttpClient {
+  _CannedClient(this.fixture);
+  final _CannedHttp fixture;
+
+  @override
+  Future<HttpClientRequest> openUrl(String method, Uri url) async {
+    fixture.requests.add('$method ${url.path}');
+    final body = fixture.routesByPath[url.path];
+    if (body == null) {
+      throw StateError('Unexpected request: $method $url');
+    }
+    return _CannedRequest(method, url, utf8.encode(body));
+  }
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _CannedRequest implements HttpClientRequest {
+  _CannedRequest(this.method, this.uri, this._body);
+
+  @override
+  final String method;
+  @override
+  final Uri uri;
+  final List<int> _body;
+
+  @override
+  final HttpHeaders headers = _CannedHeaders({});
+  @override
+  bool followRedirects = true;
+  @override
+  int maxRedirects = 5;
+  @override
+  int contentLength = -1;
+  @override
+  bool persistentConnection = true;
+  @override
+  bool bufferOutput = true;
+
+  late final _CannedResponse _response = _CannedResponse(_body, {
+    'content-type': ['application/json'],
+    'x-total-count': ['0'],
+  });
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) => stream.drain<void>();
+
+  @override
+  void add(List<int> data) {}
+
+  @override
+  Future<HttpClientResponse> close() async => _response;
+
+  @override
+  Future<HttpClientResponse> get done async => _response;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _CannedResponse extends Stream<List<int>> implements HttpClientResponse {
+  _CannedResponse(this._bytes, Map<String, List<String>> headerMap)
+    : headers = _CannedHeaders(headerMap);
+
+  final List<int> _bytes;
+
+  @override
+  final HttpHeaders headers;
+
+  @override
+  int get statusCode => 200;
+  @override
+  String get reasonPhrase => 'OK';
+  @override
+  int get contentLength => _bytes.length;
+  @override
+  bool get isRedirect => false;
+  @override
+  bool get persistentConnection => false;
+  @override
+  List<RedirectInfo> get redirects => const [];
+  @override
+  List<Cookie> get cookies => const [];
+  @override
+  X509Certificate? get certificate => null;
+  @override
+  HttpConnectionInfo? get connectionInfo => null;
+  @override
+  HttpClientResponseCompressionState get compressionState =>
+      HttpClientResponseCompressionState.notCompressed;
+
+  @override
+  StreamSubscription<List<int>> listen(
+    void Function(List<int> event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) => Stream<List<int>>.value(_bytes).listen(
+    onData,
+    onError: onError,
+    onDone: onDone,
+    cancelOnError: cancelOnError,
+  );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _CannedHeaders implements HttpHeaders {
+  _CannedHeaders(this._values);
+  final Map<String, List<String>> _values;
+
+  @override
+  List<String>? operator [](String name) => _values[name.toLowerCase()];
+
+  @override
+  String? value(String name) => _values[name.toLowerCase()]?.join(', ');
+
+  @override
+  void forEach(void Function(String name, List<String> values) action) =>
+      _values.forEach(action);
+
+  @override
+  void set(String name, Object value, {bool preserveHeaderCase = false}) {
+    _values[name.toLowerCase()] = ['$value'];
+  }
+
+  @override
+  void add(String name, Object value, {bool preserveHeaderCase = false}) {
+    _values.putIfAbsent(name.toLowerCase(), () => []).add('$value');
+  }
+
+  @override
+  void remove(String name, Object value) {}
+
+  @override
+  void removeAll(String name) => _values.remove(name.toLowerCase());
+
+  @override
+  int contentLength = -1;
+  @override
+  bool chunkedTransferEncoding = false;
+  @override
+  bool persistentConnection = true;
+  @override
+  ContentType? contentType;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}

--- a/test/cloud_folder_sort_unit_test.dart
+++ b/test/cloud_folder_sort_unit_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:debrify/models/rd_file_node.dart';
 import 'package:debrify/services/cloud/cloud_folder_sort.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -100,4 +102,76 @@ void main() {
       ]);
     },
   );
+
+  for (final folders in [true, false]) {
+    final kind = folders ? 'folders' : 'files';
+    RDFileNode node(String name) =>
+        folders ? RDFileNode.folder(name: name) : file(name);
+
+    test('$kind with equal numbers do not gain a name tiebreaker', () {
+      final names = folders
+          ? ['Season 2 zebra', 'Chapter 02 alpha', 'Part 2 middle']
+          : ['2. zebra.mkv', '02_alpha.mkv', '2-middle.mkv'];
+      final input = List<RDFileNode>.unmodifiable(names.map(node));
+      expect(CloudFolderSort.sortedView(input), orderedEquals(input));
+    });
+
+    test('$kind with case-insensitive name ties retain distinct nodes', () {
+      final input = List<RDFileNode>.unmodifiable(
+        ['extras', 'EXTRAS', 'Extras'].map(node),
+      );
+      expect(CloudFolderSort.sortedView(input), orderedEquals(input));
+    });
+
+    test('$kind retain SDK quicksort ordering across large tie groups', () {
+      // These ranks explicitly describe the fixture's intended order. They do
+      // not parse names or duplicate CloudFolderSort's comparator. List.sort is
+      // intentionally not stable: equal-ranked identities must follow the SDK's
+      // ordering, including on cohorts larger than its insertion-sort cutoff.
+      final names = folders
+          ? [
+              ('Season 2 zebra', 0),
+              ('Chapter 02 alpha', 0),
+              ('Part 2 middle', 0),
+              ('Episode 10', 1),
+              ('Extras', 2),
+              ('EXTRAS', 2),
+              ('extras', 2),
+              ('Zebra', 3),
+            ]
+          : [
+              ('2. zebra.mkv', 0),
+              ('02_alpha.mkv', 0),
+              ('2-middle.mkv', 0),
+              ('10. episode.mkv', 1),
+              ('Alpha.mkv', 2),
+              ('ALPHA.mkv', 2),
+              ('alpha.mkv', 2),
+              ('Zebra.mkv', 3),
+            ];
+      for (final size in [31, 32, 33, 34, 64, 129]) {
+        for (var seed = 0; seed < 12; seed++) {
+          final random = Random(seed);
+          final entries = [
+            for (var i = 0; i < size; i++)
+              (
+                node: node(names[i % names.length].$1),
+                rank: names[i % names.length].$2,
+              ),
+          ]..shuffle(random);
+          final input = List<RDFileNode>.unmodifiable(
+            entries.map((entry) => entry.node),
+          );
+          final expected = [...entries]
+            ..sort((a, b) => a.rank.compareTo(b.rank));
+          expect(
+            CloudFolderSort.sortedView(input),
+            orderedEquals(expected.map((entry) => entry.node)),
+            reason: '$kind cohort=$size seed=$seed; preserve exact identities',
+          );
+          expect(input, orderedEquals(entries.map((entry) => entry.node)));
+        }
+      }
+    });
+  }
 }

--- a/test/cloud_folder_sort_unit_test.dart
+++ b/test/cloud_folder_sort_unit_test.dart
@@ -1,0 +1,103 @@
+import 'package:debrify/models/rd_file_node.dart';
+import 'package:debrify/services/cloud/cloud_folder_sort.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  RDFileNode file(String name) => RDFileNode.file(
+    name: name,
+    fileId: 7,
+    path: '/unchanged/$name',
+    bytes: 123,
+    linkIndex: 4,
+    selected: false,
+  );
+
+  test(
+    'empty and singleton input produce independent lists of the same nodes',
+    () {
+      const empty = <RDFileNode>[];
+      final result = CloudFolderSort.sortedView(empty);
+      final node = file('only.mkv');
+      result.add(node);
+      expect(empty, isEmpty);
+      final input = List<RDFileNode>.unmodifiable([node]);
+      final sorted = CloudFolderSort.sortedView(input);
+      expect(sorted.single, same(node));
+      sorted.clear();
+      expect(input.single, same(node));
+    },
+  );
+
+  test(
+    'keeps duplicate identities, metadata and unsorted children untouched',
+    () {
+      final childB = file('b.mkv');
+      final childA = file('a.mkv');
+      final children = <RDFileNode>[childB, childA];
+      final folder = RDFileNode.folder(name: 'Extras', children: children);
+      final input = List<RDFileNode>.unmodifiable([
+        childB,
+        folder,
+        childA,
+        childB,
+      ]);
+      final sorted = CloudFolderSort.sortedView(input);
+      expect(sorted, [folder, childA, childB, childB]);
+      expect(input, [childB, folder, childA, childB]);
+      expect(folder.children, same(children));
+      expect(children, [childB, childA]);
+      expect(sorted.last.path, '/unchanged/b.mkv');
+      expect(sorted.last.fileId, 7);
+      expect(sorted.last.linkIndex, 4);
+      expect(sorted.last.bytes, 123);
+      expect(sorted.last.selected, isFalse);
+    },
+  );
+
+  test('folder patterns retain priority and sort numerically before names', () {
+    final names = [
+      'Season 10',
+      'Extras',
+      'Module-4',
+      'Episode 5',
+      'chapter_3',
+      'Part 2',
+      '01. Season 99',
+    ];
+    final nodes = names.map((name) => RDFileNode.folder(name: name)).toList();
+    expect(CloudFolderSort.sortedView(nodes).map((node) => node.name), [
+      '01. Season 99',
+      'Part 2',
+      'chapter_3',
+      'Module-4',
+      'Episode 5',
+      'Season 10',
+      'Extras',
+    ]);
+  });
+
+  test(
+    'digits without separators and overflowing numbers stay ordinary names',
+    () {
+      const overflow = '99999999999999999999999999999999_oversize.mkv';
+      final nodes = [
+        'zeta.mkv',
+        overflow,
+        '12',
+        'Alpha.mkv',
+        '10. ten.mkv',
+        '2no-separator.mkv',
+        '02_two.mkv',
+      ].map(file).toList();
+      expect(CloudFolderSort.sortedView(nodes).map((node) => node.name), [
+        '02_two.mkv',
+        '10. ten.mkv',
+        '12',
+        '2no-separator.mkv',
+        overflow,
+        'Alpha.mkv',
+        'zeta.mkv',
+      ]);
+    },
+  );
+}


### PR DESCRIPTION
Real-Debrid and TorBox download screens duplicate the same folder ordering and tree-building logic. Move those three unchanged method bodies into `CloudFolderSort` and route both screens through it, preserving numeric ordering, tie behavior and existing handling of non-numbered names.

Based independently on `webdav-sync` at `077f2e79`. The helper uses the existing `RDFileNode`; no provider registry, shared screen state machine or other refactor is required.

Validation with Flutter 3.44.8 / Dart 3.12.2: the two public-screen tests pass on the original and extracted implementations; four additional helper tests pass. Original-body comparison and all redirected host calls were checked. Changed-path analysis has the same 72 existing diagnostics as upstream, with none added. No device playback or full device build is claimed.

Independent adversarial review found no production regressions. The final branch passes 12 tests after adding tie-collision and larger-cohort ordering coverage; mutations that introduced numeric-name tiebreakers or stable-sort behavior were rejected. Supplemental-test analysis is clean; the existing production analysis baseline above is unchanged.

Combined validation with the other ten proposed slices: **304 focused/integration tests passed** and an Android release build succeeded with Flutter 3.44.8 / Dart 3.12.2 / JDK 17. The test and build source trees match. The existing Windows Spotlight golden is excluded from that selection. A separate clean upstream full-suite run has 6,044 passes, 12 skips, 55 failing user tests and one failing teardown hook; this is not a full-suite or GitHub CI pass. Physical-device validation of the upstream ports remains outstanding.
