### PR TITLE
Reveal focused recommendations in three detail layouts

### DIFF
--- a/lib/widgets/detail/detail_layout_console.dart
+++ b/lib/widgets/detail/detail_layout_console.dart
@@ -997,7 +997,19 @@ class _ConsolePosterState extends State<_ConsolePoster> {
         child: InkWell(
           focusNode: widget.focusNode,
           onTap: widget.onTap,
-          onFocusChange: (f) => setState(() => _focused = f),
+          onFocusChange: (focused) {
+            setState(() => _focused = focused);
+            if (!focused) return;
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (mounted && _focused) {
+                Scrollable.ensureVisible(
+                  context,
+                  alignment: 0.5,
+                  duration: Duration.zero,
+                );
+              }
+            });
+          },
           child: (p != null && p.isNotEmpty)
               ? CachedNetworkImage(
                   imageUrl: p,

--- a/lib/widgets/detail/detail_layout_dossier.dart
+++ b/lib/widgets/detail/detail_layout_dossier.dart
@@ -651,7 +651,19 @@ class _RecPosterState extends State<_RecPoster> {
           clipBehavior: Clip.antiAlias,
           child: InkWell(
             onTap: widget.onTap,
-            onFocusChange: (f) => setState(() => _focused = f),
+            onFocusChange: (focused) {
+              setState(() => _focused = focused);
+              if (!focused) return;
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (mounted && _focused) {
+                  Scrollable.ensureVisible(
+                    context,
+                    alignment: 0.5,
+                    duration: Duration.zero,
+                  );
+                }
+              });
+            },
             child: (poster != null && poster.isNotEmpty)
                 ? CachedNetworkImage(
                     imageUrl: poster,

--- a/lib/widgets/detail/detail_layout_marquee.dart
+++ b/lib/widgets/detail/detail_layout_marquee.dart
@@ -432,7 +432,19 @@ class _RecCardState extends State<_RecCard> {
               child: InkWell(
                 focusNode: widget.focusNode,
                 onTap: widget.onTap,
-                onFocusChange: (f) => setState(() => _focused = f),
+                onFocusChange: (focused) {
+                  setState(() => _focused = focused);
+                  if (!focused) return;
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    if (mounted && _focused) {
+                      Scrollable.ensureVisible(
+                        context,
+                        alignment: 0.5,
+                        duration: Duration.zero,
+                      );
+                    }
+                  });
+                },
                 child: AspectRatio(
                   aspectRatio: 2 / 3,
                   child: (poster != null && poster.isNotEmpty)

--- a/test/detail_recommendation_focus_reveal_test.dart
+++ b/test/detail_recommendation_focus_reveal_test.dart
@@ -1,0 +1,128 @@
+import 'package:debrify/models/stremio_addon.dart';
+import 'package:debrify/widgets/detail/detail_layout_console.dart';
+import 'package:debrify/widgets/detail/detail_layout_dossier.dart';
+import 'package:debrify/widgets/detail/detail_layout_marquee.dart';
+import 'package:debrify/widgets/detail/detail_model.dart';
+import 'package:debrify/widgets/detail/theme/detail_theme.dart';
+import 'package:debrify/widgets/detail/theme/detail_themes.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  for (final layout in ['marquee', 'dossier', 'console']) {
+    testWidgets(
+      '$layout reveals a cached recommendation focused programmatically',
+      (tester) async {
+        tester.view.physicalSize = const Size(960, 540);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+        final back = FocusNode();
+        final primary = FocusNode();
+        addTearDown(back.dispose);
+        addTearDown(primary.dispose);
+        final model = DetailModel(
+          item: const StremioMeta(
+            id: 'movie',
+            type: 'movie',
+            name: 'Movie',
+            description: 'Movie synopsis for the reference pane.',
+          ),
+          isMovie: true,
+          isTelevision: true,
+          accent: Colors.amber,
+          imdbExtra: null,
+          parentsGuide: null,
+          recommendations: [
+            for (var i = 0; i < 30; i++)
+              StremioMeta(id: 'rec-$i', type: 'movie', name: 'Title $i'),
+          ],
+          primaryLabel: 'Play',
+          sourceCount: 0,
+          hasTrailer: false,
+          trailerBusy: false,
+          trailerPlaying: false,
+          hasTrakt: false,
+          traktTracked: false,
+          traktLabel: '',
+          traktRating: null,
+          hasSimkl: false,
+          simklTracked: false,
+          simklLabel: '',
+          simklRating: null,
+          showPrimary: true,
+          onPrimary: () {},
+          onBrowse: null,
+          onTrailer: () {},
+          onSelectSource: () {},
+          onAppMenu: () {},
+          onTraktMenu: () {},
+          onSimklMenu: () {},
+          onRecommendationTap: (_) {},
+          onAmbientStill: (_) {},
+          focus: DetailFocusCoordinator(backNode: back, primaryEntry: primary),
+        );
+        final body = switch (layout) {
+          'marquee' => DetailMarquee(model: model, episodesHost: null),
+          'dossier' => DetailDossier(model: model, episodesHost: null),
+          _ => DetailConsole(model: model, episodesHost: null),
+        };
+        await tester.pumpWidget(
+          MaterialApp(
+            home: DetailThemeScope(
+              theme: DetailThemes.signal,
+              child: Scaffold(body: body),
+            ),
+          ),
+        );
+        await tester.pump();
+        final list = layout == 'console'
+            ? find.byType(GridView).first
+            : find
+                  .byWidgetPredicate(
+                    (widget) =>
+                        widget is ListView &&
+                        widget.scrollDirection == Axis.horizontal,
+                  )
+                  .first;
+        final viewport = tester.getRect(list);
+        final scroll = tester.state<ScrollableState>(
+          find.descendant(of: list, matching: find.byType(Scrollable)).first,
+        );
+        final cards = find.descendant(of: list, matching: find.byType(InkWell));
+        final element = tester.element(cards.last);
+        final card = find.byElementPredicate((e) => identical(e, element));
+        final before = tester.getRect(card);
+        expect(
+          layout == 'console'
+              ? before.bottom > viewport.bottom
+              : before.right > viewport.right,
+          isTrue,
+          reason:
+              'The target must start beyond the visible viewport, in the lazy cache.',
+        );
+        final focus = find
+            .descendant(of: card, matching: find.byType(Focus))
+            .last;
+        final child = tester.widget<Focus>(focus).child;
+        final node = Focus.of(tester.element(find.byWidget(child)));
+        node.requestFocus();
+        await tester.pump();
+        await tester.pump();
+        expect(node.hasFocus, isTrue);
+        expect(scroll.position.pixels, greaterThan(0));
+        final after = tester.getRect(card);
+        if (layout == 'console') {
+          expect(after.top, greaterThanOrEqualTo(viewport.top - 1));
+          expect(after.bottom, lessThanOrEqualTo(viewport.bottom + 1));
+        } else {
+          expect(after.left, greaterThanOrEqualTo(viewport.left - 1));
+          expect(after.right, lessThanOrEqualTo(viewport.right + 1));
+        }
+        expect(tester.takeException(), isNull);
+        await tester.pumpWidget(const SizedBox());
+        await tester.pump();
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+}


### PR DESCRIPTION
Reveal focused recommendation cards in the Marquee, Dossier and Console detail layouts. A mounted/focus-guarded post-frame callback brings the card into view when remote or keyboard navigation reaches it.

Based independently on `webdav-sync` at `077f2e79`. This is a visibility fix using immediate reveal; it does not depend on the optional Spotlight motion preference or change settings organization.

Flutter 3.44.8 / Dart 3.12.2: three regression cases fail on upstream; 94 related tests, including existing DPAD coverage, pass with the fix. Scoped analysis is clean. Physical-device validation is outstanding.

Independent review passed 12 tests, including continued directional movement beyond the initial lazy-list cache and existing person/native metadata behavior. Disabling reveal caused six failures; restored code passed again.

Combined validation with the other ten proposed slices: **304 focused/integration tests passed** and an Android release build succeeded with Flutter 3.44.8 / Dart 3.12.2 / JDK 17. The test and build source trees match. The existing Windows Spotlight golden is excluded from that selection. A separate clean upstream full-suite run has 6,044 passes, 12 skips, 55 failing user tests and one failing teardown hook; this is not a full-suite or GitHub CI pass. Physical-device validation of the upstream ports remains outstanding.
