### PR TITLE
Isolate the indexer configuration storage adapter

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -30,7 +30,9 @@ right code instead of re-discovering it. Flutter app; code under `lib/{screens,s
   `sizeFromTitle`), `services/stremio_marketplace_service.dart`, `screens/addons/addon_hub_screen.dart`.
 - Indexer managers (Prowlarr/Jackett): `services/indexer_manager_service.dart`
   (`_searchProwlarr*`, Torznab), `models/indexer_manager_config.dart`,
-  `screens/settings/indexer_managers_settings_page.dart`.
+  `screens/settings/indexer_managers_settings_page.dart`. Configuration adaptation and legacy storage:
+  `services/storage/indexer_manager_config_store.dart`, behind the StorageService facade;
+  canonical credentials and permissions remain in `ProfileCollectionResourceFacade`.
 - Scraper "engine" system (YAML-config, **not** a code-plugin runtime): `services/engine/*`.
 - **Filters**: `models/torrent_filter_state.dart` (QualityTier/RipSource/AudioLanguage/SizeBucket dims),
   format/HDR tag detection already exists in `utils/format_tag_detector.dart` +

--- a/lib/services/storage/indexer_manager_config_store.dart
+++ b/lib/services/storage/indexer_manager_config_store.dart
@@ -1,0 +1,92 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import '../../models/indexer_manager_config.dart';
+import '../../models/profiles/connection_resource.dart';
+import '../../models/profiles/profile_policy.dart';
+import '../profiles/connection_resource_service.dart';
+import '../profiles/profile_collection_resource_facade.dart';
+import '../profiles/profile_preferences.dart';
+import '../secret_vault.dart';
+
+/// Indexer model adaptation and legacy storage. Canonical resource authority
+/// remains in ProfileCollectionResourceFacade and its services.
+class IndexerManagerConfigStore {
+  IndexerManagerConfigStore._();
+
+  static const String _indexerManagerConfigsKey = 'indexer_manager_configs_v1';
+
+  static Future<List<IndexerManagerConfig>> getIndexerManagerConfigs({
+    bool forSettings = true,
+    bool forRemoteTransfer = false,
+  }) async {
+    if (ProfileCollectionResourceFacade.active) {
+      final rows = await ProfileCollectionResourceFacade.read(
+        types: const <ConnectionResourceType>{
+          ConnectionResourceType.jackett,
+          ConnectionResourceType.prowlarr,
+        },
+        feature: ProfileFeature.torrentSearch,
+        forSettings: forSettings,
+        forRemoteTransfer: forRemoteTransfer,
+      );
+      return rows.map(IndexerManagerConfig.fromJson).toList(growable: false);
+    }
+    final prefs = await ProfilePreferences.instance();
+    final rawList = await SecretVault.getStringList(
+      prefs,
+      _indexerManagerConfigsKey,
+    );
+    return rawList
+        .map((raw) {
+          try {
+            return IndexerManagerConfig.fromJson(
+              Map<String, dynamic>.from(jsonDecode(raw) as Map),
+            );
+          } catch (e) {
+            debugPrint('Error loading indexer manager config: $e');
+            return null;
+          }
+        })
+        .whereType<IndexerManagerConfig>()
+        .toList();
+  }
+
+  static Future<List<IndexerManagerConfig>> setIndexerManagerConfigs(
+    List<IndexerManagerConfig> configs,
+  ) async {
+    if (ProfileCollectionResourceFacade.active) {
+      final rows = await ProfileCollectionResourceFacade.replaceAndRead(
+        types: const <ConnectionResourceType>{
+          ConnectionResourceType.jackett,
+          ConnectionResourceType.prowlarr,
+        },
+        feature: ProfileFeature.torrentSearch,
+        items: <ResourceCollectionItem>[
+          for (final config in configs)
+            ResourceCollectionItem(
+              type: config.type == IndexerManagerType.prowlarr
+                  ? ConnectionResourceType.prowlarr
+                  : ConnectionResourceType.jackett,
+              label: config.displayName,
+              publicConfig: <String, dynamic>{
+                'managerName': config.displayName,
+              },
+              secretConfig: config.toJson(),
+              sourceResourceId: config.connectionResourceId,
+            ),
+        ],
+        forSettings: true,
+      );
+      return rows.map(IndexerManagerConfig.fromJson).toList(growable: false);
+    }
+    final prefs = await ProfilePreferences.instance();
+    final rawList = configs
+        .map((config) => jsonEncode(config.toJson()))
+        .toList();
+    await SecretVault.setStringList(prefs, _indexerManagerConfigsKey, rawList);
+    return List<IndexerManagerConfig>.unmodifiable(configs);
+  }
+
+}

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -20,6 +20,7 @@ import 'profiles/tvos_recovery_limits.dart';
 import '../models/profiles/connection_resource.dart';
 import '../models/profiles/profile_policy.dart';
 import 'secret_vault.dart';
+import 'storage/indexer_manager_config_store.dart';
 import '../models/iptv_playlist.dart';
 import '../models/indexer_manager_config.dart';
 import '../models/quick_play_rules.dart';
@@ -547,7 +548,6 @@ class StorageService {
   // Values: 'none' (ask every time), 'torbox', 'debrid', 'pikpak'
   static const String _defaultTorrentProviderKey =
       'default_torrent_provider_v1';
-  static const String _indexerManagerConfigsKey = 'indexer_manager_configs_v1';
 
   // Quick Play VR Settings
   // VR Player Mode: 'disabled' (always regular player), 'auto' (detect VR content), 'always' (always use DeoVR)
@@ -8288,74 +8288,14 @@ class StorageService {
   static Future<List<IndexerManagerConfig>> getIndexerManagerConfigs({
     bool forSettings = true,
     bool forRemoteTransfer = false,
-  }) async {
-    if (ProfileCollectionResourceFacade.active) {
-      final rows = await ProfileCollectionResourceFacade.read(
-        types: const <ConnectionResourceType>{
-          ConnectionResourceType.jackett,
-          ConnectionResourceType.prowlarr,
-        },
-        feature: ProfileFeature.torrentSearch,
-        forSettings: forSettings,
-        forRemoteTransfer: forRemoteTransfer,
-      );
-      return rows.map(IndexerManagerConfig.fromJson).toList(growable: false);
-    }
-    final prefs = await ProfilePreferences.instance();
-    final rawList = await SecretVault.getStringList(
-      prefs,
-      _indexerManagerConfigsKey,
-    );
-    return rawList
-        .map((raw) {
-          try {
-            return IndexerManagerConfig.fromJson(
-              Map<String, dynamic>.from(jsonDecode(raw) as Map),
-            );
-          } catch (e) {
-            debugPrint('Error loading indexer manager config: $e');
-            return null;
-          }
-        })
-        .whereType<IndexerManagerConfig>()
-        .toList();
-  }
+  }) => IndexerManagerConfigStore.getIndexerManagerConfigs(
+    forSettings: forSettings,
+    forRemoteTransfer: forRemoteTransfer,
+  );
 
   static Future<List<IndexerManagerConfig>> setIndexerManagerConfigs(
     List<IndexerManagerConfig> configs,
-  ) async {
-    if (ProfileCollectionResourceFacade.active) {
-      final rows = await ProfileCollectionResourceFacade.replaceAndRead(
-        types: const <ConnectionResourceType>{
-          ConnectionResourceType.jackett,
-          ConnectionResourceType.prowlarr,
-        },
-        feature: ProfileFeature.torrentSearch,
-        items: <ResourceCollectionItem>[
-          for (final config in configs)
-            ResourceCollectionItem(
-              type: config.type == IndexerManagerType.prowlarr
-                  ? ConnectionResourceType.prowlarr
-                  : ConnectionResourceType.jackett,
-              label: config.displayName,
-              publicConfig: <String, dynamic>{
-                'managerName': config.displayName,
-              },
-              secretConfig: config.toJson(),
-              sourceResourceId: config.connectionResourceId,
-            ),
-        ],
-        forSettings: true,
-      );
-      return rows.map(IndexerManagerConfig.fromJson).toList(growable: false);
-    }
-    final prefs = await ProfilePreferences.instance();
-    final rawList = configs
-        .map((config) => jsonEncode(config.toJson()))
-        .toList();
-    await SecretVault.setStringList(prefs, _indexerManagerConfigsKey, rawList);
-    return List<IndexerManagerConfig>.unmodifiable(configs);
-  }
+  ) => IndexerManagerConfigStore.setIndexerManagerConfigs(configs);
 
   static Future<String?> getSupportRemoteConfigCache() async {
     final prefs = await DevicePreferences.instance();

--- a/test/indexer_manager_config_store_origin_test.dart
+++ b/test/indexer_manager_config_store_origin_test.dart
@@ -1,0 +1,474 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:debrify/models/indexer_manager_config.dart';
+import 'package:debrify/models/profiles/connection_resource.dart';
+import 'package:debrify/models/profiles/profile_policy.dart';
+import 'package:debrify/services/profiles/connection_resource_service.dart';
+import 'package:debrify/services/profiles/device_key_provider.dart';
+import 'package:debrify/services/profiles/profile_authorization.dart';
+import 'package:debrify/services/profiles/profile_bootstrap.dart';
+import 'package:debrify/services/profiles/profile_collection_resource_facade.dart';
+import 'package:debrify/services/profiles/profile_registry.dart';
+import 'package:debrify/services/profiles/profile_runtime.dart';
+import 'package:debrify/services/profiles/profile_scope.dart';
+import 'package:debrify/services/secret_vault.dart';
+import 'package:debrify/services/storage_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/types.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+// Public facade characterization pinned on upstream 75b53ef3. Synthetic-only credentials, never real resources.
+// No copied adapter/authorization logic; local transports exercise actual APIs.
+const _key = 'indexer_manager_configs_v1';
+const _limit = Duration(seconds: 5);
+IndexerManagerConfig _config(
+  String id, {
+  IndexerManagerType type = IndexerManagerType.jackett,
+}) => IndexerManagerConfig(
+  id: id,
+  name: id,
+  type: type,
+  baseUrl: 'https://synthetic.invalid',
+  apiKey: 'synthetic-test-only',
+);
+
+class _Prefs extends InMemorySharedPreferencesStore {
+  _Prefs(super.data) : super.withData();
+  final entered = Completer<void>();
+  final release = Completer<void>();
+  final failure = StateError('synthetic preference write failure');
+  int writes = 0;
+  int otherWrites = 0;
+  bool hold = false;
+  String outcome = 'ok';
+  @override
+  Future<bool> setValue(String type, String key, Object value) async {
+    if (key != 'flutter.$_key') {
+      otherWrites++;
+      return super.setValue(type, key, value);
+    }
+    writes++;
+    if (hold) {
+      entered.complete();
+      await release.future.timeout(_limit);
+    }
+    if (outcome == 'throw') throw failure;
+    if (outcome == 'false') return false;
+    return super.setValue(type, key, value);
+  }
+
+  Future<Map<String, Object>> durable() => super.getAllWithParameters(
+    GetAllParameters(filter: PreferencesFilter(prefix: 'flutter.')),
+  );
+}
+
+class _HeldCipher implements DeviceSecretCipher {
+  _HeldCipher(this.delegate, {this.sealFirst = false});
+  final DeviceSecretCipher delegate;
+  final bool sealFirst;
+  final entered = Completer<void>();
+  final release = Completer<void>();
+  bool used = false;
+  Future<void> barrier(bool sealing) async {
+    if (used || sealing != sealFirst) return;
+    used = true;
+    entered.complete();
+    await release.future.timeout(_limit);
+  }
+
+  @override
+  Future<void> initialize() => delegate.initialize();
+  @override
+  Future<List<int>> open(
+    String envelope, {
+    required List<int> associatedData,
+  }) async {
+    await barrier(false);
+    return delegate.open(envelope, associatedData: associatedData);
+  }
+
+  @override
+  Future<String> seal(
+    List<int> plaintext, {
+    required List<int> associatedData,
+  }) async {
+    await barrier(true);
+    return delegate.seal(plaintext, associatedData: associatedData);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late SharedPreferencesStorePlatform previous;
+  late _Prefs prefsBackend;
+  Directory? directory;
+  ProfileRegistry? registry;
+  late MemoryDeviceSecretCipher cipher;
+  late String admin;
+  late String member;
+  final held = <_HeldCipher>[];
+  int epoch = 1;
+
+  void install(Map<String, Object> values) {
+    SharedPreferences.resetStatic();
+    prefsBackend = _Prefs({
+      for (final e in values.entries) 'flutter.${e.key}': e.value,
+    });
+    SharedPreferencesStorePlatform.instance = prefsBackend;
+  }
+
+  Future<void> canonical() async {
+    directory = await Directory.systemTemp.createTemp('indexer-origin-');
+    registry = await ProfileRegistry.open(
+      path: p.join(directory!.path, 'profiles.db'),
+    );
+    admin = (await registry!.createProfile(
+      name: 'Owner',
+      role: UserProfileRole.admin,
+    )).id;
+    member = (await registry!.createProfile(
+      name: 'Borrower',
+      role: UserProfileRole.member,
+    )).id;
+    await registry!.commitBootstrap(
+      activeProfileId: admin,
+      migratedLegacyInstall: false,
+    );
+    cipher = MemoryDeviceSecretCipher(List<int>.generate(32, (i) => i + 1));
+    await cipher.initialize();
+    DeviceKeyProvider.debugInstallCipher(cipher);
+    ProfileBootstrap.debugInstallRegistry(registry);
+    ProfileRuntime.initializeCommitted(
+      ProfileScope(profileId: admin, dataGeneration: 1, sessionEpoch: epoch),
+    );
+  }
+
+  void publish(String id) => ProfileRuntime.publish(
+    ProfileScope(profileId: id, dataGeneration: 1, sessionEpoch: ++epoch),
+  );
+  Future<ConnectionResource> create(
+    String id, {
+    IndexerManagerType type = IndexerManagerType.jackett,
+    bool malformed = false,
+  }) async =>
+      ConnectionResourceService(registry: registry!, cipher: cipher).create(
+        context: await ProfileAuthorizationContext.capture(registry!),
+        type: type == IndexerManagerType.jackett
+            ? ConnectionResourceType.jackett
+            : ConnectionResourceType.prowlarr,
+        label: id,
+        publicConfig: {'managerName': id},
+        secretConfig: {
+          ..._config(id, type: type).toJson(),
+          if (malformed) 'enabled': 'wrong-type',
+        },
+      );
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+  setUp(() {
+    previous = SharedPreferencesStorePlatform.instance;
+    ProfileRuntime.debugReset();
+    ProfileRuntime.initializeLegacy();
+    DeviceKeyProvider.debugReset();
+    SecretVault.debugReset(deviceIdOverride: 'synthetic-indexer-origin');
+    install({});
+    epoch = 1;
+  });
+  tearDown(() async {
+    if (!prefsBackend.release.isCompleted) prefsBackend.release.complete();
+    for (final gate in held) {
+      if (!gate.release.isCompleted) gate.release.complete();
+    }
+    held.clear();
+    ProfileRuntime.debugReset();
+    ProfileBootstrap.debugInstallRegistry(null);
+    DeviceKeyProvider.debugReset();
+    SecretVault.debugReset();
+    await registry?.close();
+    registry = null;
+    await directory?.delete(recursive: true);
+    directory = null;
+    SharedPreferences.resetStatic();
+    SharedPreferencesStorePlatform.instance = previous;
+  });
+
+  test(
+    'legacy absent returns growable empty; wrong physical type escapes',
+    () async {
+      final empty = await StorageService.getIndexerManagerConfigs();
+      empty.add(_config('local'));
+      expect(await StorageService.getIndexerManagerConfigs(), isEmpty);
+      install({_key: true});
+      await expectLater(
+        StorageService.getIndexerManagerConfigs(),
+        throwsA(isA<TypeError>()),
+      );
+    },
+  );
+
+  test(
+    'legacy per-row JSON failures skip in order and clean plaintext reseals',
+    () async {
+      install({
+        _key: [
+          jsonEncode(_config('a').toJson()),
+          '{',
+          jsonEncode(_config('b').toJson()),
+          '[]',
+        ],
+      });
+      final result = await StorageService.getIndexerManagerConfigs();
+      expect(result.map((e) => e.id), ['a', 'b']);
+      result.add(_config('mutable'));
+      final raw = (await prefsBackend.durable())['flutter.$_key'] as List;
+      expect(raw.length, 4);
+      expect(raw.every((e) => SecretVault.isSealed(e as String)), isTrue);
+      expect(prefsBackend.writes, 1);
+    },
+  );
+
+  test(
+    'legacy decrypt failure drops row and prevents clean-legacy rewrite',
+    () async {
+      final raw = [jsonEncode(_config('a').toJson()), 'enc1:invalid'];
+      install({_key: raw});
+      expect(
+        (await StorageService.getIndexerManagerConfigs()).map((e) => e.id),
+        ['a'],
+      );
+      expect(prefsBackend.writes, 0);
+      expect(
+        jsonEncode((await prefsBackend.durable())['flutter.$_key']) ==
+            jsonEncode(raw),
+        isTrue,
+      );
+    },
+  );
+
+  for (final outcome in ['ok', 'false', 'throw']) {
+    test(
+      'legacy held write $outcome retains prewrite snapshot and late live readback',
+      () async {
+        prefsBackend.hold = true;
+        prefsBackend.outcome = outcome;
+        final input = [_config('before')];
+        final result = StorageService.setIndexerManagerConfigs(input);
+        List<IndexerManagerConfig>? returned;
+        final observed = outcome == 'throw'
+            ? expectLater(result, throwsA(same(prefsBackend.failure)))
+            : result.then<void>((value) {
+                returned = value;
+              });
+        await prefsBackend.entered.future.timeout(_limit);
+        input.add(_config('after'));
+        prefsBackend.release.complete();
+        await observed;
+        if (returned != null) {
+          expect(returned!.map((e) => e.id), ['before', 'after']);
+          expect(
+            () => returned!.add(_config('rejected')),
+            throwsUnsupportedError,
+          );
+        }
+        final durable = await prefsBackend.durable();
+        expect(durable.containsKey('flutter.$_key'), outcome == 'ok');
+        // SDK updates its cached list before platform completion, even on false/throw.
+        expect(
+          (await StorageService.getIndexerManagerConfigs()).map((e) => e.id),
+          ['before'],
+        );
+      },
+    );
+  }
+
+  test(
+    'canonical both types return stable current authority and fixed-length readback',
+    () async {
+      await canonical();
+      final input = [
+        _config('a'),
+        _config('b', type: IndexerManagerType.prowlarr),
+      ];
+      final saved = await StorageService.setIndexerManagerConfigs(input);
+      expect(
+        saved.map((e) => e.type).toSet(),
+        IndexerManagerType.values.toSet(),
+      );
+      expect(
+        saved.every(
+          (e) =>
+              e.id == e.connectionResourceId &&
+              e.connectionResourceRevision != null,
+        ),
+        isTrue,
+      );
+      expect(() => saved.add(_config('no')), throwsUnsupportedError);
+      final first = saved.first;
+      final updated = await StorageService.setIndexerManagerConfigs([
+        for (final e in saved) e.copyWith(maxResults: 77),
+      ]);
+      final current = updated.singleWhere((e) => e.id == first.id);
+      expect(
+        current.connectionResourceRevision!,
+        greaterThan(first.connectionResourceRevision!),
+      );
+      expect(current.maxResults, 77);
+      await ProfileCollectionResourceFacade.authorizeExecution(
+        resourceId: current.connectionResourceId,
+        resourceRevision: current.connectionResourceRevision,
+        acceptedTypes: {
+          ConnectionResourceType.jackett,
+          ConnectionResourceType.prowlarr,
+        },
+        feature: ProfileFeature.torrentSearch,
+      );
+      expect(
+        (await prefsBackend.durable()).containsKey('flutter.$_key'),
+        isFalse,
+      );
+    },
+  );
+
+  test(
+    'canonical default settings redact borrower; execution and remote obey different grants',
+    () async {
+      await canonical();
+      final resource = await create('shared');
+      final service = ConnectionResourceService(
+        registry: registry!,
+        cipher: cipher,
+      );
+      await service.grant(
+        actor: await ProfileAuthorizationContext.capture(registry!),
+        targetProfileId: member,
+        resourceId: resource.id,
+        permissions: {ResourcePermission.use},
+      );
+      publish(member);
+      final settings = (await StorageService.getIndexerManagerConfigs()).single;
+      expect(
+        settings.connectionReadOnly && settings.credentialsRedacted,
+        isTrue,
+      );
+      expect(settings.apiKey.isEmpty && settings.baseUrl.isEmpty, isTrue);
+      final operational = (await StorageService.getIndexerManagerConfigs(
+        forSettings: false,
+      )).single;
+      expect(operational.apiKey.isNotEmpty, isTrue);
+      expect(
+        await StorageService.getIndexerManagerConfigs(forRemoteTransfer: true),
+        isEmpty,
+      );
+      publish(admin);
+      await service.grant(
+        actor: await ProfileAuthorizationContext.capture(registry!),
+        targetProfileId: member,
+        resourceId: resource.id,
+        permissions: {ResourcePermission.use, ResourcePermission.writeRemote},
+      );
+      publish(member);
+      final remote = (await StorageService.getIndexerManagerConfigs(
+        forRemoteTransfer: true,
+      )).single;
+      expect(remote.apiKey.isNotEmpty, isTrue);
+    },
+  );
+
+  test(
+    'canonical disabled setting hides execution but remains visible in settings',
+    () async {
+      await canonical();
+      final resource = await create('disabled');
+      await ProfileCollectionResourceFacade.setLocalEnabled(
+        resourceId: resource.id,
+        resourceRevision: resource.authorizationRevision,
+        feature: ProfileFeature.torrentSearch,
+        enabled: false,
+      );
+      expect(
+        await StorageService.getIndexerManagerConfigs(forSettings: false),
+        isEmpty,
+      );
+      expect(
+        (await StorageService.getIndexerManagerConfigs()).single.enabled,
+        isFalse,
+      );
+    },
+  );
+
+  test('canonical execution requires feature even with a use grant', () async {
+    await canonical();
+    final actor = await ProfileAuthorizationContext.capture(registry!);
+    final restricted = (await registry!.createProfile(
+      name: 'Restricted',
+      actingProfileId: actor.profileId,
+      actingAuthorizationRevision: actor.authorizationRevision,
+      actingSessionEpoch: actor.sessionEpoch,
+      role: UserProfileRole.member,
+      policy: const ProfilePolicy(enabled: {}),
+    )).id;
+    final resource = await create('feature');
+    await ConnectionResourceService(registry: registry!, cipher: cipher).grant(
+      actor: await ProfileAuthorizationContext.capture(registry!),
+      targetProfileId: restricted,
+      resourceId: resource.id,
+      permissions: {ResourcePermission.use},
+    );
+    publish(restricted);
+    await expectLater(
+      StorageService.getIndexerManagerConfigs(forSettings: false),
+      throwsA(isA<ResourceAuthorizationException>()),
+    );
+  });
+
+  test(
+    'canonical malformed model propagates instead of falling back to legacy',
+    () async {
+      install({
+        _key: [jsonEncode(_config('legacy').toJson())],
+      });
+      await canonical();
+      await create('malformed', malformed: true);
+      await expectLater(
+        StorageService.getIndexerManagerConfigs(),
+        throwsA(isA<TypeError>()),
+      );
+      expect(prefsBackend.writes, 0);
+    },
+  );
+
+  for (final saving in [false, true]) {
+    test(
+      'canonical held ${saving ? 'save' : 'read'} cannot return across session change',
+      () async {
+        await canonical();
+        await create('existing');
+        final gate = _HeldCipher(cipher, sealFirst: saving);
+        held.add(gate);
+        DeviceKeyProvider.debugInstallCipher(gate);
+        final result = saving
+            ? StorageService.setIndexerManagerConfigs([_config('new')])
+            : StorageService.getIndexerManagerConfigs();
+        final observed = expectLater(
+          result,
+          throwsA(
+            anyOf(isA<StateError>(), isA<ResourceAuthorizationException>()),
+          ),
+        );
+        await gate.entered.future.timeout(_limit);
+        publish(member);
+        gate.release.complete();
+        await observed;
+        expect(prefsBackend.writes, 0);
+      },
+    );
+  }
+}


### PR DESCRIPTION
Extracts the two indexer configuration storage adapters from StorageService while preserving their public APIs. Canonical profile resources remain authoritative: saves return canonical readback, and settings reads keep the existing credential redaction rules. Legacy parsing and vault handling are unchanged.

Validated independently against `webdav-sync` at `75b53ef3`: the same 58 tests pass before and after extraction. Mutations returning the original input instead of canonical readback and using execution authority for settings reads both fail their behavioral assertions. Scoped analysis reports no diagnostics. Independent review found no confirmed regression.

No model, credential service, settings layout or caller changes. This independent draft replaces only the indexer-adapter slice of retired #61. Verification is focused tests and analysis; no real-provider or device test is claimed.
