### PR TITLE
Apply hide-watched filtering to detail recommendations

### DIFF
--- a/lib/screens/catalog_item_detail_screen.dart
+++ b/lib/screens/catalog_item_detail_screen.dart
@@ -1,4 +1,5 @@
 import '../services/metadata_provider_service.dart';
+import '../services/watched_filter.dart';
 import '../widgets/metadata_franchise_rail.dart';
 import '../widgets/metadata_title_navigation.dart';
 import '../services/metadata_preferences_service.dart';
@@ -554,9 +555,10 @@ class _CatalogItemDetailScreenState extends State<CatalogItemDetailScreen>
     bool valid() => mounted && generation == _detailsMetadataGeneration && scope == ProfileRuntime.scope.value && revision == MetadataPreferencesService.revision.value;
     final loader = widget.recommendationsLoader;
     try {
-      final recs = await MetadataDetailsService.instance.recommendations(
-        _item,
-        loader,
+      // Filter before presentation so every batch and its original-item
+      // mapping retain the same surviving titles.
+      final recs = WatchedFilter.apply(
+        await MetadataDetailsService.instance.recommendations(_item, loader),
       );
       if (mounted && valid()) {
         _recommendationOriginals.clear();

--- a/lib/screens/merged_series_detail_screen.dart
+++ b/lib/screens/merged_series_detail_screen.dart
@@ -1,6 +1,7 @@
 import '../widgets/metadata_franchise_rail.dart';
 import '../widgets/metadata_title_navigation.dart';
 import '../services/metadata_provider_service.dart';
+import '../services/watched_filter.dart';
 import '../services/metadata_preferences_service.dart';
 import '../models/metadata_preferences.dart';
 import '../services/profiles/profile_runtime.dart';
@@ -1419,9 +1420,10 @@ class _MergedDetailScreenState extends State<MergedDetailScreen>
     bool valid() => mounted && generation == _detailsMetadataGeneration && scope == ProfileRuntime.scope.value && revision == MetadataPreferencesService.revision.value;
     final loader = widget.recommendationsLoader;
     try {
-      final recs = await MetadataDetailsService.instance.recommendations(
-        _item,
-        loader,
+      // Filter before presentation so every batch and its original-item
+      // mapping retain the same surviving titles.
+      final recs = WatchedFilter.apply(
+        await MetadataDetailsService.instance.recommendations(_item, loader),
       );
       if (mounted && valid()) {
         _recommendationOriginals.clear();

--- a/test/detail_recommendations_hide_watched_test.dart
+++ b/test/detail_recommendations_hide_watched_test.dart
@@ -1,0 +1,142 @@
+import 'package:debrify/models/metadata_preferences.dart';
+import 'package:debrify/models/stremio_addon.dart';
+import 'package:debrify/screens/catalog_item_detail_screen.dart';
+import 'package:debrify/screens/merged_series_detail_screen.dart';
+import 'package:debrify/services/hide_watched_prefs.dart';
+import 'package:debrify/services/metadata_preferences_service.dart';
+import 'package:debrify/services/storage_service.dart';
+import 'package:debrify/services/watched_status_service.dart';
+import 'package:debrify/theme/app_theme.dart';
+import 'package:debrify/theme/app_theme_scope.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const watched = StremioMeta(
+    id: 'tt1234567',
+    imdbId: 'tt1234567',
+    type: 'movie',
+    name: 'Finished recommendation',
+  );
+  const fresh = StremioMeta(
+    id: 'tt7654321',
+    imdbId: 'tt7654321',
+    type: 'movie',
+    name: 'Fresh recommendation',
+    description: 'Original playback metadata',
+  );
+  const native = StremioMeta(
+    id: 'tmdb:42',
+    type: 'movie',
+    name: 'Unresolved native recommendation',
+  );
+  const item = StremioMeta(id: 'test-title', type: 'movie', name: 'Detail');
+
+  for (final merged in [false, true]) {
+    for (final hide in [false, true]) {
+      for (final batches in [false, true]) {
+        testWidgets(
+          '${merged ? 'merged' : 'catalog'} recommendations hide=$hide batches=$batches',
+          (tester) async {
+            tester.view.physicalSize = const Size(1280, 2400);
+            tester.view.devicePixelRatio = 1;
+            addTearDown(tester.view.reset);
+            await tester.runAsync(() async {
+              SharedPreferences.setMockInitialValues({
+                HideWatchedPrefs.key: hide,
+                'finished_movies_v1': ['tt1234567'],
+              });
+              HideWatchedPrefs.debugReset();
+              await HideWatchedPrefs.warmUp();
+              WatchedStatusService.instance.resetProfileScope();
+              WatchedStatusService.instance.ensureStarted();
+              await WatchedStatusService.instance.firstSnapshot;
+            });
+            addTearDown(() {
+              HideWatchedPrefs.debugReset();
+              WatchedStatusService.instance.resetProfileScope();
+            });
+            expect(
+              WatchedStatusService.instance.isWatchedForTicks(
+                watched.id,
+                'movie',
+              ),
+              isTrue,
+            );
+            await StorageService.setDetailPageStyle('marquee');
+            // A missing selected artwork provider still publishes new presentation
+            // objects. Exercise that real batch path without network credentials.
+            await MetadataPreferencesService.save(
+              MetadataPreferences(
+                features: {},
+                providers: {
+                  if (batches)
+                    MetadataCategory.posters: MetadataPreferences.tmdb,
+                  MetadataCategory.credits: MetadataPreferences.current,
+                },
+                fallback: true,
+              ),
+            );
+            StremioMeta? opened;
+            Future<List<StremioMeta>> load() async => [watched, fresh, native];
+            final screen = merged
+                ? MergedDetailScreen(
+                    item: item,
+                    addon: StremioAddon(
+                      id: 'test',
+                      name: 'Test',
+                      manifestUrl: '',
+                      baseUrl: '',
+                    ),
+                    isTelevision: true,
+                    onResume: (_) async {},
+                    recommendationsLoader: load,
+                    onRecommendationTap: (value) => opened = value,
+                  )
+                : CatalogItemDetailScreen(
+                    item: item,
+                    isTelevision: true,
+                    onPlay: () {},
+                    onBrowse: () {},
+                    recommendationsLoader: load,
+                    onRecommendationTap: (value) => opened = value,
+                  );
+            await tester.pumpWidget(
+              MaterialApp(
+                builder: (context, child) =>
+                    AppThemeScope(theme: AppThemes.legacy, child: child!),
+                home: screen,
+              ),
+            );
+            for (var frame = 0; frame < 20; frame++) {
+              await tester.pump(const Duration(milliseconds: 100));
+            }
+            expect(find.text(watched.name), hide ? findsNothing : findsWidgets);
+            expect(find.text(fresh.name), findsWidgets);
+            expect(find.text(native.name), findsWidgets);
+            final freshLabel = find.text(fresh.name).first;
+            await tester.ensureVisible(freshLabel);
+            if (merged) {
+              final card = find
+                  .ancestor(of: freshLabel, matching: find.byType(SizedBox))
+                  .first;
+              await tester.tap(
+                find.descendant(of: card, matching: find.byType(InkWell)).first,
+              );
+            } else {
+              await tester.tap(freshLabel);
+            }
+            await tester.pump();
+            // Presentation must never replace the original item used to open
+            // playback, including after a hidden first row shifts the indices.
+            expect(opened, same(fresh));
+            expect(tester.takeException(), isNull);
+            await tester.pumpWidget(const SizedBox());
+            await tester.pump(const Duration(seconds: 1));
+          },
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
Apply the existing hide-watched preference to recommendations in catalog and merged-series detail screens before presentation batching. Watched recommendations disappear when the preference is enabled, while displayed items retain their original identity when opened.

This follows up the already-merged hide-watched feature without resubmitting it. Based independently on `webdav-sync` at `077f2e79`.

Flutter 3.44.8 / Dart 3.12.2: four new regression cases fail on upstream; 22 related tests pass with the fix. Coverage includes both detail hosts, enabled/disabled filtering, batched/unbatched presentation and tap identity. Scoped analysis retains one existing diagnostic. Physical-device validation is outstanding.

Independent review passed 41 tests with supplemental coverage. Removing the filter caused eight behavioral failures; the restored production code passed again.

Combined validation with the other ten proposed slices: **304 focused/integration tests passed** and an Android release build succeeded with Flutter 3.44.8 / Dart 3.12.2 / JDK 17. The test and build source trees match. The existing Windows Spotlight golden is excluded from that selection. A separate clean upstream full-suite run has 6,044 passes, 12 skips, 55 failing user tests and one failing teardown hook; this is not a full-suite or GitHub CI pass. Physical-device validation of the upstream ports remains outstanding.
