### PR TITLE
Keep focused indexer manager controls visible

### DIFF
--- a/lib/screens/settings/indexer_managers_settings_page.dart
+++ b/lib/screens/settings/indexer_managers_settings_page.dart
@@ -7,6 +7,7 @@ import '../../services/storage_service.dart';
 import '../../services/torrent_service.dart';
 import '../../services/analytics_service.dart';
 import '../../utils/platform_util.dart';
+import '../../utils/tv_reveal.dart';
 import '../../widgets/tv_text_field.dart';
 import 'widgets/settings_widgets.dart';
 import '../../theme/app_theme_scope.dart';
@@ -428,7 +429,7 @@ class _IndexerManagersSettingsPageState
       ],
     );
 
-    return Card(
+    final card = Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: LayoutBuilder(
@@ -462,6 +463,25 @@ class _IndexerManagersSettingsPageState
             );
           },
         ),
+      ),
+    );
+    var rowFocused = false;
+    return Builder(
+      builder: (rowContext) => Focus(
+        canRequestFocus: false,
+        skipTraversal: true,
+        onFocusChange: (focused) {
+          rowFocused = focused;
+          if (!focused) return;
+          // A programmatic focus handoff skips traversal's implicit reveal.
+          // Reveal the whole manager, including its label and all controls.
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (rowContext.mounted && rowFocused) {
+              tvRevealMinimal(rowContext);
+            }
+          });
+        },
+        child: card,
       ),
     );
   }

--- a/test/indexer_manager_focus_reveal_test.dart
+++ b/test/indexer_manager_focus_reveal_test.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+import 'package:debrify/models/indexer_manager_config.dart';
+import 'package:debrify/screens/settings/indexer_managers_settings_page.dart';
+import 'package:debrify/services/secret_vault.dart';
+import 'package:debrify/theme/app_theme.dart';
+import 'package:debrify/theme/app_theme_scope.dart';
+import 'package:debrify/utils/platform_util.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  for (final control in ['switch', 'Test connection', 'Edit', 'Delete']) {
+    testWidgets('$control reveals an offscreen manager on focus', (
+      tester,
+    ) async {
+      PlatformUtil.debugSetAndroidTvCached(true);
+      addTearDown(() => PlatformUtil.debugSetAndroidTvCached(null));
+      tester.view.physicalSize = const Size(960, 540);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      SecretVault.debugReset(deviceIdOverride: 'indexer-focus-test');
+      addTearDown(SecretVault.debugReset);
+      SharedPreferences.setMockInitialValues({
+        'indexer_manager_configs_v1': [
+          for (var i = 0; i < 12; i++)
+            jsonEncode(
+              IndexerManagerConfig(
+                id: '$i',
+                name: 'Manager $i',
+                type: IndexerManagerType.jackett,
+                baseUrl: 'https://example.invalid/$i',
+                apiKey: 'test',
+              ).toJson(),
+            ),
+        ],
+      });
+      await tester.pumpWidget(
+        MaterialApp(
+          builder: (context, child) =>
+              AppThemeScope(theme: AppThemes.legacy, child: child!),
+          home: const IndexerManagersSettingsPage(),
+        ),
+      );
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      final controls = control == 'switch'
+          ? find.byType(Switch)
+          : find.byTooltip(control);
+      expect(controls, findsNWidgets(12));
+      final scroll = tester.state<ScrollableState>(
+        find.byType(Scrollable).first,
+      );
+      final viewport = tester.getRect(find.byType(SingleChildScrollView).first);
+      // Programmatic DPAD handoffs bypass traversal's implicit reveal.
+      Future<void> focusAndCheck(Finder target) async {
+        final focus = find
+            .descendant(of: target, matching: find.byType(Focus))
+            .last;
+        final child = tester.widget<Focus>(focus).child;
+        final node = Focus.of(tester.element(find.byWidget(child)));
+        node.requestFocus();
+        await tester.pump();
+        await tester.pumpAndSettle();
+        expect(node.hasFocus, isTrue);
+        final rect = tester.getRect(target);
+        expect(rect.top, greaterThanOrEqualTo(viewport.top));
+        expect(rect.bottom, lessThanOrEqualTo(viewport.bottom));
+      }
+
+      expect(tester.getRect(controls.last).top, greaterThan(viewport.bottom));
+      await focusAndCheck(controls.last);
+      expect(scroll.position.pixels, greaterThan(0));
+      await focusAndCheck(controls.first);
+      expect(tester.takeException(), isNull);
+      await tester.pumpWidget(const SizedBox());
+    });
+  }
+}


### PR DESCRIPTION
Reveal an indexer manager card when one of its controls gains focus, so keyboard/remote navigation does not leave the active Switch, Test, Edit or Delete control outside the viewport. A guarded post-frame callback uses the existing minimal-reveal helper.

Based independently on `webdav-sync` at `077f2e79`. No settings rows, labels or groups are rearranged.

Flutter 3.44.8 / Dart 3.12.2: all four regression cases fail on upstream and pass with the fix, exercising focus in both scroll directions. Scoped analysis retains two existing diagnostics. Physical-device validation is outstanding.

Independent review passed eight tests with supplemental focus coverage. Disabling reveal caused all eight to fail; restored code passed again.

Combined validation with the other ten proposed slices: **304 focused/integration tests passed** and an Android release build succeeded with Flutter 3.44.8 / Dart 3.12.2 / JDK 17. The test and build source trees match. The existing Windows Spotlight golden is excluded from that selection. A separate clean upstream full-suite run has 6,044 passes, 12 skips, 55 failing user tests and one failing teardown hook; this is not a full-suite or GitHub CI pass. Physical-device validation of the upstream ports remains outstanding.
