### PR TITLE
Use readable theme colors for episode action hints

### DIFF
--- a/lib/widgets/detail/detail_episode_cells.dart
+++ b/lib/widgets/detail/detail_episode_cells.dart
@@ -312,19 +312,19 @@ class _DetailHoldHintState extends State<DetailHoldHint> {
   }
 }
 
-/// Black glass with white ink, so it reads over artwork and over a light
-/// theme's ground alike — it floats above the page, not inside it.
+/// The active theme's ink and ground keep the floating hint legible over art.
 class _DetailHoldHintPill extends StatelessWidget {
   const _DetailHoldHintPill();
 
   @override
   Widget build(BuildContext context) {
+    final t = DetailThemeScope.of(context);
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 7),
       decoration: BoxDecoration(
-        color: Colors.black.withValues(alpha: 0.72),
+        color: t.ground.withValues(alpha: 0.92),
         borderRadius: BorderRadius.circular(999),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.22)),
+        border: Border.all(color: t.hair),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -332,13 +332,13 @@ class _DetailHoldHintPill extends StatelessWidget {
           Icon(
             Icons.more_horiz_rounded,
             size: 15,
-            color: Colors.white.withValues(alpha: 0.92),
+            color: t.tx,
           ),
           const SizedBox(width: 6),
           Text(
             'Long press for more actions',
             style: TextStyle(
-              color: Colors.white.withValues(alpha: 0.92),
+              color: t.tx,
               fontSize: 12,
               fontWeight: FontWeight.w600,
             ),

--- a/test/detail_episode_hint_theme_test.dart
+++ b/test/detail_episode_hint_theme_test.dart
@@ -1,0 +1,71 @@
+import 'package:debrify/utils/platform_util.dart';
+import 'package:debrify/widgets/detail/detail_episode_cells.dart';
+import 'package:debrify/widgets/detail/theme/detail_theme.dart';
+import 'package:debrify/widgets/detail/theme/detail_themes.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('focused episode hint follows live detail-theme colors', (
+    tester,
+  ) async {
+    PlatformUtil.debugSetAndroidTvCached(true);
+    addTearDown(() => PlatformUtil.debugSetAndroidTvCached(null));
+    final node = FocusNode();
+    addTearDown(node.dispose);
+    for (final theme in [DetailThemes.phosphor, DetailThemes.broadsheet]) {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DetailThemeScope(
+            theme: theme,
+            child: Scaffold(
+              body: DetailHoldHint(
+                child: DetailEpisodeInteraction(
+                  focusNode: node,
+                  gesture: DetailOptionsGesture.holdOk,
+                  onPlay: () {},
+                  onOptions: () {},
+                  builder: (_, focused) =>
+                      const SizedBox(width: 100, height: 100),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      node.requestFocus();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      final label = find.text('Long press for more actions');
+      expect(label, findsOneWidget);
+      expect(tester.widget<Text>(label).style!.color, theme.tx);
+      expect(
+        tester.widget<Icon>(find.byIcon(Icons.more_horiz_rounded)).color,
+        theme.tx,
+      );
+      final pill = tester.widget<Container>(
+        find.ancestor(of: label, matching: find.byType(Container)).first,
+      );
+      final decoration = pill.decoration! as BoxDecoration;
+      expect((decoration.border! as Border).top.color, theme.hair);
+      expect(decoration.color, theme.ground.withValues(alpha: 0.92));
+      // Artwork can be bright or dark behind the translucent hint. The active
+      // theme must keep its small text readable over either extreme.
+      for (final artwork in [Colors.black, Colors.white]) {
+        final background = Color.alphaBlend(decoration.color!, artwork);
+        final ink = Color.alphaBlend(theme.tx, background).computeLuminance();
+        final ground = background.computeLuminance();
+        final contrast = ink > ground
+            ? (ink + 0.05) / (ground + 0.05)
+            : (ground + 0.05) / (ink + 0.05);
+        expect(contrast, greaterThanOrEqualTo(4.5));
+      }
+      final opacity = tester.widget<AnimatedOpacity>(
+        find.ancestor(of: label, matching: find.byType(AnimatedOpacity)).first,
+      );
+      expect(opacity.opacity, 1);
+      expect(tester.takeException(), isNull);
+    }
+    await tester.pumpWidget(const SizedBox());
+  });
+}


### PR DESCRIPTION
Render the episode long-press action hint with the active detail theme's text, background and border colors. Updating both text and background keeps the hint readable over artwork in light and dark themes and responds to live theme changes.

Based independently on `webdav-sync` at `077f2e79`; no settings organization or episode navigation changes.

Flutter 3.44.8 / Dart 3.12.2: the regression fails on upstream; 120 related tests pass with the fix. Coverage checks live theme changes and contrast. Scoped analysis is clean. Physical-device visual validation is outstanding.

Independent review passed 12 tests, including actual rendered-theme contrast. An unreadable-ink mutation failed the contrast check; restored code passed again.

Combined validation with the other ten proposed slices: **304 focused/integration tests passed** and an Android release build succeeded with Flutter 3.44.8 / Dart 3.12.2 / JDK 17. The test and build source trees match. The existing Windows Spotlight golden is excluded from that selection. A separate clean upstream full-suite run has 6,044 passes, 12 skips, 55 failing user tests and one failing teardown hook; this is not a full-suite or GitHub CI pass. Physical-device validation of the upstream ports remains outstanding.
