### PR TITLE
Restore PikPak folder focus from footer controls

### DIFF
--- a/lib/widgets/pikpak_folder_picker_dialog.dart
+++ b/lib/widgets/pikpak_folder_picker_dialog.dart
@@ -7,8 +7,18 @@ import 'tv_text_field.dart';
 
 class PikPakFolderPickerDialog extends StatefulWidget {
   final String? initialFolderId;
+  @visibleForTesting
+  final bool? isTelevisionOverride;
+  @visibleForTesting
+  final Future<({List<Map<String, dynamic>> files, String? nextPageToken})>
+      Function({String? parentId, required int limit})? listFilesOverride;
 
-  const PikPakFolderPickerDialog({super.key, this.initialFolderId});
+  const PikPakFolderPickerDialog({
+    super.key,
+    this.initialFolderId,
+    this.isTelevisionOverride,
+    this.listFilesOverride,
+  });
 
   @override
   State<PikPakFolderPickerDialog> createState() =>
@@ -50,6 +60,7 @@ class _PikPakFolderPickerDialogState extends State<PikPakFolderPickerDialog> {
 
   // TV Navigation support
   bool _isTelevision = false;
+  final ScrollController _folderScrollController = ScrollController();
   final List<FocusNode> _folderFocusNodes = [];
   final List<ValueNotifier<bool>> _folderFocusStates = [];
   late final FocusNode _cancelButtonFocusNode;
@@ -79,9 +90,7 @@ class _PikPakFolderPickerDialogState extends State<PikPakFolderPickerDialog> {
         }
         // DPAD Up: Move to last folder item
         if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-          final flatFolders = _getFlattenedFolders();
-          if (flatFolders.isNotEmpty && _folderFocusNodes.isNotEmpty) {
-            _folderFocusNodes[flatFolders.length - 1].requestFocus();
+          if (_focusLastFolder(node)) {
             return KeyEventResult.handled;
           }
         }
@@ -105,9 +114,7 @@ class _PikPakFolderPickerDialogState extends State<PikPakFolderPickerDialog> {
         }
         // DPAD Up: Move to last folder item
         if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-          final flatFolders = _getFlattenedFolders();
-          if (flatFolders.isNotEmpty && _folderFocusNodes.isNotEmpty) {
-            _folderFocusNodes[flatFolders.length - 1].requestFocus();
+          if (_focusLastFolder(node)) {
             return KeyEventResult.handled;
           }
         }
@@ -126,9 +133,7 @@ class _PikPakFolderPickerDialogState extends State<PikPakFolderPickerDialog> {
         }
         // DPAD Up: Move to last folder item
         if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-          final flatFolders = _getFlattenedFolders();
-          if (flatFolders.isNotEmpty && _folderFocusNodes.isNotEmpty) {
-            _folderFocusNodes[flatFolders.length - 1].requestFocus();
+          if (_focusLastFolder(node)) {
             return KeyEventResult.handled;
           }
         }
@@ -137,9 +142,58 @@ class _PikPakFolderPickerDialogState extends State<PikPakFolderPickerDialog> {
     );
   }
 
+  bool _focusLastFolder(FocusNode from) {
+    final folders = _getFlattenedFolders();
+    if (folders.isEmpty || folders.length > _folderFocusNodes.length) {
+      return false;
+    }
+    final target = _folderFocusNodes[folders.length - 1];
+    final folderId = folders.last.id;
+
+    bool stillRequested() {
+      if (!mounted ||
+          !from.hasFocus ||
+          _folderFocusNodes.isEmpty ||
+          !identical(_folderFocusNodes.last, target)) {
+        return false;
+      }
+      final current = _getFlattenedFolders();
+      return current.isNotEmpty && current.last.id == folderId;
+    }
+
+    void reveal(int attempt) {
+      if (!stillRequested() || !_folderScrollController.hasClients) return;
+      // A lazy row has no focus attachment until the list builds it. Its
+      // estimated extent can change as rows are laid out, so retry boundedly.
+      _folderScrollController.jumpTo(
+        _folderScrollController.position.maxScrollExtent,
+      );
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!stillRequested()) return;
+        final rowContext = target.context;
+        if (rowContext != null) {
+          target.requestFocus();
+          Scrollable.ensureVisible(
+            rowContext,
+            alignment: 1,
+            duration: Duration.zero,
+          );
+        } else if (attempt < 3) {
+          reveal(attempt + 1);
+        }
+      });
+      // Even an already-visible last row needs a frame for the handoff.
+      WidgetsBinding.instance.scheduleFrame();
+    }
+
+    reveal(0);
+    return true;
+  }
+
   Future<void> _detectTelevision() async {
     try {
-      final isTv = await AndroidNativeDownloader.isTelevision();
+      final isTv = widget.isTelevisionOverride ??
+          await AndroidNativeDownloader.isTelevision();
       if (mounted) {
         setState(() {
           _isTelevision = isTv;
@@ -157,7 +211,7 @@ class _PikPakFolderPickerDialogState extends State<PikPakFolderPickerDialog> {
     });
 
     try {
-      final result = await _apiService.listFiles(
+      final result = await (widget.listFilesOverride ?? _apiService.listFiles)(
         parentId: null, // Root folder
         limit: 100,
       );
@@ -217,7 +271,7 @@ class _PikPakFolderPickerDialogState extends State<PikPakFolderPickerDialog> {
     });
 
     try {
-      final result = await _apiService.listFiles(
+      final result = await (widget.listFilesOverride ?? _apiService.listFiles)(
         parentId: folder.id,
         limit: 100,
       );
@@ -600,6 +654,7 @@ class _PikPakFolderPickerDialogState extends State<PikPakFolderPickerDialog> {
                               ),
                             )
                           : ListView.builder(
+                              controller: _folderScrollController,
                               itemCount: _getFlattenedFolders().length,
                               itemBuilder: (context, index) {
                                 return _buildFolderItem(context, index);
@@ -857,6 +912,7 @@ class _PikPakFolderPickerDialogState extends State<PikPakFolderPickerDialog> {
 
   @override
   void dispose() {
+    _folderScrollController.dispose();
     for (final node in _folderFocusNodes) {
       node.dispose();
     }

--- a/lib/widgets/pikpak_folder_picker_dialog.dart
+++ b/lib/widgets/pikpak_folder_picker_dialog.dart
@@ -151,14 +151,13 @@ class _PikPakFolderPickerDialogState extends State<PikPakFolderPickerDialog> {
     final folderId = folders.last.id;
 
     bool stillRequested() {
-      if (!mounted ||
-          !from.hasFocus ||
-          _folderFocusNodes.isEmpty ||
-          !identical(_folderFocusNodes.last, target)) {
-        return false;
-      }
+      if (!mounted || !from.hasFocus) return false;
       final current = _getFlattenedFolders();
-      return current.isNotEmpty && current.last.id == folderId;
+      // Pointer collapse can leave unused nodes at the end of the focus pool.
+      return current.length == folders.length &&
+          current.last.id == folderId &&
+          current.length <= _folderFocusNodes.length &&
+          identical(_folderFocusNodes[current.length - 1], target);
     }
 
     void reveal(int attempt) {

--- a/test/pikpak_folder_collapse_focus_test.dart
+++ b/test/pikpak_folder_collapse_focus_test.dart
@@ -1,0 +1,56 @@
+import 'package:debrify/widgets/pikpak_folder_picker_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'pikpak_last_folder_reveal_test.dart' as fixture;
+
+void main() {
+  testWidgets('footer UP survives pointer collapse of loaded children', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(960, 540);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PikPakFolderPickerDialog(
+            isTelevisionOverride: true,
+            listFilesOverride: ({String? parentId, required int limit}) async =>
+                (
+                  files: [
+                    for (var i = 0; i < 2; i++)
+                      <String, dynamic>{
+                        'id': parentId == null
+                            ? 'root-$i'
+                            : '$parentId-child-$i',
+                        'name': parentId == null ? 'Root $i' : 'Child $i',
+                        'kind': 'drive#folder',
+                      },
+                  ],
+                  nextPageToken: null,
+                ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pumpAndSettle();
+    expect(fixture.folderFocus('folder-item-3'), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.expand_more).first);
+    await tester.pumpAndSettle();
+    expect(fixture.folderFocus('folder-item-3'), findsNothing);
+    final cancel = tester
+        .widget<Focus>(fixture.folderFocus('cancel-button'))
+        .focusNode!;
+    cancel.requestFocus();
+    await tester.pumpAndSettle();
+    expect(cancel.hasFocus, isTrue);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(FocusManager.instance.primaryFocus?.debugLabel, 'folder-item-1');
+    expect(tester.takeException(), isNull);
+    await tester.pumpWidget(const SizedBox());
+  });
+}

--- a/test/pikpak_last_folder_reveal_test.dart
+++ b/test/pikpak_last_folder_reveal_test.dart
@@ -1,0 +1,141 @@
+import 'package:debrify/widgets/pikpak_folder_picker_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Finder folderFocus(String label) => find.byWidgetPredicate(
+  (widget) => widget is Focus && widget.focusNode?.debugLabel == label,
+);
+
+Future<void> openPicker(WidgetTester tester, {int count = 60}) async {
+  tester.view.physicalSize = const Size(960, 540);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: PikPakFolderPickerDialog(
+          isTelevisionOverride: true,
+          listFilesOverride: ({String? parentId, required int limit}) async => (
+            files: [
+              for (var i = 0; i < count; i++)
+                <String, dynamic>{
+                  'id': '$i',
+                  'name': 'Folder ${i.toString().padLeft(2, '0')}',
+                  'kind': 'drive#folder',
+                },
+            ],
+            nextPageToken: null,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  for (final footer in [
+    'new-folder-button',
+    'cancel-button',
+    'confirm-button',
+  ]) {
+    testWidgets('UP from $footer mounts and reveals the last folder', (
+      tester,
+    ) async {
+      await openPicker(tester);
+      // Select a real folder so Confirm is enabled as it would be in use.
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+      final button = tester.widget<Focus>(folderFocus(footer)).focusNode!;
+      button.requestFocus();
+      await tester.pumpAndSettle();
+      expect(button.hasFocus, isTrue);
+      expect(
+        folderFocus('folder-item-59'),
+        findsNothing,
+        reason: 'The target starts outside the lazy list cache.',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pumpAndSettle();
+      expect(FocusManager.instance.primaryFocus?.debugLabel, 'folder-item-59');
+      final last = tester.getRect(find.text('Folder 59'));
+      final viewport = tester.getRect(find.byType(ListView));
+      expect(last.top, greaterThanOrEqualTo(viewport.top));
+      expect(last.bottom, lessThanOrEqualTo(viewport.bottom));
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'new-folder-button',
+      );
+      expect(tester.takeException(), isNull);
+      await tester.pumpWidget(const SizedBox());
+    });
+  }
+
+  testWidgets('UP also focuses an already-mounted last folder', (tester) async {
+    await openPicker(tester, count: 1);
+    tester
+        .widget<Focus>(folderFocus('cancel-button'))
+        .focusNode!
+        .requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(FocusManager.instance.primaryFocus?.debugLabel, 'folder-item-0');
+    expect(tester.takeException(), isNull);
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('a pending handoff does not steal a newer focus choice', (
+    tester,
+  ) async {
+    await openPicker(tester);
+    tester
+        .widget<Focus>(folderFocus('cancel-button'))
+        .focusNode!
+        .requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    tester
+        .widget<Focus>(folderFocus('new-folder-button'))
+        .focusNode!
+        .requestFocus();
+    await tester.pumpAndSettle();
+    expect(FocusManager.instance.primaryFocus?.debugLabel, 'new-folder-button');
+    expect(tester.takeException(), isNull);
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('empty folder list keeps footer navigation usable', (
+    tester,
+  ) async {
+    await openPicker(tester, count: 0);
+    expect(find.text('No folders found in your account'), findsOneWidget);
+    final button = tester
+        .widget<Focus>(folderFocus('new-folder-button'))
+        .focusNode!;
+    button.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('a pending last-folder handoff is safe when dismissed', (
+    tester,
+  ) async {
+    await openPicker(tester);
+    tester
+        .widget<Focus>(folderFocus('cancel-button'))
+        .focusNode!
+        .requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpWidget(const SizedBox());
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
Restore focus to the final folder row when navigating up from the PikPak folder picker's footer, including when that row is not currently mounted by the lazy list. Guard the pending reveal against cancellation, dismissal and empty results.

Based independently on `webdav-sync` at `077f2e79`. The picker keeps its existing organization and selection behavior.

Flutter 3.44.8 / Dart 3.12.2: three footer-navigation regression cases fail on upstream; all seven focused tests pass with the fix. Scoped analysis retains seven existing diagnostics. Physical-device validation is outstanding.

Independent review exposed a retained focus-node-pool edge case after collapsing loaded child folders. The follow-up guard uses the current visible folder index, with a committed regression test. A second verification of the corrected head passes all eight tests, including cancellation and dismissal.

Combined validation with the other ten proposed slices: **304 focused/integration tests passed** and an Android release build succeeded with Flutter 3.44.8 / Dart 3.12.2 / JDK 17. The test and build source trees match. The existing Windows Spotlight golden is excluded from that selection. A separate clean upstream full-suite run has 6,044 passes, 12 skips, 55 failing user tests and one failing teardown hook; this is not a full-suite or GitHub CI pass. Physical-device validation of the upstream ports remains outstanding.
