### PR TITLE
Add optional Smooth/Snappy scrolling for Spotlight Home

### DIFF
--- a/dev/verification/upstream-tv-motion.md
+++ b/dev/verification/upstream-tv-motion.md
@@ -1,0 +1,102 @@
+# Optional TV motion and Spotlight scroll follow
+
+Base: `077f2e79` (`upstream/webdav-sync`). Worktree: `.worktrees/upstream-motion`.
+Branch: `codex/upstream-tv-motion`. Verified 2026-09-11 on Windows using
+Flutter 3.44.8 / Dart 3.12.2 at `.tools/flutter-3.44.8`.
+
+## Scope and behavior
+
+This is a selective port of the preference/root propagation ideas from
+`b6f844a5` and `8bb08841`, and the Spotlight reveal fix from `b219716f`.
+It does not cherry-pick their other motion migrations.
+
+- Adds Appearance > Display > TV motion, with Snappy selected unless explicitly
+  changed. Settings search also exposes the picker on TV.
+  Existing upstream menu groups, labels, and relative row order are preserved.
+  The two following Player rows only receive shifted focus indices for the new
+  entry. No settings rearrangement, title/rating controls, or previews are ported.
+- Only Spotlight card scroll-follow adopts the new policy. Explicit Smooth is
+  260ms; Android TV Snappy stays instantaneous, while tvOS Snappy preserves
+  upstream's existing 220ms. Off-TV stays 220ms. Reduced motion is zero.
+  These scroll durations retain their literal values under custom theme tempo.
+  The existing `easeOutCubic` curve and alignment are unchanged.
+- Motion dependencies are captured in the card's build callback. The current
+  upstream loading, hero visibility, metadata, preview, focus, and cache logic
+  remains intact. The separate return-to-hero animation is unchanged.
+- `TvMotionRoot` subscribes above the Navigator and ProfileGate and republishes
+  an inherited theme. Selection and profile warmers update already-mounted
+  consumers; listeners are removed on disposal.
+- `tv_motion_profile` uses `ProfilePreferences`, with the scope captured before
+  asynchronous access. Reads/writes are serialized to preserve rapid selection
+  order, and stale warm completions cannot overwrite a later choice.
+- Reset, activation, and rollback follow the existing profile lifecycle.
+  Unset, unrecognized, and unreadable preferences fall back to Snappy.
+- The key belongs to `ProfileAppearancePreferences.keys`, so automatic WebDAV
+  publication, legacy merge/materialization, replay, and bootstrap exclude it.
+  It remains eligible for explicit backups and profile-default copies, matching
+  the other appearance keys.
+
+No Collections, hover, shared-wrapper migrations, dependency changes, device
+operations, push, or PR creation are included. The prior fork fix was confirmed
+on AM9; this upstream port has not been device-certified.
+
+## Verification
+
+Dependencies: pinned SDK `flutter pub get --enforce-lockfile`; lockfile unchanged.
+
+1. With upstream's original Spotlight callback and the preference test harness
+   installed, the real DPAD Smooth/intermediate-frame and rapid-repeat tests
+   failed; four compatibility tests passed. This is a behavioral failure,
+   not the initial missing-import adaptation error.
+2. Removing the root subscription caused the profile-switch test to fail: the
+   same mounted consumer retained Smooth after the incoming profile warmed
+   Snappy. Restoring the subscription passed.
+3. Final related regression selection: **163 passed**. Includes nine real
+   Spotlight DPAD cases (intermediate frames, curve, repeats/reversal, tvOS,
+   off-TV, reduced motion), preference/race/isolation/root-refresh tests,
+   picker navigation, actual Appearance-pane entry/return, existing Spotlight
+   board and compact behavior, appearance focus-index guards, profile isolation,
+   WebDAV hot-state appearance exclusions, and existing theme motion policies.
+4. Three unrelated tests failed both with the port and with original upstream
+   source restored in this worktree. They were excluded from the final selection:
+   - `TV Spotlight settings visual`: identical 3.84% golden mismatch on Windows.
+   - `direct SharedPreferences opens stay inside reviewed adapters/stores`:
+     baseline reviewed-call-count mismatch.
+   - `device reset stops and deletes Dart and native diagnostics`: baseline
+     source-marker `RangeError` in the Kotlin scanner.
+5. Scoped analysis: no errors or warnings; 16 informational diagnostics, matching
+   original upstream exactly after ignoring shifted line numbers. These concern
+   existing main/Settings async-context/deprecation sites and Spotlight's
+   existing parameter name/cacheExtent, not the port's added code.
+
+The regression command used `flutter test --no-pub --reporter expanded` with:
+
+```text
+test/spotlight_board_scroll_motion_test.dart
+test/tv_motion_profile_test.dart
+test/settings_tv_motion_page_test.dart
+test/spotlight_board_test.dart
+test/spotlight_board_compact_test.dart
+test/settings_appearance_groups_test.dart
+test/settings_tv_spotlight_layout_test.dart
+test/profiles/isolation_suite/stale_runtime_guard_test.dart
+test/services/webdav_sync/webdav_sync_hot_merge_test.dart
+test/profiles/profile_source_guard_test.dart
+test/theme/shape_type_motion_test.dart
+```
+
+Exclusion expression supplied with `--name`:
+
+```text
+^(?!TV Spotlight settings visual|direct SharedPreferences opens stay inside reviewed adapters/stores|device reset stops and deletes Dart and native diagnostics)
+```
+
+Local raw evidence (ignored logs, not committed build artifacts), relative to
+this note's directory:
+
+- `upstream-tv-motion/red-spotlight.log`
+- `upstream-tv-motion/red-root-subscription.log`
+- `upstream-tv-motion/final-regressions.log`
+- `upstream-tv-motion/upstream-baseline-tests.log`
+- `upstream-tv-motion/analyze.log`
+- `upstream-tv-motion/upstream-baseline-analyze.log`

--- a/dev/verification/upstream-tv-motion.md
+++ b/dev/verification/upstream-tv-motion.md
@@ -51,29 +51,41 @@ Dependencies: pinned SDK `flutter pub get --enforce-lockfile`; lockfile unchange
 2. Removing the root subscription caused the profile-switch test to fail: the
    same mounted consumer retained Smooth after the incoming profile warmed
    Snappy. Restoring the subscription passed.
-3. Final related regression selection: **163 passed**. Includes nine real
+3. Final related regression selection: **169 passed**. Includes nine real
    Spotlight DPAD cases (intermediate frames, curve, repeats/reversal, tvOS,
    off-TV, reduced motion), preference/race/isolation/root-refresh tests,
    picker navigation, actual Appearance-pane entry/return, existing Spotlight
    board and compact behavior, appearance focus-index guards, profile isolation,
-   WebDAV hot-state appearance exclusions, and existing theme motion policies.
+   WebDAV hot-state appearance exclusions, existing theme motion policies,
+   and the six supplemental behavioral cases below.
 4. Three unrelated tests failed both with the port and with original upstream
    source restored in this worktree. They were excluded from the final selection:
    - `TV Spotlight settings visual`: identical 3.84% golden mismatch on Windows.
    - `direct SharedPreferences opens stay inside reviewed adapters/stores`:
-     baseline reviewed-call-count mismatch.
+     unregistered direct preference open in the untouched
+     `lib/services/webdav_sync/webdav_sync_save_feedback.dart`.
    - `device reset stops and deletes Dart and native diagnostics`: baseline
      source-marker `RangeError` in the Kotlin scanner.
 5. Scoped analysis: no errors or warnings; 16 informational diagnostics, matching
    original upstream exactly after ignoring shifted line numbers. These concern
    existing main/Settings async-context/deprecation sites and Spotlight's
    existing parameter name/cacheExtent, not the port's added code.
+6. Supplemental scoped selection: **6 passed**. Five controller tests hold the
+   preference transport across rapid selections, successful/false/throwing
+   writes, a queued warm, and profile-generation changes. One real Spotlight
+   test changes selection, incoming profile, and reduced motion while preserving
+   the focused widget's element identity and checking the next DPAD reveal.
+   These live in `test/tv_motion_profile_persistence_test.dart` and
+   `test/spotlight_board_live_motion_test.dart`.
 
-The regression command used `flutter test --no-pub --reporter expanded` with:
+Rerun the related regression selection with
+`flutter test --no-pub --reporter expanded` and the following files:
 
 ```text
 test/spotlight_board_scroll_motion_test.dart
 test/tv_motion_profile_test.dart
+test/tv_motion_profile_persistence_test.dart
+test/spotlight_board_live_motion_test.dart
 test/settings_tv_motion_page_test.dart
 test/spotlight_board_test.dart
 test/spotlight_board_compact_test.dart
@@ -96,7 +108,10 @@ this note's directory:
 
 - `upstream-tv-motion/red-spotlight.log`
 - `upstream-tv-motion/red-root-subscription.log`
-- `upstream-tv-motion/final-regressions.log`
+- `upstream-tv-motion/final-regressions.log` (initial 163-test selection)
 - `upstream-tv-motion/upstream-baseline-tests.log`
 - `upstream-tv-motion/analyze.log`
 - `upstream-tv-motion/upstream-baseline-analyze.log`
+- `../../.dart_tool/adversarial-motion/promoted-scoped.jsonl`
+- `../../.dart_tool/adversarial-motion/promoted-regression.jsonl` (169 tests)
+- `../../.dart_tool/adversarial-motion/promoted-analyze.log`

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -102,6 +102,8 @@ import 'services/remote_control/remote_command_router.dart';
 import 'services/remote_control/remote_constants.dart';
 import 'services/analytics_service.dart';
 import 'services/text_brightness.dart';
+import 'services/tv_motion_profile.dart';
+import 'theme/tv_motion_scope.dart';
 import 'services/support_remote_config_service.dart';
 import 'widgets/auto_launch_overlay.dart';
 import 'widgets/remote/addon_install_dialog.dart';
@@ -662,6 +664,7 @@ Future<void> _continueApplicationStartup() async {
   // Warms the app theme AFTER the preset (it is an input), for the same
   // reason: the controller's memoized ThemeData is read in the first build.
   await _bestEffortStartupStep('app-theme-warm', AppThemeController.warm);
+  await _bestEffortStartupStep('tv-motion-warm', TvMotionController.warm);
   // From here the system-bar owner is the authority — it re-applies on every
   // active-surface or theme change (the _initOrientation call below remains
   // the pre-warm default and matches the legacy style anyway).
@@ -1100,7 +1103,9 @@ class _DebrifyAppState extends State<DebrifyApp> {
           // launch ident (see app_texture.dart). It short-circuits to `child`
           // for legacy and for the seventeen themes that declare neither, so
           // the common path costs one build and no layer.
-          child: WebDavSaveStatus(child: AppTexture(child: child!)),
+          child: TvMotionRoot(
+            child: WebDavSaveStatus(child: AppTexture(child: child!)),
+          ),
         );
         // Pointer input counts as presence too — an Apple TV remote's
         // trackpad and an attached mouse both arrive here rather than through

--- a/lib/screens/settings/settings_tv_layout.dart
+++ b/lib/screens/settings/settings_tv_layout.dart
@@ -4,11 +4,13 @@ import '../../utils/tv_reveal.dart';
 import 'package:flutter/services.dart';
 
 import '../../services/main_page_bridge.dart';
+import '../../services/tv_motion_profile.dart';
 import '../../services/profiles/profile_bootstrap.dart';
 import '../../utils/platform_util.dart';
 import '../../theme/app_focus.dart';
 import '../../theme/widgets/parallax_focus.dart';
 import 'settings_spotlight_shell.dart';
+import 'tv_motion_page.dart';
 import 'widgets/settings_widgets.dart';
 import '../../theme/app_theme_scope.dart';
 
@@ -406,7 +408,7 @@ class _SettingsTvLayoutState extends State<SettingsTvLayout> {
   /// so a row added past the pool throws on build.
   /// Appearance is the longest fixed category. The pool must cover it, or the
   /// last row of that category has no node and cannot be reached.
-  static const int _kMaxCategoryRows = 19;
+  static const int _kMaxCategoryRows = 20;
 
   /// Selected category. A [ValueNotifier] (not setState) so a rail focus-move
   /// only rebuilds the pane and the two affected rail items via their
@@ -1127,6 +1129,17 @@ class _SettingsTvLayoutState extends State<SettingsTvLayout> {
                 onTap: widget.onOpenTvHeroArtworkQuality,
                 focusNode: _paneNodes[16],
               ),
+              ValueListenableBuilder<TvMotionProfile>(
+                valueListenable: TvMotionController.notifier,
+                builder: (context, profile, _) => SettingsTile.spec(
+                  SettingsRows.tvMotion,
+                  subtitle: profile.label,
+                  onTap: () async {
+                    await pushSettingsPage(context, const TvMotionPage());
+                  },
+                  focusNode: _paneNodes[17],
+                ),
+              ),
             ],
           ),
           // Android TV only, and LAST on purpose: this layout also renders on
@@ -1146,13 +1159,13 @@ class _SettingsTvLayoutState extends State<SettingsTvLayout> {
                   SettingsRows.tvPlayerControls,
                   subtitle: widget.tvPlayerControlsStyleLabel,
                   onTap: widget.onOpenTvPlayerControlsStyle,
-                  focusNode: _paneNodes[17],
+                  focusNode: _paneNodes[18],
                 ),
                 SettingsTile.spec(
                   SettingsRows.debrifyTvPlayer,
                   subtitle: widget.debrifyTvPlayerStyleLabel,
                   onTap: widget.onOpenDebrifyTvPlayerStyle,
-                  focusNode: _paneNodes[18],
+                  focusNode: _paneNodes[19],
                 ),
               ],
             ),

--- a/lib/screens/settings/tv_motion_page.dart
+++ b/lib/screens/settings/tv_motion_page.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+import '../../services/tv_motion_profile.dart';
+import '../../theme/app_theme_scope.dart';
+import 'widgets/settings_widgets.dart';
+
+/// Uses the existing settings radio-row and DPAD navigation conventions.
+class TvMotionPage extends StatefulWidget {
+  const TvMotionPage({super.key});
+
+  @override
+  State<TvMotionPage> createState() => _TvMotionPageState();
+}
+
+class _TvMotionPageState extends State<TvMotionPage> {
+  final _nodes = [for (final _ in TvMotionProfile.values) FocusNode()];
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _nodes[TvMotionController.current.index].requestFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    for (final node in _nodes) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => SettingsPageScaffold(
+    title: 'TV motion',
+    body: SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: kSettingsMaxWidth),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SettingsPageHeader(
+                icon: Icons.slow_motion_video_rounded,
+                title: 'TV motion',
+                subtitle:
+                    'Scrolling on Spotlight Home. Saved for this profile '
+                    'on this device; other Home layouts keep their current motion.',
+              ),
+              const SizedBox(height: 24),
+              ValueListenableBuilder<TvMotionProfile>(
+                valueListenable: TvMotionController.notifier,
+                builder: (context, selected, _) => SettingsSection(
+                  title: '',
+                  children: [
+                    for (final profile in TvMotionProfile.values)
+                      SettingsTile(
+                        icon: selected == profile
+                            ? Icons.radio_button_checked_rounded
+                            : Icons.radio_button_unchecked_rounded,
+                        title: profile.label,
+                        subtitle: profile.description,
+                        focusNode: _nodes[profile.index],
+                        trailing: selected == profile
+                            ? Icon(
+                                Icons.check_rounded,
+                                size: 20,
+                                color: AppThemeScope.of(
+                                  context,
+                                ).settings.accent2,
+                              )
+                            : const SizedBox.shrink(),
+                        onTap: () => TvMotionController.select(profile),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/screens/settings/widgets/settings_widgets.dart
+++ b/lib/screens/settings/widgets/settings_widgets.dart
@@ -204,6 +204,11 @@ abstract final class SettingsRows {
     title: 'Rendering',
     subtitle: '',
   );
+  static const tvMotion = SettingsRowContent(
+    icon: Icons.slow_motion_video_rounded,
+    title: 'TV motion',
+    subtitle: 'Smooth or Snappy scrolling on Spotlight Home',
+  );
   static const tvHeroArtworkQuality = SettingsRowContent(
     icon: Icons.photo_size_select_large_rounded,
     title: 'Hero Artwork Quality',

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -26,6 +26,8 @@ import '../services/external_player_service.dart';
 import '../services/play_loader_style.dart';
 import '../services/subtitle_font_service.dart';
 import '../services/text_brightness.dart';
+import '../services/tv_motion_profile.dart';
+import 'settings/tv_motion_page.dart';
 import '../services/profiles/profile_runtime.dart';
 import '../services/profiles/connection_resource_service.dart';
 import '../services/profiles/portable_profile_package.dart';
@@ -1985,6 +1987,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
             'home & display',
             ...labels(kTvRenderQualityChoices.map((choice) => choice.label)),
           ],
+        ),
+      if (_isTelevision)
+        nav(
+          SettingsRows.tvMotion,
+          'Appearance',
+          () async {
+            await pushSettingsPage(context, const TvMotionPage());
+          },
+          subtitle: TvMotionController.current.label,
+          keywords: const ['motion', 'smooth', 'snappy', 'scrolling', 'spotlight'],
         ),
       // Android TV + tvOS: this controls Flutter image decode bounds, so it is
       // independent of Android's native render-scale picker above.

--- a/lib/services/profiles/profile_app_lifecycle_participant.dart
+++ b/lib/services/profiles/profile_app_lifecycle_participant.dart
@@ -27,6 +27,7 @@ import '../stremio_service.dart';
 import '../subtitle_font_service.dart';
 import '../play_loader_style.dart';
 import '../text_brightness.dart';
+import '../tv_motion_profile.dart';
 import '../trakt/trakt_service.dart';
 import '../watched_status_service.dart';
 import '../torbox_account_service.dart';
@@ -48,6 +49,7 @@ class ProfileAppLifecycleParticipant implements ProfileLifecycleParticipant {
   @override
   Future<void> prepareDeactivate(ProfileScope current) async {
     ProfileSessionMemory.clearAll();
+    TvMotionController.resetProfileScope();
     EngineProfileLifecycle.prepareDeactivate();
     MainPageBridge.clearProfileSessionState();
     await TvosTopShelfService.instance.clear();
@@ -180,6 +182,7 @@ class ProfileAppLifecycleParticipant implements ProfileLifecycleParticipant {
         StorageService.getParentsGuideStyle(),
       ]);
       await TextBrightnessController.warm();
+      await TvMotionController.warm();
       await PlayLoaderStyleController.warm();
       await AppThemeController.warm();
       await TvHeroArtworkQualityController.warm();

--- a/lib/services/profiles/profile_appearance_preferences.dart
+++ b/lib/services/profiles/profile_appearance_preferences.dart
@@ -7,6 +7,7 @@ abstract final class ProfileAppearancePreferences {
     'detail_theme',
     'theme_overrides',
     'text_brightness',
+    'tv_motion_profile',
     'launch_animation',
     'launch_ident_palette',
     'tv_ui_scale_percent',

--- a/lib/services/profiles/profile_creation_service.dart
+++ b/lib/services/profiles/profile_creation_service.dart
@@ -21,6 +21,7 @@ class ProfileCreationService {
   static const Set<String> copyablePreferenceKeys = <String>{
     'app_theme',
     'text_brightness',
+    'tv_motion_profile',
     'tv_ui_scale_percent',
     'tv_home_style',
     'home_card_orientation',

--- a/lib/services/profiles/sanitized_profile_preferences.dart
+++ b/lib/services/profiles/sanitized_profile_preferences.dart
@@ -68,6 +68,9 @@ abstract final class SanitizedProfilePreferences {
       case 'text_brightness':
         return value is String &&
             const <String>{'bright', 'soft', 'dim'}.contains(value);
+      case 'tv_motion_profile':
+        return value is String &&
+            const <String>{'snappy', 'smooth'}.contains(value);
       case 'tv_home_style':
         return value is String && _tvHomeStyles.contains(value);
       case 'home_card_orientation':

--- a/lib/services/tv_motion_profile.dart
+++ b/lib/services/tv_motion_profile.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/foundation.dart';
+import 'package:synchronized/synchronized.dart';
+
+import 'profiles/profile_preferences.dart';
+import 'profiles/profile_runtime.dart';
+
+/// Optional Spotlight scroll motion, local to this profile and installation.
+enum TvMotionProfile {
+  snappy('snappy', 'Snappy', 'Keep this TV\'s default Spotlight scrolling'),
+  smooth('smooth', 'Smooth', 'Smooth scrolling between Spotlight shelves');
+
+  const TvMotionProfile(this.value, this.label, this.description);
+
+  final String value;
+  final String label;
+  final String description;
+
+  static TvMotionProfile fromPref(String? value) =>
+      value == 'smooth' ? smooth : snappy;
+}
+
+abstract final class TvMotionController {
+  static const preferenceKey = 'tv_motion_profile';
+  static final ValueNotifier<TvMotionProfile> notifier = ValueNotifier(
+    TvMotionProfile.snappy,
+  );
+  static TvMotionProfile get current => notifier.value;
+  static int _revision = 0;
+  static final Lock _preferences = Lock();
+
+  // Capture before ProfilePreferences.instance's first await. A profile
+  // switch must not redirect a pending read/write to the incoming profile.
+  static Future<T> _inProfile<T>(Future<T> Function() operation) {
+    if (ProfileRuntime.isInitialized && ProfileRuntime.isProfileCommitted) {
+      return ProfileRuntime.withCapturedScope(
+        ProfileRuntime.capture(),
+        operation,
+      );
+    }
+    return operation();
+  }
+
+  static void resetProfileScope() {
+    _revision++;
+    notifier.value = TvMotionProfile.snappy;
+  }
+
+  /// Warmed before runApp and during profile activation/rollback.
+  static Future<void> warm() async {
+    final revision = ++_revision;
+    var profile = TvMotionProfile.snappy;
+    try {
+      profile = await _inProfile(
+        () => _preferences.synchronized(() async {
+          final prefs = await ProfilePreferences.instance();
+          return TvMotionProfile.fromPref(prefs.getString(preferenceKey));
+        }),
+      );
+    } catch (_) {
+      // Failed reads must not retain another profile's Smooth choice.
+      debugPrint(
+        'TvMotionController: using default after preference read failed',
+      );
+    }
+    if (revision == _revision) notifier.value = profile;
+  }
+
+  /// Publish synchronously so rapid choices retain their input order.
+  static Future<void> select(TvMotionProfile profile) async {
+    _revision++;
+    notifier.value = profile;
+    try {
+      await _inProfile(
+        () => _preferences.synchronized(() async {
+          final prefs = await ProfilePreferences.instance();
+          await prefs.setString(preferenceKey, profile.value);
+        }),
+      );
+    } catch (_) {
+      debugPrint('TvMotionController: could not persist motion preference');
+    }
+  }
+}

--- a/lib/theme/app_motion.dart
+++ b/lib/theme/app_motion.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 
+import '../services/tv_motion_profile.dart';
 import '../widgets/detail/theme/detail_theme.dart';
 import 'app_theme_scope.dart';
+import 'tv_motion_scope.dart';
 
 /// A theme's tempo.
 ///
@@ -262,11 +264,18 @@ class AppMotion {
   /// surface that has opted out.
   final bool reduced;
 
-  const AppMotion(this.tokens, {required this.reduced});
+  final TvMotionProfile profile;
+
+  const AppMotion(
+    this.tokens, {
+    required this.reduced,
+    this.profile = TvMotionProfile.snappy,
+  });
 
   static AppMotion of(BuildContext context) => AppMotion(
     AppThemeScope.of(context).motion,
     reduced: MediaQuery.maybeDisableAnimationsOf(context) ?? false,
+    profile: TvMotionScope.of(context),
   );
 
   Duration get fast => scaled(tokens.fast);
@@ -275,6 +284,21 @@ class AppMotion {
 
   Curve get standard => tokens.standard;
   Curve get emphasized => tokens.emphasized;
+
+  /// Spotlight opts into TV scroll motion. Preserve its shipped durations
+  /// independent of theme tempo; only explicit Smooth and reduced motion
+  /// change this scroll policy. Other motion tokens keep their own scaling.
+  Duration scrollTempo(
+    bool isTv,
+    Duration otherwise, {
+    Duration tvSnappy = Duration.zero,
+  }) {
+    if (reduced) return Duration.zero;
+    if (!isTv) return otherwise;
+    return profile == TvMotionProfile.smooth
+        ? const Duration(milliseconds: 260)
+        : tvSnappy;
+  }
 
   /// [d] at this theme's tempo — or nothing at all under reduced motion.
   ///

--- a/lib/theme/tv_motion_scope.dart
+++ b/lib/theme/tv_motion_scope.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+import '../services/tv_motion_profile.dart';
+
+/// Captured by routes and overlays alongside the app theme.
+class TvMotionScope extends InheritedTheme {
+  const TvMotionScope({super.key, required this.profile, required super.child});
+
+  final TvMotionProfile profile;
+
+  static TvMotionProfile of(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<TvMotionScope>()?.profile ??
+      TvMotionController.current;
+
+  @override
+  Widget wrap(BuildContext context, Widget child) =>
+      TvMotionScope(profile: profile, child: child);
+
+  @override
+  bool updateShouldNotify(TvMotionScope oldWidget) =>
+      profile != oldWidget.profile;
+}
+
+/// Lives above the Navigator and ProfileGate. The gate only rekeys its own
+/// child, so this root must subscribe to profile warmers as well as selection.
+class TvMotionRoot extends StatefulWidget {
+  const TvMotionRoot({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<TvMotionRoot> createState() => _TvMotionRootState();
+}
+
+class _TvMotionRootState extends State<TvMotionRoot> {
+  @override
+  void initState() {
+    super.initState();
+    TvMotionController.notifier.addListener(_changed);
+  }
+
+  void _changed() => setState(() {});
+
+  @override
+  void dispose() {
+    TvMotionController.notifier.removeListener(_changed);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      TvMotionScope(profile: TvMotionController.current, child: widget.child);
+}

--- a/lib/widgets/home/spotlight_board.dart
+++ b/lib/widgets/home/spotlight_board.dart
@@ -11,6 +11,7 @@ import 'package:flutter/services.dart';
 import '../../models/stremio_addon.dart';
 import '../../services/debrify_image_cache.dart';
 import '../../theme/app_focus.dart';
+import '../../theme/app_motion.dart';
 import '../../theme/app_theme.dart';
 import '../../theme/app_theme_scope.dart';
 import '../../theme/widgets/focus_expression.dart';
@@ -2724,6 +2725,16 @@ class _CardState extends State<_Card> with MetadataPresentationMixin<_Card> {
   Widget build(BuildContext context) {
     final app = AppThemeScope.of(context);
     final c = widget.card;
+    // Capture inherited settings in build so focus notifications use the
+    // latest profile/accessibility policy without performing inherited reads.
+    final scrollDuration = AppMotion.of(context).scrollTempo(
+      PlatformUtil.isTelevision,
+      const Duration(milliseconds: 220),
+      // Android TV shipped an immediate reveal; tvOS shipped a 220ms glide.
+      tvSnappy: PlatformUtil.isAndroidTvCached
+          ? Duration.zero
+          : const Duration(milliseconds: 220),
+    );
     final w = widget.height * c.shape.aspect;
     // Decode at the card's own PHYSICAL width plus the 10% focus growth —
     // never a fixed constant. The hardcoded 400/800 decoded ~1.7× oversized
@@ -3087,13 +3098,8 @@ class _CardState extends State<_Card> with MetadataPresentationMixin<_Card> {
           Scrollable.ensureVisible(
             context,
             alignment: 0.5,
-            // Snap on TV — the detail rails' rule: a held key retargets an
-            // in-flight glide every repeat, so the cursor perpetually
-            // trails the press, and every glide frame is scroll paint a
-            // MiBox-class GPU visibly drops. Pointer/touch keeps the glide.
-            duration: PlatformUtil.isAndroidTvCached
-                ? Duration.zero
-                : const Duration(milliseconds: 220),
+            // Smooth opts into a glide; Snappy preserves the platform default.
+            duration: scrollDuration,
             curve: Curves.easeOutCubic,
           );
         }

--- a/test/settings_tv_motion_page_test.dart
+++ b/test/settings_tv_motion_page_test.dart
@@ -1,0 +1,52 @@
+import 'package:debrify/screens/settings/tv_motion_page.dart';
+import 'package:debrify/screens/settings/widgets/settings_widgets.dart';
+import 'package:debrify/services/profiles/profile_runtime.dart';
+import 'package:debrify/services/tv_motion_profile.dart';
+import 'package:debrify/utils/platform_util.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    ProfileRuntime.debugReset();
+    ProfileRuntime.initializeLegacy();
+    TvMotionController.resetProfileScope();
+    PlatformUtil.debugSetAndroidTvCached(true);
+  });
+  tearDown(() {
+    TvMotionController.resetProfileScope();
+    PlatformUtil.debugSetAndroidTvCached(null);
+    ProfileRuntime.debugReset();
+  });
+
+  testWidgets(
+    'DPAD selects Smooth and Snappy and writes only motion preference',
+    (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: TvMotionPage()));
+      await tester.pumpAndSettle();
+      final rows = tester
+          .widgetList<SettingsTile>(find.byType(SettingsTile))
+          .toList();
+      expect(rows.first.focusNode!.hasPrimaryFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(rows.last.focusNode!.hasPrimaryFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
+      expect(TvMotionController.current, TvMotionProfile.smooth);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getKeys(), {TvMotionController.preferenceKey});
+      expect(prefs.getString(TvMotionController.preferenceKey), 'smooth');
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
+      expect(TvMotionController.current, TvMotionProfile.snappy);
+      expect(prefs.getString(TvMotionController.preferenceKey), 'snappy');
+      await tester.pumpWidget(const SizedBox.shrink());
+      expect(tester.takeException(), isNull);
+    },
+  );
+}

--- a/test/settings_tv_spotlight_layout_test.dart
+++ b/test/settings_tv_spotlight_layout_test.dart
@@ -1,4 +1,9 @@
 import 'package:debrify/screens/settings/settings_tv_layout.dart';
+import 'package:debrify/screens/settings/tv_motion_page.dart';
+import 'package:debrify/services/profiles/profile_runtime.dart';
+import 'package:debrify/services/tv_motion_profile.dart';
+import 'package:debrify/utils/platform_util.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:debrify/screens/settings/widgets/settings_widgets.dart';
 import 'package:debrify/services/text_brightness.dart';
 import 'package:debrify/theme/app_theme.dart';
@@ -144,6 +149,53 @@ Future<void> _pumpTv(
 }
 
 void main() {
+  testWidgets('Appearance DPAD reaches TV motion and refreshes its summary', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    ProfileRuntime.debugReset();
+    ProfileRuntime.initializeLegacy();
+    TvMotionController.resetProfileScope();
+    PlatformUtil.debugSetAndroidTvCached(true);
+    final entry = FocusNode(debugLabel: 'settings-test-entry-motion');
+    addTearDown(() {
+      entry.dispose();
+      TvMotionController.resetProfileScope();
+      ProfileRuntime.debugReset();
+      PlatformUtil.debugSetAndroidTvCached(null);
+    });
+    await _pumpTv(tester, const Size(960, 540), entry);
+    entry.requestFocus();
+    await tester.pump();
+    for (var i = 0; i < 6; i++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+    }
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    for (var i = 0; i < 17; i++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+    }
+    expect(FocusManager.instance.primaryFocus?.debugLabel, 'settings-tv-pane-17');
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
+    await tester.pumpAndSettle();
+    expect(find.byType(TvMotionPage), findsOneWidget);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
+    await tester.pumpAndSettle();
+    expect(TvMotionController.current, TvMotionProfile.smooth);
+    Navigator.of(tester.element(find.byType(TvMotionPage))).pop();
+    await tester.pumpAndSettle();
+    final row = tester.widget<SettingsTile>(find.byWidgetPredicate(
+      (widget) => widget is SettingsTile && widget.title == 'TV motion',
+    ));
+    expect(row.subtitle, 'Smooth');
+    await tester.pumpWidget(const SizedBox.shrink());
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('Sync and Migrate has its own reachable TV rail category', (
     tester,
   ) async {

--- a/test/spotlight_board_live_motion_test.dart
+++ b/test/spotlight_board_live_motion_test.dart
@@ -1,0 +1,173 @@
+import 'package:debrify/models/stremio_addon.dart';
+import 'package:debrify/services/profiles/profile_runtime.dart';
+import 'package:debrify/services/profiles/profile_scope.dart';
+import 'package:debrify/services/tv_motion_profile.dart';
+import 'package:debrify/theme/app_motion.dart';
+import 'package:debrify/theme/app_theme.dart';
+import 'package:debrify/theme/app_theme_scope.dart';
+import 'package:debrify/theme/tv_motion_scope.dart';
+import 'package:debrify/utils/platform_util.dart';
+import 'package:debrify/widgets/detail/theme/detail_themes.dart';
+import 'package:debrify/widgets/home/spotlight_board.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final reducedMotion = ValueNotifier(false);
+  tearDownAll(reducedMotion.dispose);
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    ProfileRuntime.debugReset();
+    ProfileRuntime.initializeLegacy();
+    TvMotionController.resetProfileScope();
+  });
+
+  tearDown(() {
+    TvMotionController.resetProfileScope();
+    ProfileRuntime.debugReset();
+    PlatformUtil.debugSetAndroidTvCached(null);
+    PlatformUtil.debugSetTvOS(null);
+  });
+
+  Future<({List<FocusNode> rows, ScrollPosition scroll})> mountBoard(
+    WidgetTester tester,
+  ) async {
+    await TvMotionController.select(TvMotionProfile.smooth);
+    reducedMotion.value = false;
+    PlatformUtil.debugSetAndroidTvCached(true);
+    PlatformUtil.debugSetTvOS(false);
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1;
+    final hero = FocusNode(debugLabel: 'hero');
+    final rows = List.generate(6, (i) => FocusNode(debugLabel: 'shelf-$i'));
+    addTearDown(() async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      hero.dispose();
+      for (final node in rows) {
+        node.dispose();
+      }
+      tester.view.reset();
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ValueListenableBuilder<bool>(
+          valueListenable: reducedMotion,
+          builder: (_, disabled, child) => MediaQuery(
+            data: MediaQueryData(
+              size: const Size(1280, 720),
+              disableAnimations: disabled,
+            ),
+            child: child!,
+          ),
+          child: AppThemeScope(
+            theme: AppTheme.fromDetail(
+              DetailThemes.byId('signal'),
+              motion: MotionTokens.legacy,
+            ),
+            child: TvMotionRoot(
+              child: Scaffold(
+                body: SpotlightBoard(
+                  hero: [StremioMeta(id: 'hero', type: 'series', name: 'Hero')],
+                  heroNode: hero,
+                  heroAddon: null,
+                  onHeroOpen: (_, __) {},
+                  trailersEnabled: false,
+                  // Keep real card focus and scroll handling while the policy changes.
+                  dpad: true,
+                  sections: [
+                    for (var i = 0; i < rows.length; i++)
+                      SpotlightShelf(
+                        id: 'shelf-$i',
+                        title: 'Shelf $i',
+                        nodes: [rows[i]],
+                        items: [
+                          SpotlightCard(
+                            title: 'Card $i',
+                            rating: 8.1,
+                            shape: SpotlightCardShape.wide,
+                            onOpen: () {},
+                          ),
+                        ],
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    hero.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(rows.first.hasPrimaryFocus, isTrue);
+    expect(rows[1].context?.mounted, isTrue);
+
+    final scroll = tester
+        .stateList<ScrollableState>(
+          find.descendant(
+            of: find.byType(SpotlightBoard),
+            matching: find.byType(Scrollable),
+          ),
+        )
+        .singleWhere((state) => state.axisDirection == AxisDirection.down)
+        .position;
+    return (rows: rows, scroll: scroll);
+  }
+
+  testWidgets('focused Spotlight consumers refresh without recreation', (
+    tester,
+  ) async {
+    final f = await mountBoard(tester);
+    final firstContext = f.rows[0].context;
+    await TvMotionController.select(TvMotionProfile.snappy);
+    await tester.pump();
+    expect(f.rows[0].context, same(firstContext));
+    expect(f.rows[0].hasPrimaryFocus, isTrue);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    expect(f.rows[1].hasPrimaryFocus, isTrue);
+    expect(f.scroll.isScrollingNotifier.value, isFalse);
+
+    await TvMotionController.select(TvMotionProfile.smooth);
+    await tester.pump();
+    final before = f.scroll.pixels;
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    await tester.pump();
+    expect(f.rows[2].hasPrimaryFocus, isTrue);
+    expect(f.scroll.isScrollingNotifier.value, isTrue);
+    await tester.pump(const Duration(milliseconds: 60));
+    expect(f.scroll.pixels, greaterThan(before));
+    await tester.pumpAndSettle();
+
+    final focusedContext = f.rows[2].context;
+    ProfileRuntime.initializeCommitted(
+      ProfileScope(profileId: 'incoming', dataGeneration: 2, sessionEpoch: 2),
+    );
+    await TvMotionController.warm();
+    await tester.pump();
+    expect(f.rows[2].context, same(focusedContext));
+    expect(f.rows[2].hasPrimaryFocus, isTrue);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pump();
+    expect(f.rows[1].hasPrimaryFocus, isTrue);
+    expect(f.scroll.isScrollingNotifier.value, isFalse);
+
+    await TvMotionController.select(TvMotionProfile.smooth);
+    reducedMotion.value = true;
+    await tester.pump();
+    expect(f.rows[1].hasPrimaryFocus, isTrue);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    expect(f.rows[2].hasPrimaryFocus, isTrue);
+    expect(f.scroll.isScrollingNotifier.value, isFalse);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/spotlight_board_scroll_motion_test.dart
+++ b/test/spotlight_board_scroll_motion_test.dart
@@ -1,0 +1,256 @@
+import 'package:debrify/models/stremio_addon.dart';
+import 'package:debrify/services/tv_motion_profile.dart';
+import 'package:debrify/theme/app_motion.dart';
+import 'package:debrify/theme/app_theme.dart';
+import 'package:debrify/theme/app_theme_scope.dart';
+import 'package:debrify/theme/tv_motion_scope.dart';
+import 'package:debrify/utils/platform_util.dart';
+import 'package:debrify/widgets/detail/theme/detail_themes.dart';
+import 'package:debrify/widgets/home/spotlight_board.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  tearDown(() {
+    PlatformUtil.debugSetAndroidTvCached(null);
+    PlatformUtil.debugSetTvOS(null);
+  });
+
+  Future<({List<FocusNode> rows, ScrollPosition scroll})> mountBoard(
+    WidgetTester tester, {
+    required TvMotionProfile profile,
+    bool tv = true,
+    bool tvOS = false,
+    bool reduced = false,
+  }) async {
+    PlatformUtil.debugSetAndroidTvCached(tv);
+    PlatformUtil.debugSetTvOS(tvOS);
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1;
+    final hero = FocusNode(debugLabel: 'hero');
+    final rows = List.generate(6, (i) => FocusNode(debugLabel: 'shelf-$i'));
+    addTearDown(() async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      hero.dispose();
+      for (final node in rows) {
+        node.dispose();
+      }
+      tester.view.reset();
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: MediaQueryData(
+            size: const Size(1280, 720),
+            disableAnimations: reduced,
+          ),
+          child: AppThemeScope(
+            theme: AppTheme.fromDetail(
+              DetailThemes.byId('signal'),
+              motion: MotionTokens.legacy,
+            ),
+            child: TvMotionScope(
+              profile: profile,
+              child: Scaffold(
+                body: SpotlightBoard(
+                  hero: [StremioMeta(id: 'hero', type: 'series', name: 'Hero')],
+                  heroNode: hero,
+                  heroAddon: null,
+                  onHeroOpen: (_, __) {},
+                  trailersEnabled: false,
+                  // Keyboard navigation also exercises the off-TV scroll path.
+                  dpad: true,
+                  sections: [
+                    for (var i = 0; i < rows.length; i++)
+                      SpotlightShelf(
+                        id: 'shelf-$i',
+                        title: 'Shelf $i',
+                        nodes: [rows[i]],
+                        items: [
+                          SpotlightCard(
+                            title: 'Card $i',
+                            rating: 8.1,
+                            shape: SpotlightCardShape.wide,
+                            onOpen: () {},
+                          ),
+                        ],
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    hero.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(rows.first.hasPrimaryFocus, isTrue);
+    expect(rows[1].context?.mounted, isTrue);
+
+    final scroll = tester
+        .stateList<ScrollableState>(
+          find.descendant(
+            of: find.byType(SpotlightBoard),
+            matching: find.byType(Scrollable),
+          ),
+        )
+        .singleWhere((state) => state.axisDirection == AxisDirection.down)
+        .position;
+    return (rows: rows, scroll: scroll);
+  }
+
+  for (final scenario in [
+    (
+      name: 'TV Smooth',
+      tvOS: false,
+      profile: TvMotionProfile.smooth,
+      tv: true,
+      reduced: false,
+      milliseconds: 260,
+    ),
+    (
+      name: 'TV Snappy',
+      tvOS: false,
+      profile: TvMotionProfile.snappy,
+      tv: true,
+      reduced: false,
+      milliseconds: 0,
+    ),
+    (
+      name: 'TV Smooth with reduced motion',
+      tvOS: false,
+      profile: TvMotionProfile.smooth,
+      tv: true,
+      reduced: true,
+      milliseconds: 0,
+    ),
+    (
+      name: 'off-TV Smooth',
+      tvOS: false,
+      profile: TvMotionProfile.smooth,
+      tv: false,
+      reduced: false,
+      milliseconds: 220,
+    ),
+    (
+      name: 'off-TV Snappy',
+      tvOS: false,
+      profile: TvMotionProfile.snappy,
+      tv: false,
+      reduced: false,
+      milliseconds: 220,
+    ),
+    (
+      name: 'tvOS default Snappy',
+      profile: TvMotionProfile.snappy,
+      tv: false,
+      tvOS: true,
+      reduced: false,
+      milliseconds: 220,
+    ),
+    (
+      name: 'tvOS explicit Smooth',
+      profile: TvMotionProfile.smooth,
+      tv: false,
+      tvOS: true,
+      reduced: false,
+      milliseconds: 260,
+    ),
+    (
+      name: 'off-TV reduced motion',
+      profile: TvMotionProfile.smooth,
+      tv: false,
+      tvOS: false,
+      reduced: true,
+      milliseconds: 0,
+    ),
+  ]) {
+    testWidgets('${scenario.name}: vertical DPAD preserves scroll timing', (
+      tester,
+    ) async {
+      final f = await mountBoard(
+        tester,
+        profile: scenario.profile,
+        tv: scenario.tv,
+        tvOS: scenario.tvOS,
+        reduced: scenario.reduced,
+      );
+      final start = f.scroll.pixels;
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      await tester.pump(); // Start the animation clock without advancing time.
+      expect(f.rows[1].hasPrimaryFocus, isTrue);
+      final immediate = f.scroll.pixels;
+      expect(f.scroll.isScrollingNotifier.value, scenario.milliseconds > 0);
+
+      await tester.pump(const Duration(milliseconds: 60));
+      final intermediate = f.scroll.pixels;
+      await tester.pump(const Duration(milliseconds: 161));
+      expect(f.scroll.isScrollingNotifier.value, scenario.milliseconds > 221);
+      await tester.pump(const Duration(milliseconds: 79));
+      final end = f.scroll.pixels;
+      expect(end, greaterThan(start));
+      expect(f.scroll.isScrollingNotifier.value, isFalse);
+
+      if (scenario.milliseconds == 0) {
+        expect(immediate, closeTo(end, 0.1));
+        expect(intermediate, closeTo(end, 0.1));
+      } else {
+        expect(immediate, closeTo(start, 0.1));
+        expect(intermediate, greaterThan(start));
+        expect(intermediate, lessThan(end));
+        expect(
+          intermediate,
+          closeTo(
+            start +
+                (end - start) *
+                    Curves.easeOutCubic.transform(60 / scenario.milliseconds),
+            0.5,
+          ),
+        );
+      }
+      expect(tester.takeException(), isNull);
+    });
+  }
+
+  testWidgets('Smooth: repeated Down then Up settles at the latest shelf', (
+    tester,
+  ) async {
+    final f = await mountBoard(tester, profile: TvMotionProfile.smooth);
+    final start = f.scroll.pixels;
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 60));
+    expect(f.rows[1].hasPrimaryFocus, isTrue);
+    expect(f.scroll.isScrollingNotifier.value, isTrue);
+    await tester.sendKeyRepeatEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 60));
+    expect(f.rows[2].hasPrimaryFocus, isTrue);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pump();
+    await tester.pumpAndSettle();
+    expect(f.rows[1].hasPrimaryFocus, isTrue);
+    final destination = f.scroll.pixels;
+
+    // A settled visit to the same shelf must produce the same target.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(f.scroll.pixels, closeTo(start, 0.5));
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(f.scroll.pixels, closeTo(destination, 0.5));
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/tv_motion_profile_persistence_test.dart
+++ b/test/tv_motion_profile_persistence_test.dart
@@ -1,0 +1,135 @@
+import 'dart:async';
+
+import 'package:debrify/services/profiles/profile_runtime.dart';
+import 'package:debrify/services/profiles/profile_scope.dart';
+import 'package:debrify/services/tv_motion_profile.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+// Exercise real controller/profile preferences with delayed transport completion.
+// Durable values, write order and live selection are asserted independently.
+const _key = 'tv_motion_profile';
+
+class _DelayedBackend extends InMemorySharedPreferencesStore {
+  _DelayedBackend() : super.withData({});
+  final attempts = <(String, Object)>[];
+  final entered = Completer<void>();
+  final release = Completer<void>();
+  String firstOutcome = 'ok';
+
+  @override
+  Future<bool> setValue(String type, String key, Object value) async {
+    final first = attempts.isEmpty;
+    attempts.add((key, value));
+    if (first) {
+      entered.complete();
+      await release.future.timeout(const Duration(seconds: 5));
+      if (firstOutcome == 'false') return false;
+      if (firstOutcome == 'throw') {
+        throw StateError('injected transport failure');
+      }
+    }
+    return super.setValue(type, key, value);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late SharedPreferencesStorePlatform previous;
+  late _DelayedBackend backend;
+  setUp(() {
+    previous = SharedPreferencesStorePlatform.instance;
+    SharedPreferences.resetStatic();
+    backend = _DelayedBackend();
+    SharedPreferencesStorePlatform.instance = backend;
+    ProfileRuntime.debugReset();
+    ProfileRuntime.initializeLegacy();
+    TvMotionController.resetProfileScope();
+  });
+  tearDown(() {
+    if (!backend.release.isCompleted) backend.release.complete();
+    TvMotionController.resetProfileScope();
+    ProfileRuntime.debugReset();
+    SharedPreferences.resetStatic();
+    SharedPreferencesStorePlatform.instance = previous;
+  });
+
+  for (final outcome in ['ok', 'false', 'throw']) {
+    test(
+      'delayed first $outcome write cannot overtake the latest choice',
+      () async {
+        backend.firstOutcome = outcome;
+        final first = TvMotionController.select(TvMotionProfile.smooth);
+        await backend.entered.future.timeout(const Duration(seconds: 5));
+        final last = TvMotionController.select(TvMotionProfile.snappy);
+        try {
+          expect(TvMotionController.current, TvMotionProfile.snappy);
+          // Allow a wrongly concurrent second write to reach the transport.
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+          expect(backend.attempts, [('flutter.$_key', 'smooth')]);
+        } finally {
+          backend.release.complete();
+          await Future.wait([first, last]);
+        }
+        expect(backend.attempts, [
+          ('flutter.$_key', 'smooth'),
+          ('flutter.$_key', 'snappy'),
+        ]);
+        expect((await backend.getAll())['flutter.$_key'], 'snappy');
+        expect(TvMotionController.current, TvMotionProfile.snappy);
+      },
+    );
+  }
+
+  test(
+    'warm queued between selections cannot publish an older choice',
+    () async {
+      final first = TvMotionController.select(TvMotionProfile.smooth);
+      await backend.entered.future.timeout(const Duration(seconds: 5));
+      final warm = TvMotionController.warm();
+      final last = TvMotionController.select(TvMotionProfile.snappy);
+      backend.release.complete();
+      await Future.wait([first, warm, last]);
+      expect(TvMotionController.current, TvMotionProfile.snappy);
+      expect((await backend.getAll())['flutter.$_key'], 'snappy');
+    },
+  );
+
+  test(
+    'queued writes retain profile and generation while incoming warm wins',
+    () async {
+      final a = ProfileScope(
+        profileId: 'a',
+        dataGeneration: 1,
+        sessionEpoch: 1,
+      );
+      final nextGeneration = ProfileScope(
+        profileId: 'a',
+        dataGeneration: 2,
+        sessionEpoch: 2,
+      );
+      final b = ProfileScope(
+        profileId: 'b',
+        dataGeneration: 1,
+        sessionEpoch: 3,
+      );
+      ProfileRuntime.initializeCommitted(a);
+      final first = TvMotionController.select(TvMotionProfile.smooth);
+      await backend.entered.future.timeout(const Duration(seconds: 5));
+      TvMotionController.resetProfileScope();
+      ProfileRuntime.publish(nextGeneration);
+      final second = TvMotionController.select(TvMotionProfile.smooth);
+      TvMotionController.resetProfileScope();
+      ProfileRuntime.publish(b);
+      final incomingWarm = TvMotionController.warm();
+      backend.release.complete();
+      await Future.wait([first, second, incomingWarm]);
+      expect(TvMotionController.current, TvMotionProfile.snappy);
+      expect(await backend.getAll(), {
+        'flutter.${a.preferenceKey(_key)}': 'smooth',
+        'flutter.${nextGeneration.preferenceKey(_key)}': 'smooth',
+      });
+    },
+  );
+}

--- a/test/tv_motion_profile_test.dart
+++ b/test/tv_motion_profile_test.dart
@@ -1,0 +1,227 @@
+import 'dart:io';
+
+import 'package:debrify/services/profiles/profile_appearance_preferences.dart';
+import 'package:debrify/services/profiles/profile_creation_service.dart';
+import 'package:debrify/services/profiles/profile_runtime.dart';
+import 'package:debrify/services/profiles/profile_scope.dart';
+import 'package:debrify/services/profiles/sanitized_profile_preferences.dart';
+import 'package:debrify/services/tv_motion_profile.dart';
+import 'package:debrify/services/webdav_sync/webdav_sync_scheduler.dart';
+import 'package:debrify/theme/app_motion.dart';
+import 'package:debrify/theme/tv_motion_scope.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MotionProbe extends StatelessWidget {
+  const _MotionProbe();
+
+  @override
+  Widget build(BuildContext context) => Text(
+    '${AppMotion.of(context).scrollTempo(true, const Duration(milliseconds: 220)).inMilliseconds}',
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const key = TvMotionController.preferenceKey;
+  ProfileScope scope(String id, int epoch) =>
+      ProfileScope(profileId: id, dataGeneration: 1, sessionEpoch: epoch);
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    ProfileRuntime.debugReset();
+    ProfileRuntime.initializeLegacy();
+    TvMotionController.resetProfileScope();
+  });
+  tearDown(() {
+    TvMotionController.resetProfileScope();
+    ProfileRuntime.debugReset();
+  });
+
+  test(
+    'unset and unknown values keep Snappy without writing a default',
+    () async {
+      await TvMotionController.warm();
+      expect(TvMotionController.current, TvMotionProfile.snappy);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getKeys(), isEmpty);
+      await prefs.setString(key, 'future-profile');
+      await TvMotionController.warm();
+      expect(TvMotionController.current, TvMotionProfile.snappy);
+      expect(prefs.getString(key), 'future-profile');
+    },
+  );
+
+  test(
+    'selection writes only the captured profile and notifies immediately',
+    () async {
+      ProfileRuntime.initializeCommitted(scope('alpha', 1));
+      final selected = TvMotionController.select(TvMotionProfile.smooth);
+      expect(TvMotionController.current, TvMotionProfile.smooth);
+      ProfileRuntime.publish(scope('beta', 2));
+      await TvMotionController.warm();
+      await selected;
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getKeys(), {'p.alpha.g.1.$key'});
+      expect(prefs.getString('p.alpha.g.1.$key'), 'smooth');
+      expect(TvMotionController.current, TvMotionProfile.snappy);
+    },
+  );
+
+  test('an older warm cannot overwrite a later selection', () async {
+    final warm = TvMotionController.warm();
+    final selected = TvMotionController.select(TvMotionProfile.smooth);
+    await Future.wait([warm, selected]);
+    expect(TvMotionController.current, TvMotionProfile.smooth);
+  });
+
+  test(
+    'profile rollback restores its choice and failed reads fall back safely',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        'p.alpha.g.1.$key': 'smooth',
+        'p.beta.g.1.$key': 42,
+      });
+      ProfileRuntime.initializeCommitted(scope('alpha', 1));
+      await TvMotionController.warm();
+      expect(TvMotionController.current, TvMotionProfile.smooth);
+      TvMotionController.resetProfileScope();
+      ProfileRuntime.publish(scope('beta', 2));
+      await TvMotionController.warm();
+      expect(TvMotionController.current, TvMotionProfile.snappy);
+      ProfileRuntime.publish(scope('alpha', 3));
+      await TvMotionController.warm();
+      expect(TvMotionController.current, TvMotionProfile.smooth);
+    },
+  );
+
+  test('rapid selections persist the last input', () async {
+    final first = TvMotionController.select(TvMotionProfile.smooth);
+    final last = TvMotionController.select(TvMotionProfile.snappy);
+    await Future.wait([first, last]);
+    expect(TvMotionController.current, TvMotionProfile.snappy);
+    expect((await SharedPreferences.getInstance()).getString(key), 'snappy');
+  });
+
+  test(
+    'motion stays local to automatic sync, but is valid in explicit copies',
+    () {
+      expect(ProfileAppearancePreferences.keys, contains(key));
+      expect(WebDavSyncScheduler.admitsLocalChangeKey(key), isFalse);
+      expect(ProfileCreationService.copyablePreferenceKeys, contains(key));
+      for (final profile in TvMotionProfile.values) {
+        expect(
+          SanitizedProfilePreferences.allowsEntry(key, profile.value),
+          isTrue,
+        );
+      }
+      expect(
+        SanitizedProfilePreferences.allowsEntry(key, 'future-profile'),
+        isFalse,
+      );
+      expect(SanitizedProfilePreferences.allowsEntry(key, true), isFalse);
+    },
+  );
+
+  test('resolver preserves platform baselines and reduced motion', () {
+    const pointer = Duration(milliseconds: 220);
+    for (final profile in TvMotionProfile.values) {
+      final motion = AppMotion(
+        MotionTokens.legacy,
+        reduced: false,
+        profile: profile,
+      );
+      expect(motion.scrollTempo(false, pointer), pointer);
+      expect(
+        motion.scrollTempo(true, pointer),
+        profile == TvMotionProfile.smooth
+            ? const Duration(milliseconds: 260)
+            : Duration.zero,
+      );
+      // Upstream tvOS already glides; the opt-in must not change its default.
+      expect(
+        motion.scrollTempo(true, pointer, tvSnappy: pointer),
+        profile == TvMotionProfile.smooth
+            ? const Duration(milliseconds: 260)
+            : pointer,
+      );
+      final reduced = AppMotion(
+        MotionTokens.legacy,
+        reduced: true,
+        profile: profile,
+      );
+      expect(reduced.scrollTempo(true, pointer), Duration.zero);
+      expect(reduced.scrollTempo(false, pointer), Duration.zero);
+    }
+  });
+
+  test('theme tempo does not change the shipped scroll defaults', () {
+    const pointer = Duration(milliseconds: 220);
+    final tokens = MotionTokens.legacy.copyWith(scale: 1.3);
+    final snappy = AppMotion(tokens, reduced: false);
+    final smooth = AppMotion(
+      tokens,
+      reduced: false,
+      profile: TvMotionProfile.smooth,
+    );
+    expect(snappy.scrollTempo(true, pointer), Duration.zero);
+    expect(snappy.scrollTempo(true, pointer, tvSnappy: pointer), pointer);
+    expect(snappy.scrollTempo(false, pointer), pointer);
+    expect(smooth.scrollTempo(false, pointer), pointer);
+    expect(
+      smooth.scrollTempo(true, pointer),
+      const Duration(milliseconds: 260),
+    );
+  });
+
+  testWidgets(
+    'root refreshes the same mounted consumer on selection and profile warm',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({
+        'p.alpha.g.1.$key': 'smooth',
+        'p.beta.g.1.$key': 'snappy',
+      });
+      ProfileRuntime.initializeCommitted(scope('alpha', 1));
+      await TvMotionController.warm();
+      await tester.pumpWidget(
+        MaterialApp(
+          builder: (_, child) => TvMotionRoot(child: child!),
+          home: const Scaffold(body: _MotionProbe()),
+        ),
+      );
+      final element = tester.element(find.byType(_MotionProbe));
+      expect(find.text('260'), findsOneWidget);
+
+      ProfileRuntime.publish(scope('beta', 2));
+      await TvMotionController.warm();
+      await tester.pump();
+      expect(find.text('0'), findsOneWidget);
+      expect(tester.element(find.byType(_MotionProbe)), same(element));
+      await TvMotionController.select(TvMotionProfile.smooth);
+      await tester.pump();
+      expect(find.text('260'), findsOneWidget);
+      expect(tester.element(find.byType(_MotionProbe)), same(element));
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      TvMotionController.resetProfileScope();
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  test('production root and profile lifecycle wire the motion policy', () {
+    final main = File('lib/main.dart').readAsStringSync();
+    expect(main, contains("'tv-motion-warm', TvMotionController.warm"));
+    final root = main.substring(
+      main.indexOf('class _DebrifyAppState'),
+      main.indexOf('class MainPage'),
+    );
+    expect(root, contains('child: TvMotionRoot('));
+    final participant = File(
+      'lib/services/profiles/profile_app_lifecycle_participant.dart',
+    ).readAsStringSync();
+    expect(participant, contains('TvMotionController.resetProfileScope();'));
+    expect(participant, contains('await TvMotionController.warm();'));
+  });
+}


### PR DESCRIPTION
Add an optional Smooth/Snappy picker for Spotlight Home scrolling. Snappy remains the default and preserves Android TV's immediate reveal and tvOS's 220 ms reveal; Smooth uses a 260 ms glide. Reduced motion disables the animation and off-TV timing stays unchanged.

The picker is added within the existing Appearance/Display section and settings search. Existing menu groups, labels and relative order are preserved: no settings rearrangement is included. Only Spotlight scroll-follow opts into this policy; this does not migrate Collections, other layouts or shared scroll wrappers. The preference is local to the active profile and installation, follows profile activation/reset/rollback, and is excluded from automatic WebDAV appearance synchronization.

Based independently on `webdav-sync` at `077f2e79`, preserving the owner's newer Spotlight performance, loading and hero behavior.

Flutter 3.44.8 / Dart 3.12.2: behavioral red-before-green checks exercise actual DPAD intermediate frames and repeated movement. 163 related tests pass, including profile races, mounted-consumer refresh, picker navigation, reduced motion, tvOS/off-TV compatibility and WebDAV appearance exclusions. Analysis matches upstream's 16 informational diagnostics with no warnings or errors. Three reproduced upstream failures (a Windows golden and two source guards) are documented in the verification note and excluded from this selection.

The earlier fork fix was accepted on AM9; this independently ported upstream implementation has not yet been validated on a physical device. Keep draft until that gate is completed.

Independent review rejected 12 distinct behavioral mutations. Six additional regression tests are now committed, bringing the final related suite to 169 passing tests; analysis of the additional tests is clean. Settings groups and relative row order were independently checked.

Combined validation with the other ten proposed slices: **304 focused/integration tests passed** and an Android release build succeeded with Flutter 3.44.8 / Dart 3.12.2 / JDK 17. The test and build source trees match. The existing Windows Spotlight golden is excluded from that selection. A separate clean upstream full-suite run has 6,044 passes, 12 skips, 55 failing user tests and one failing teardown hook; this is not a full-suite or GitHub CI pass. Physical-device validation of the upstream ports remains outstanding.
