### PR TITLE
Isolate Quick Play preference policy

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -18,6 +18,8 @@ right code instead of re-discovering it. Flutter app; code under `lib/{screens,s
   favourites rows, the D-pad `_BoardCell` focus grid, poster sizing (`_railPosterW`), bind-sources entry.
 - **`services/storage_service.dart`** 🔴 — all SharedPreferences/persisted state (settings, continue
   watching (cap 50), playback state, favourites, provider toggles, home disabled-sections).
+  Quick Play policy and legacy mirrors: `services/storage/quick_play_policy_prefs.dart`;
+  StorageService retains its facade and ProfilePreferences retains profile authority.
 - **`services/torrent_playback_service.dart`** 🔴 — provider-agnostic play/add/bind pipeline;
   string-keyed switches per provider (`_add`, `_isConfigured`, `_pickProvider`, `bindSource`).
 - **`main.dart`** — app shell + nav branch (TV rail / desktop rail / `MobileFloatingNav`), tab indices.

--- a/lib/services/storage/quick_play_policy_prefs.dart
+++ b/lib/services/storage/quick_play_policy_prefs.dart
@@ -1,0 +1,232 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../models/quick_play_rules.dart';
+import '../profiles/profile_preferences.dart';
+
+/// Movie/series Quick Play preferences and their legacy compatibility mirrors.
+/// StorageService retains the public facade; ProfilePreferences owns scope guards.
+class QuickPlayPolicyPrefs {
+  QuickPlayPolicyPrefs._();
+
+  static const String _quickPlayHonorsFiltersKey =
+      'quick_play_honors_filters_v1';
+
+  static const String _quickPlaySearchTimeoutKey = 'quick_play_search_timeout';
+
+  static const String _stremioSourcesTimeoutKey = 'stremio_sources_timeout';
+
+  // Quick Play Cache Fallback Settings
+  // When enabled, if first torrent is not cached, try next torrents until one works
+  static const String _quickPlayTryMultipleTorrentsKey =
+      'quick_play_try_multiple_torrents';
+  static const String _quickPlayMaxRetriesKey = 'quick_play_max_retries';
+  static const String _quickPlayMovieRulesKey = 'quick_play_movie_rules_v2';
+  static const String _quickPlaySeriesRulesKey = 'quick_play_series_rules_v2';
+  static const String _playButtonModeKey = 'play_button_mode';
+
+  // Series auto-pin: on a series play with no pinned source, search packs
+  // first (complete series → season pack), and pin whatever source plays so
+  // subsequent episode plays go straight through the bound path.
+  /// LEGACY MIRROR ONLY. Written by [setQuickPlayRules] to carry
+  /// `preferSeriesPacks` for downgrade builds, and read once by
+  /// [_quickPlayRulesFromPrefs] to migrate pre-v2 profiles. Nothing on the live
+  /// playback path may read it — see [_seriesAutoPinOnPlayKey].
+  static const String _autoBindSeriesPacksKey =
+      'auto_bind_series_packs_on_play';
+
+  /// Whether a series play pins the source that played. Split out of
+  /// [_autoBindSeriesPacksKey] because that key doubles as the legacy mirror of
+  /// `preferSeriesPacks`: turning OFF "Prefer season packs" in Quick Play also
+  /// silently disabled all series auto-pinning, so Smart mode never found a pin
+  /// and Quick Play lost its fast path. Deliberately does NOT inherit the old
+  /// key's value — a `false` there was the packs toggle bleeding through, never
+  /// an auto-pin choice (no UI ever wrote it directly).
+  static const String _seriesAutoPinOnPlayKey = 'series_auto_pin_on_play';
+
+  static Future<bool> getQuickPlayHonorsFilters() async {
+    final prefs = await ProfilePreferences.instance();
+    return prefs.getBool(_quickPlayHonorsFiltersKey) ?? true;
+  }
+
+  static Future<void> setQuickPlayHonorsFilters(bool value) async {
+    final prefs = await ProfilePreferences.instance();
+    await prefs.setBool(_quickPlayHonorsFiltersKey, value);
+  }
+
+  static Future<String> getPlayButtonMode() async {
+    final prefs = await ProfilePreferences.instance();
+    final raw = prefs.getString(_playButtonModeKey);
+    return (raw == 'smart' || raw == 'always') ? raw! : 'quick';
+  }
+
+  static Future<void> setPlayButtonMode(String value) async {
+    final prefs = await ProfilePreferences.instance();
+    await prefs.setString(_playButtonModeKey, value);
+  }
+
+  static Future<QuickPlayRules> getQuickPlayRules({
+    required bool isMovie,
+  }) async {
+    final prefs = await ProfilePreferences.instance();
+    return _quickPlayRulesFromPrefs(prefs, isMovie: isMovie);
+  }
+
+  static QuickPlayRules _quickPlayRulesFromPrefs(
+    SharedPreferences prefs, {
+    required bool isMovie,
+  }) {
+    final key = isMovie ? _quickPlayMovieRulesKey : _quickPlaySeriesRulesKey;
+    final stored = prefs.getString(key);
+    if (stored != null) {
+      try {
+        final decoded = jsonDecode(stored);
+        if (decoded is Map<String, dynamic>) {
+          return QuickPlayRules.fromJson(decoded, isMovie: isMovie);
+        }
+        if (decoded is Map) {
+          return QuickPlayRules.fromJson(
+            decoded.map((key, value) => MapEntry(key.toString(), value)),
+            isMovie: isMovie,
+          );
+        }
+      } catch (e) {
+        debugPrint('Invalid Quick Play profile, using legacy values: $e');
+      }
+    }
+
+    final defaults = QuickPlayRules.debrifyDefault(isMovie: isMovie);
+    final migrated = defaults.copyWith(
+      preset: QuickPlayPreset.debrifyDefault,
+      useFilters: prefs.getBool(_quickPlayHonorsFiltersKey) ?? true,
+      tryNextOnFailure: prefs.getBool(_quickPlayTryMultipleTorrentsKey) ?? true,
+      maxAttempts: prefs.getInt(_quickPlayMaxRetriesKey) ?? 5,
+      preferSeriesPacks:
+          !isMovie && (prefs.getBool(_autoBindSeriesPacksKey) ?? true),
+    );
+    return migrated == defaults
+        ? migrated
+        : migrated.copyWith(preset: QuickPlayPreset.custom);
+  }
+
+  static Future<void> setQuickPlayRules(
+    QuickPlayRules rules, {
+    required bool isMovie,
+  }) async {
+    final prefs = await ProfilePreferences.instance();
+    final siblingIsMovie = !isMovie;
+    final siblingKey = siblingIsMovie
+        ? _quickPlayMovieRulesKey
+        : _quickPlaySeriesRulesKey;
+    // Snapshot an as-yet-unpersisted sibling BEFORE updating the legacy global
+    // mirrors below. Otherwise saving Movies first could make a later Series
+    // migration inherit the movie retry count (and vice versa).
+    final sibling = prefs.containsKey(siblingKey)
+        ? null
+        : _quickPlayRulesFromPrefs(prefs, isMovie: siblingIsMovie);
+    await prefs.setString(
+      isMovie ? _quickPlayMovieRulesKey : _quickPlaySeriesRulesKey,
+      jsonEncode(rules.toJson()),
+    );
+    if (sibling != null) {
+      await prefs.setString(siblingKey, jsonEncode(sibling.toJson()));
+    }
+
+    // Keep old readers and downgrade builds safe. Media-specific values can't
+    // be represented perfectly by the legacy global keys, so the active v2
+    // playback path never reads these; they are compatibility mirrors only.
+    //
+    // That invariant was violated once: series auto-pinning read
+    // _autoBindSeriesPacksKey, so writing this mirror turned pinning off
+    // whenever the user turned off "Prefer season packs". Auto-pin now owns
+    // _seriesAutoPinOnPlayKey. Before adding a reader for any key below, check
+    // it is genuinely write-only on this path.
+    await prefs.setBool(
+      _quickPlayTryMultipleTorrentsKey,
+      rules.tryNextOnFailure,
+    );
+    await prefs.setInt(_quickPlayMaxRetriesKey, rules.maxAttempts);
+    if (!isMovie) {
+      await prefs.setBool(_autoBindSeriesPacksKey, rules.preferSeriesPacks);
+    }
+  }
+
+  static Future<void> restoreQuickPlayDefaults() async {
+    await setQuickPlayRules(
+      QuickPlayRules.debrifyDefault(isMovie: true),
+      isMovie: true,
+    );
+    await setQuickPlayRules(
+      QuickPlayRules.debrifyDefault(isMovie: false),
+      isMovie: false,
+    );
+    final prefs = await ProfilePreferences.instance();
+    await prefs.setBool(_quickPlayHonorsFiltersKey, true);
+    // The page's reset button reads as "reset this page", and this function
+    // already resets a non-per-tab key above, so the Play button mode goes back
+    // to the shipped Quick Play too. Leaving it would restore defaults while
+    // Play kept behaving differently.
+    await prefs.remove(_playButtonModeKey);
+  }
+
+  static Future<bool> getQuickPlayTryMultipleTorrents() async {
+    final prefs = await ProfilePreferences.instance();
+    return prefs.getBool(_quickPlayTryMultipleTorrentsKey) ?? true;
+  }
+
+  static Future<void> setQuickPlayTryMultipleTorrents(bool tryMultiple) async {
+    final prefs = await ProfilePreferences.instance();
+    await prefs.setBool(_quickPlayTryMultipleTorrentsKey, tryMultiple);
+  }
+
+  static Future<bool> getSeriesAutoPinOnPlay() async {
+    final prefs = await ProfilePreferences.instance();
+    return prefs.getBool(_seriesAutoPinOnPlayKey) ?? true;
+  }
+
+  static Future<void> setSeriesAutoPinOnPlay(bool enabled) async {
+    final prefs = await ProfilePreferences.instance();
+    await prefs.setBool(_seriesAutoPinOnPlayKey, enabled);
+  }
+
+  static Future<int> getQuickPlayMaxRetries() async {
+    final prefs = await ProfilePreferences.instance();
+    return prefs.getInt(_quickPlayMaxRetriesKey) ?? 5;
+  }
+
+  static Future<void> setQuickPlayMaxRetries(int maxRetries) async {
+    final prefs = await ProfilePreferences.instance();
+    // Clamp between 2 and 10
+    await prefs.setInt(_quickPlayMaxRetriesKey, maxRetries.clamp(2, 10));
+  }
+
+  static Future<int> getQuickPlaySearchTimeout() async {
+    final prefs = await ProfilePreferences.instance();
+    return prefs.getInt(_quickPlaySearchTimeoutKey) ?? 5;
+  }
+
+  static Future<void> setQuickPlaySearchTimeout(int seconds) async {
+    final prefs = await ProfilePreferences.instance();
+    await prefs.setInt(_quickPlaySearchTimeoutKey, seconds);
+  }
+
+  static Future<int> getStremioSourcesTimeout() async {
+    final prefs = await ProfilePreferences.instance();
+    return prefs.getInt(_stremioSourcesTimeoutKey) ?? 15;
+  }
+
+  static Future<void> setStremioSourcesTimeout(int seconds) async {
+    final prefs = await ProfilePreferences.instance();
+    await prefs.setInt(_stremioSourcesTimeoutKey, seconds);
+  }
+
+  static Future<void> clearQuickPlayCacheFallbackSettings() async {
+    final prefs = await ProfilePreferences.instance();
+    await prefs.remove(_quickPlayTryMultipleTorrentsKey);
+    await prefs.remove(_quickPlayMaxRetriesKey);
+    await prefs.remove(_quickPlayMovieRulesKey);
+    await prefs.remove(_quickPlaySeriesRulesKey);
+  }
+}

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -1,5 +1,4 @@
 import '../models/home_collection.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:http/http.dart' as http;
 import 'package:flutter/foundation.dart';
@@ -20,6 +19,7 @@ import 'profiles/tvos_recovery_limits.dart';
 import '../models/profiles/connection_resource.dart';
 import '../models/profiles/profile_policy.dart';
 import 'secret_vault.dart';
+import 'storage/quick_play_policy_prefs.dart';
 import '../models/iptv_playlist.dart';
 import '../models/indexer_manager_config.dart';
 import '../models/quick_play_rules.dart';
@@ -540,8 +540,6 @@ class StorageService {
   static const String _defaultFilterSizesKey = 'default_filter_sizes_v1';
   static const String _defaultFilterDynamicRangesKey =
       'default_filter_dynamic_ranges_v1';
-  static const String _quickPlayHonorsFiltersKey =
-      'quick_play_honors_filters_v1';
 
   // Default Torrent Provider Settings
   // Values: 'none' (ask every time), 'torbox', 'debrid', 'pikpak'
@@ -559,34 +557,6 @@ class StorageService {
   static const String _quickPlayVrAutoDetectFormatKey =
       'quick_play_vr_auto_detect_format';
   static const String _quickPlayVrShowDialogKey = 'quick_play_vr_show_dialog';
-
-  // Quick Play Cache Fallback Settings
-  // When enabled, if first torrent is not cached, try next torrents until one works
-  static const String _quickPlayTryMultipleTorrentsKey =
-      'quick_play_try_multiple_torrents';
-  static const String _quickPlayMaxRetriesKey = 'quick_play_max_retries';
-  static const String _quickPlayMovieRulesKey = 'quick_play_movie_rules_v2';
-  static const String _quickPlaySeriesRulesKey = 'quick_play_series_rules_v2';
-  static const String _playButtonModeKey = 'play_button_mode';
-
-  // Series auto-pin: on a series play with no pinned source, search packs
-  // first (complete series → season pack), and pin whatever source plays so
-  // subsequent episode plays go straight through the bound path.
-  /// LEGACY MIRROR ONLY. Written by [setQuickPlayRules] to carry
-  /// `preferSeriesPacks` for downgrade builds, and read once by
-  /// [_quickPlayRulesFromPrefs] to migrate pre-v2 profiles. Nothing on the live
-  /// playback path may read it — see [_seriesAutoPinOnPlayKey].
-  static const String _autoBindSeriesPacksKey =
-      'auto_bind_series_packs_on_play';
-
-  /// Whether a series play pins the source that played. Split out of
-  /// [_autoBindSeriesPacksKey] because that key doubles as the legacy mirror of
-  /// `preferSeriesPacks`: turning OFF "Prefer season packs" in Quick Play also
-  /// silently disabled all series auto-pinning, so Smart mode never found a pin
-  /// and Quick Play lost its fast path. Deliberately does NOT inherit the old
-  /// key's value — a `false` there was the packs toggle bleeding through, never
-  /// an auto-pin choice (no UI ever wrote it directly).
-  static const String _seriesAutoPinOnPlayKey = 'series_auto_pin_on_play';
 
   // Trakt settings
   static const String _traktAccessTokenKey = 'trakt_access_token';
@@ -8152,18 +8122,14 @@ class StorageService {
 
   /// Whether quick-play ranks candidates by the default filters (the
   /// FilterLadder). ON by default — the ladder only reorders, never drops.
-  static Future<bool> getQuickPlayHonorsFilters() async {
-    final prefs = await ProfilePreferences.instance();
-    return prefs.getBool(_quickPlayHonorsFiltersKey) ?? true;
-  }
+  static Future<bool> getQuickPlayHonorsFilters() =>
+      QuickPlayPolicyPrefs.getQuickPlayHonorsFilters();
 
   /// Legacy global preference retained for migration and profile-less callers.
   /// The Quick Play page owns the independent Movie and Series `useFilters`
   /// values; a global write must never silently rewrite either profile.
-  static Future<void> setQuickPlayHonorsFilters(bool value) async {
-    final prefs = await ProfilePreferences.instance();
-    await prefs.setBool(_quickPlayHonorsFiltersKey, value);
-  }
+  static Future<void> setQuickPlayHonorsFilters(bool value) =>
+      QuickPlayPolicyPrefs.setQuickPlayHonorsFilters(value);
 
   // Default Torrent Filter Settings
   static Future<List<String>> getDefaultFilterQualities() async {
@@ -8465,16 +8431,11 @@ class StorageService {
   /// applies it solely when a picker opener is supplied) — binge auto-advance and
   /// post-failure recovery keep auto-selecting, since re-prompting mid-chain is
   /// exactly what those paths exist to avoid.
-  static Future<String> getPlayButtonMode() async {
-    final prefs = await ProfilePreferences.instance();
-    final raw = prefs.getString(_playButtonModeKey);
-    return (raw == 'smart' || raw == 'always') ? raw! : 'quick';
-  }
+  static Future<String> getPlayButtonMode() =>
+      QuickPlayPolicyPrefs.getPlayButtonMode();
 
-  static Future<void> setPlayButtonMode(String value) async {
-    final prefs = await ProfilePreferences.instance();
-    await prefs.setString(_playButtonModeKey, value);
-  }
+  static Future<void> setPlayButtonMode(String value) =>
+      QuickPlayPolicyPrefs.setPlayButtonMode(value);
 
   /// Loads the per-content Quick Play profile. When no v2 profile exists,
   /// legacy filter/retry/series-pack preferences are folded into one without
@@ -8482,181 +8443,61 @@ class StorageService {
   /// labelled Custom; an untouched install is Debrify default.
   static Future<QuickPlayRules> getQuickPlayRules({
     required bool isMovie,
-  }) async {
-    final prefs = await ProfilePreferences.instance();
-    return _quickPlayRulesFromPrefs(prefs, isMovie: isMovie);
-  }
-
-  static QuickPlayRules _quickPlayRulesFromPrefs(
-    SharedPreferences prefs, {
-    required bool isMovie,
-  }) {
-    final key = isMovie ? _quickPlayMovieRulesKey : _quickPlaySeriesRulesKey;
-    final stored = prefs.getString(key);
-    if (stored != null) {
-      try {
-        final decoded = jsonDecode(stored);
-        if (decoded is Map<String, dynamic>) {
-          return QuickPlayRules.fromJson(decoded, isMovie: isMovie);
-        }
-        if (decoded is Map) {
-          return QuickPlayRules.fromJson(
-            decoded.map((key, value) => MapEntry(key.toString(), value)),
-            isMovie: isMovie,
-          );
-        }
-      } catch (e) {
-        debugPrint('Invalid Quick Play profile, using legacy values: $e');
-      }
-    }
-
-    final defaults = QuickPlayRules.debrifyDefault(isMovie: isMovie);
-    final migrated = defaults.copyWith(
-      preset: QuickPlayPreset.debrifyDefault,
-      useFilters: prefs.getBool(_quickPlayHonorsFiltersKey) ?? true,
-      tryNextOnFailure: prefs.getBool(_quickPlayTryMultipleTorrentsKey) ?? true,
-      maxAttempts: prefs.getInt(_quickPlayMaxRetriesKey) ?? 5,
-      preferSeriesPacks:
-          !isMovie && (prefs.getBool(_autoBindSeriesPacksKey) ?? true),
-    );
-    return migrated == defaults
-        ? migrated
-        : migrated.copyWith(preset: QuickPlayPreset.custom);
-  }
+  }) =>
+      QuickPlayPolicyPrefs.getQuickPlayRules(isMovie: isMovie);
 
   static Future<void> setQuickPlayRules(
     QuickPlayRules rules, {
     required bool isMovie,
-  }) async {
-    final prefs = await ProfilePreferences.instance();
-    final siblingIsMovie = !isMovie;
-    final siblingKey = siblingIsMovie
-        ? _quickPlayMovieRulesKey
-        : _quickPlaySeriesRulesKey;
-    // Snapshot an as-yet-unpersisted sibling BEFORE updating the legacy global
-    // mirrors below. Otherwise saving Movies first could make a later Series
-    // migration inherit the movie retry count (and vice versa).
-    final sibling = prefs.containsKey(siblingKey)
-        ? null
-        : _quickPlayRulesFromPrefs(prefs, isMovie: siblingIsMovie);
-    await prefs.setString(
-      isMovie ? _quickPlayMovieRulesKey : _quickPlaySeriesRulesKey,
-      jsonEncode(rules.toJson()),
-    );
-    if (sibling != null) {
-      await prefs.setString(siblingKey, jsonEncode(sibling.toJson()));
-    }
+  }) =>
+      QuickPlayPolicyPrefs.setQuickPlayRules(rules, isMovie: isMovie);
 
-    // Keep old readers and downgrade builds safe. Media-specific values can't
-    // be represented perfectly by the legacy global keys, so the active v2
-    // playback path never reads these; they are compatibility mirrors only.
-    //
-    // That invariant was violated once: series auto-pinning read
-    // _autoBindSeriesPacksKey, so writing this mirror turned pinning off
-    // whenever the user turned off "Prefer season packs". Auto-pin now owns
-    // _seriesAutoPinOnPlayKey. Before adding a reader for any key below, check
-    // it is genuinely write-only on this path.
-    await prefs.setBool(
-      _quickPlayTryMultipleTorrentsKey,
-      rules.tryNextOnFailure,
-    );
-    await prefs.setInt(_quickPlayMaxRetriesKey, rules.maxAttempts);
-    if (!isMovie) {
-      await prefs.setBool(_autoBindSeriesPacksKey, rules.preferSeriesPacks);
-    }
-  }
-
-  static Future<void> restoreQuickPlayDefaults() async {
-    await setQuickPlayRules(
-      QuickPlayRules.debrifyDefault(isMovie: true),
-      isMovie: true,
-    );
-    await setQuickPlayRules(
-      QuickPlayRules.debrifyDefault(isMovie: false),
-      isMovie: false,
-    );
-    final prefs = await ProfilePreferences.instance();
-    await prefs.setBool(_quickPlayHonorsFiltersKey, true);
-    // The page's reset button reads as "reset this page", and this function
-    // already resets a non-per-tab key above, so the Play button mode goes back
-    // to the shipped Quick Play too. Leaving it would restore defaults while
-    // Play kept behaving differently.
-    await prefs.remove(_playButtonModeKey);
-  }
+  static Future<void> restoreQuickPlayDefaults() =>
+      QuickPlayPolicyPrefs.restoreQuickPlayDefaults();
 
   /// Get whether to try multiple torrents if first is not cached
   /// Default: true (try next torrent on failure)
-  static Future<bool> getQuickPlayTryMultipleTorrents() async {
-    final prefs = await ProfilePreferences.instance();
-    return prefs.getBool(_quickPlayTryMultipleTorrentsKey) ?? true;
-  }
+  static Future<bool> getQuickPlayTryMultipleTorrents() =>
+      QuickPlayPolicyPrefs.getQuickPlayTryMultipleTorrents();
 
-  static Future<void> setQuickPlayTryMultipleTorrents(bool tryMultiple) async {
-    final prefs = await ProfilePreferences.instance();
-    await prefs.setBool(_quickPlayTryMultipleTorrentsKey, tryMultiple);
-  }
+  static Future<void> setQuickPlayTryMultipleTorrents(bool tryMultiple) =>
+      QuickPlayPolicyPrefs.setQuickPlayTryMultipleTorrents(tryMultiple);
 
   /// Whether a series play pins the source that played, so later episodes go
   /// straight through the bound path. Defaults ON.
   ///
   /// Independent of "Prefer season packs" — the two shared a key until this
   /// split, which meant turning packs off silently killed pinning. See
-  /// [_seriesAutoPinOnPlayKey].
-  static Future<bool> getSeriesAutoPinOnPlay() async {
-    final prefs = await ProfilePreferences.instance();
-    return prefs.getBool(_seriesAutoPinOnPlayKey) ?? true;
-  }
+  /// [QuickPlayPolicyPrefs].
+  static Future<bool> getSeriesAutoPinOnPlay() =>
+      QuickPlayPolicyPrefs.getSeriesAutoPinOnPlay();
 
-  static Future<void> setSeriesAutoPinOnPlay(bool enabled) async {
-    final prefs = await ProfilePreferences.instance();
-    await prefs.setBool(_seriesAutoPinOnPlayKey, enabled);
-  }
+  static Future<void> setSeriesAutoPinOnPlay(bool enabled) =>
+      QuickPlayPolicyPrefs.setSeriesAutoPinOnPlay(enabled);
 
   /// Get max number of torrents to try before giving up
   /// Default: 5, Range: 2-10
-  static Future<int> getQuickPlayMaxRetries() async {
-    final prefs = await ProfilePreferences.instance();
-    return prefs.getInt(_quickPlayMaxRetriesKey) ?? 5;
-  }
+  static Future<int> getQuickPlayMaxRetries() =>
+      QuickPlayPolicyPrefs.getQuickPlayMaxRetries();
 
-  static Future<void> setQuickPlayMaxRetries(int maxRetries) async {
-    final prefs = await ProfilePreferences.instance();
-    // Clamp between 2 and 10
-    await prefs.setInt(_quickPlayMaxRetriesKey, maxRetries.clamp(2, 10));
-  }
+  static Future<void> setQuickPlayMaxRetries(int maxRetries) =>
+      QuickPlayPolicyPrefs.setQuickPlayMaxRetries(maxRetries);
 
-  static const String _quickPlaySearchTimeoutKey = 'quick_play_search_timeout';
+  static Future<int> getQuickPlaySearchTimeout() =>
+      QuickPlayPolicyPrefs.getQuickPlaySearchTimeout();
 
-  static Future<int> getQuickPlaySearchTimeout() async {
-    final prefs = await ProfilePreferences.instance();
-    return prefs.getInt(_quickPlaySearchTimeoutKey) ?? 5;
-  }
+  static Future<void> setQuickPlaySearchTimeout(int seconds) =>
+      QuickPlayPolicyPrefs.setQuickPlaySearchTimeout(seconds);
 
-  static Future<void> setQuickPlaySearchTimeout(int seconds) async {
-    final prefs = await ProfilePreferences.instance();
-    await prefs.setInt(_quickPlaySearchTimeoutKey, seconds);
-  }
+  static Future<int> getStremioSourcesTimeout() =>
+      QuickPlayPolicyPrefs.getStremioSourcesTimeout();
 
-  static const String _stremioSourcesTimeoutKey = 'stremio_sources_timeout';
-
-  static Future<int> getStremioSourcesTimeout() async {
-    final prefs = await ProfilePreferences.instance();
-    return prefs.getInt(_stremioSourcesTimeoutKey) ?? 15;
-  }
-
-  static Future<void> setStremioSourcesTimeout(int seconds) async {
-    final prefs = await ProfilePreferences.instance();
-    await prefs.setInt(_stremioSourcesTimeoutKey, seconds);
-  }
+  static Future<void> setStremioSourcesTimeout(int seconds) =>
+      QuickPlayPolicyPrefs.setStremioSourcesTimeout(seconds);
 
   /// Clear all Quick Play Cache Fallback settings
-  static Future<void> clearQuickPlayCacheFallbackSettings() async {
-    final prefs = await ProfilePreferences.instance();
-    await prefs.remove(_quickPlayTryMultipleTorrentsKey);
-    await prefs.remove(_quickPlayMaxRetriesKey);
-    await prefs.remove(_quickPlayMovieRulesKey);
-    await prefs.remove(_quickPlaySeriesRulesKey);
-  }
+  static Future<void> clearQuickPlayCacheFallbackSettings() =>
+      QuickPlayPolicyPrefs.clearQuickPlayCacheFallbackSettings();
 
   // External Player Settings methods
 

--- a/test/quick_play_policy_prefs_origin_test.dart
+++ b/test/quick_play_policy_prefs_origin_test.dart
@@ -1,0 +1,584 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:debrify/models/quick_play_rules.dart';
+import 'package:debrify/services/profiles/profile_runtime.dart';
+import 'package:debrify/services/profiles/profile_scope.dart';
+import 'package:debrify/services/storage_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+// Public facade characterization pinned on upstream 75b53ef3.
+// No store copy, private helper invocation or production seam. Backend controls
+// only persistence transport; cached SharedPreferences values remain real SDK state.
+const movieKey = 'quick_play_movie_rules_v2';
+const seriesKey = 'quick_play_series_rules_v2';
+const honorsKey = 'quick_play_honors_filters_v1';
+const retryKey = 'quick_play_try_multiple_torrents';
+const maxKey = 'quick_play_max_retries';
+const packsKey = 'auto_bind_series_packs_on_play';
+const modeKey = 'play_button_mode';
+
+class _Observed extends InMemorySharedPreferencesStore {
+  _Observed(super.data) : super.withData();
+  final attempts = <String>[];
+  final values = <Object?>[];
+  int? failAt;
+  int? falseAt;
+  int? holdAt;
+  final entered = Completer<void>();
+  final release = Completer<void>();
+  Future<bool> _write(
+    String key,
+    Object? value,
+    Future<bool> Function() commit,
+  ) async {
+    attempts.add(key);
+    values.add(value);
+    final index = attempts.length - 1;
+    if (index == holdAt) {
+      entered.complete();
+      await release.future.timeout(const Duration(seconds: 5));
+    }
+    if (index == failAt) throw StateError('synthetic write failure');
+    if (index == falseAt) return false;
+    return commit();
+  }
+
+  @override
+  Future<bool> setValue(String valueType, String key, Object value) =>
+      _write(key, value, () => super.setValue(valueType, key, value));
+  @override
+  Future<bool> remove(String key) => _write(key, null, () => super.remove(key));
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late SharedPreferencesStorePlatform previous;
+  late _Observed backend;
+  final a = ProfileScope(
+    profileId: 'quick-policy-a',
+    dataGeneration: 1,
+    sessionEpoch: 1,
+  );
+  final b = ProfileScope(
+    profileId: 'quick-policy-b',
+    dataGeneration: 2,
+    sessionEpoch: 2,
+  );
+  const legacy = <String, Object>{
+    honorsKey: false,
+    retryKey: false,
+    maxKey: 3,
+    packsKey: false,
+    modeKey: 'smart',
+  };
+  const sentinels = <String, Object>{
+    'series_auto_pin_on_play': false,
+    'quick_play_search_timeout': 42,
+    'quick_play_vr_mode': 'auto',
+    'policy_sentinel': 'untouched',
+  };
+  final selected = QuickPlayRules.debrifyDefault(isMovie: false).copyWith(
+    preset: QuickPlayPreset.custom,
+    maxAttempts: 8,
+    tryNextOnFailure: true,
+    preferSeriesPacks: true,
+  );
+  Future<void> install(
+    Map<String, Object> data, {
+    bool committed = false,
+  }) async {
+    SharedPreferences.resetStatic();
+    backend = _Observed({
+      if (!committed)
+        for (final e in data.entries) 'flutter.${e.key}': e.value,
+      if (committed)
+        for (final scope in [a, b])
+          for (final e in data.entries)
+            'flutter.${scope.preferenceKey(e.key)}': e.value,
+    });
+    SharedPreferencesStorePlatform.instance = backend;
+    if (committed) ProfileRuntime.initializeCommitted(a);
+  }
+
+  setUp(() async {
+    previous = SharedPreferencesStorePlatform.instance;
+    ProfileRuntime.debugReset();
+    ProfileRuntime.initializeLegacy();
+    await install({...legacy, ...sentinels});
+  });
+  tearDown(() {
+    if (!backend.release.isCompleted) backend.release.complete();
+    SharedPreferences.resetStatic();
+    SharedPreferencesStorePlatform.instance = previous;
+    ProfileRuntime.debugReset();
+  });
+
+  for (final raw in ['[', '[]', 'null', '{"maxAttempts":"bad"}']) {
+    test(
+      'invalid v2 $raw falls back without normalizing stored bytes',
+      () async {
+        await install({...legacy, movieKey: raw});
+        final result = await StorageService.getQuickPlayRules(isMovie: true);
+        expect(result.preset, QuickPlayPreset.custom);
+        expect(result.useFilters, false);
+        expect(result.maxAttempts, 3);
+        expect(result.tryNextOnFailure, false);
+        expect(result.preferSeriesPacks, false);
+        expect((await SharedPreferences.getInstance()).get(movieKey), raw);
+        expect(backend.attempts, isEmpty);
+      },
+    );
+  }
+  test('wrong physical v2 type escapes before parser catch', () async {
+    await install({...legacy, movieKey: 7});
+    await expectLater(
+      StorageService.getQuickPlayRules(isMovie: true),
+      throwsA(isA<TypeError>()),
+    );
+    expect(backend.attempts, isEmpty);
+  });
+  for (final key in [honorsKey, retryKey, maxKey]) {
+    test('wrong legacy physical type $key escapes fallback', () async {
+      await install({...legacy, key: 'bad'});
+      await expectLater(
+        StorageService.getQuickPlayRules(isMovie: true),
+        throwsA(isA<TypeError>()),
+      );
+      expect(backend.attempts, isEmpty);
+    });
+  }
+  test('movie skips malformed packs legacy read; series throws', () async {
+    await install({...legacy, packsKey: 'bad'});
+    expect(
+      (await StorageService.getQuickPlayRules(isMovie: true)).preferSeriesPacks,
+      false,
+    );
+    await expectLater(
+      StorageService.getQuickPlayRules(isMovie: false),
+      throwsA(isA<TypeError>()),
+    );
+  });
+  test(
+    'existing malformed sibling is preserved by containsKey without parsing',
+    () async {
+      await install({...legacy, movieKey: 7});
+      await StorageService.setQuickPlayRules(selected, isMovie: false);
+      expect(
+        backend.attempts,
+        [seriesKey, retryKey, maxKey, packsKey].map((k) => 'flutter.$k'),
+      );
+      expect((await SharedPreferences.getInstance()).get(movieKey), 7);
+    },
+  );
+  test(
+    'missing sibling snapshots legacy BEFORE selected write and mirrors',
+    () async {
+      backend.holdAt = 0;
+      final work = StorageService.setQuickPlayRules(selected, isMovie: false);
+      await backend.entered.future;
+      final prefs = await SharedPreferences.getInstance();
+      expect(backend.attempts, ['flutter.$seriesKey']);
+      expect(prefs.getString(seriesKey), jsonEncode(selected.toJson()));
+      expect((await backend.getAll()).containsKey('flutter.$seriesKey'), false);
+      // Change real SDK cache while the durable first write is held. The sibling
+      // must use the already captured legacy values, not re-read these new ones.
+      await prefs.setInt(maxKey, 9);
+      backend.release.complete();
+      await work;
+      final sibling = jsonDecode(prefs.getString(movieKey)!) as Map;
+      expect(sibling['maxAttempts'], 3);
+      expect(sibling['tryNextOnFailure'], false);
+      expect(sibling['useFilters'], false);
+      expect(
+        backend.attempts,
+        [
+          seriesKey,
+          maxKey,
+          movieKey,
+          retryKey,
+          maxKey,
+          packsKey,
+        ].map((k) => 'flutter.$k'),
+      );
+      expect(prefs.getBool(honorsKey), false);
+    },
+  );
+  test('malformed missing-sibling legacy prevents every write', () async {
+    await install({...legacy, maxKey: 'bad'});
+    await expectLater(
+      StorageService.setQuickPlayRules(selected, isMovie: false),
+      throwsA(isA<TypeError>()),
+    );
+    expect(backend.attempts, isEmpty);
+  });
+  final ordered = [seriesKey, movieKey, retryKey, maxKey, packsKey];
+  for (var failure = 0; failure < 5; failure++) {
+    test(
+      'write throw $failure leaves only durable prefix, cached failed write remains',
+      () async {
+        backend.failAt = failure;
+        final before = await backend.getAll();
+        await expectLater(
+          StorageService.setQuickPlayRules(selected, isMovie: false),
+          throwsStateError,
+        );
+        expect(
+          backend.attempts,
+          ordered.take(failure + 1).map((k) => 'flutter.$k'),
+        );
+        final durable = await backend.getAll();
+        for (var i = 0; i < ordered.length; i++) {
+          final k = 'flutter.${ordered[i]}';
+          expect(
+            durable[k],
+            i < failure ? backend.values[i] : before[k],
+            reason: k,
+          );
+        }
+        expect(
+          (await SharedPreferences.getInstance()).get(ordered[failure]),
+          backend.values[failure],
+        );
+      },
+    );
+  }
+  test('false write is ignored and later writes continue', () async {
+    backend.falseAt = 0;
+    await StorageService.setQuickPlayRules(selected, isMovie: false);
+    expect(backend.attempts, ordered.map((k) => 'flutter.$k'));
+    expect((await backend.getAll()).containsKey('flutter.$seriesKey'), false);
+    expect(
+      (await SharedPreferences.getInstance()).getString(seriesKey),
+      jsonEncode(selected.toJson()),
+    );
+  });
+  test(
+    'captured prefs reject later writes after held write switches session',
+    () async {
+      await install({...legacy, ...sentinels}, committed: true);
+      backend.holdAt = 0;
+      final work = StorageService.setQuickPlayRules(selected, isMovie: false);
+      final failure = expectLater(work, throwsStateError);
+      await backend.entered.future;
+      ProfileRuntime.initializeCommitted(b);
+      backend.release.complete();
+      await failure;
+      expect(backend.attempts, ['flutter.${a.preferenceKey(seriesKey)}']);
+      expect((await backend.getAll())['flutter.${b.preferenceKey(maxKey)}'], 3);
+    },
+  );
+  test(
+    'restore reacquires for second rules phase after first final write',
+    () async {
+      await install({...legacy, ...sentinels}, committed: true);
+      backend.holdAt =
+          3; // movie, missing series, try, max: first phase ends here
+      final work = StorageService.restoreQuickPlayDefaults();
+      await backend.entered.future;
+      ProfileRuntime.initializeCommitted(b);
+      backend.release.complete();
+      await work;
+      expect(backend.attempts, [
+        for (final key in [movieKey, seriesKey, retryKey, maxKey])
+          'flutter.${a.preferenceKey(key)}',
+        for (final key in [
+          seriesKey,
+          movieKey,
+          retryKey,
+          maxKey,
+          packsKey,
+          honorsKey,
+          modeKey,
+        ])
+          'flutter.${b.preferenceKey(key)}',
+      ]);
+      final raw = await backend.getAll();
+      expect(raw['flutter.${a.preferenceKey(modeKey)}'], 'smart');
+      expect(raw.containsKey('flutter.${b.preferenceKey(modeKey)}'), false);
+      expect(raw['flutter.${a.preferenceKey(honorsKey)}'], false);
+      expect(raw['flutter.${b.preferenceKey(honorsKey)}'], true);
+    },
+  );
+  test(
+    'restore reacquires final honors and mode phase after series finishes',
+    () async {
+      await install({...legacy, ...sentinels}, committed: true);
+      backend.holdAt = 7;
+      final work = StorageService.restoreQuickPlayDefaults();
+      await backend.entered.future;
+      ProfileRuntime.initializeCommitted(b);
+      backend.release.complete();
+      await work;
+      expect(backend.attempts, [
+        for (final key in [
+          movieKey,
+          seriesKey,
+          retryKey,
+          maxKey,
+          seriesKey,
+          retryKey,
+          maxKey,
+          packsKey,
+        ])
+          'flutter.${a.preferenceKey(key)}',
+        for (final key in [honorsKey, modeKey])
+          'flutter.${b.preferenceKey(key)}',
+      ]);
+      final raw = await backend.getAll();
+      expect(raw['flutter.${a.preferenceKey(honorsKey)}'], false);
+      expect(raw['flutter.${a.preferenceKey(modeKey)}'], 'smart');
+      expect(raw.containsKey('flutter.${b.preferenceKey(movieKey)}'), false);
+    },
+  );
+  test(
+    'clear retains captured prefs after held remove and stops on stale scope',
+    () async {
+      await install({
+        ...legacy,
+        movieKey: '{}',
+        seriesKey: '{}',
+      }, committed: true);
+      backend.holdAt = 0;
+      final work = StorageService.clearQuickPlayCacheFallbackSettings();
+      final failure = expectLater(work, throwsStateError);
+      await backend.entered.future;
+      ProfileRuntime.initializeCommitted(b);
+      backend.release.complete();
+      await failure;
+      expect(backend.attempts, ['flutter.${a.preferenceKey(retryKey)}']);
+      expect(
+        (await backend.getAll())['flutter.${b.preferenceKey(retryKey)}'],
+        false,
+      );
+    },
+  );
+  final clearKeys = [retryKey, maxKey, movieKey, seriesKey];
+  for (final clearing in [false, true]) {
+    final keys = clearing ? clearKeys : ordered;
+    for (var held = 0; held < keys.length; held++) {
+      test(
+        '${clearing ? "clear" : "save"} profile switch at write $held',
+        () async {
+          await install({
+            ...legacy,
+            ...sentinels,
+            if (clearing) movieKey: '{}',
+            if (clearing) seriesKey: '{}',
+          }, committed: true);
+          final before = await backend.getAll();
+          backend.holdAt = held;
+          final work = clearing
+              ? StorageService.clearQuickPlayCacheFallbackSettings()
+              : StorageService.setQuickPlayRules(selected, isMovie: false);
+          // The existing facade validates before the next write, not after the
+          // final platform completion. Pin that boundary rather than adding one.
+          final observed = held == keys.length - 1
+              ? work
+              : expectLater(work, throwsStateError);
+          await backend.entered.future.timeout(const Duration(seconds: 5));
+          ProfileRuntime.initializeCommitted(b);
+          backend.release.complete();
+          await observed;
+          expect(
+            backend.attempts,
+            keys.take(held + 1).map((key) => 'flutter.${a.preferenceKey(key)}'),
+          );
+          final after = await backend.getAll();
+          for (final entry in before.entries.where(
+            (e) => e.key.startsWith('flutter.p.${b.profileId}.'),
+          )) {
+            expect(after[entry.key], entry.value, reason: entry.key);
+          }
+        },
+      );
+      test(
+        '${clearing ? "clear" : "save"} false write $held continues',
+        () async {
+          await install({
+            ...legacy,
+            if (clearing) movieKey: '{}',
+            if (clearing) seriesKey: '{}',
+          });
+          final before = await backend.getAll();
+          backend.falseAt = held;
+          if (clearing) {
+            await StorageService.clearQuickPlayCacheFallbackSettings();
+          } else {
+            await StorageService.setQuickPlayRules(selected, isMovie: false);
+          }
+          expect(backend.attempts, keys.map((key) => 'flutter.$key'));
+          final after = await backend.getAll();
+          for (var i = 0; i < keys.length; i++) {
+            final key = 'flutter.${keys[i]}';
+            expect(after[key], i == held ? before[key] : backend.values[i]);
+          }
+        },
+      );
+    }
+  }
+
+  final scalars =
+      <
+        (
+          String,
+          Object,
+          Object,
+          Future<Object> Function(),
+          Future<void> Function(Object),
+        )
+      >[
+        (
+          honorsKey,
+          true,
+          false,
+          StorageService.getQuickPlayHonorsFilters,
+          (v) => StorageService.setQuickPlayHonorsFilters(v as bool),
+        ),
+        (
+          retryKey,
+          true,
+          false,
+          StorageService.getQuickPlayTryMultipleTorrents,
+          (v) => StorageService.setQuickPlayTryMultipleTorrents(v as bool),
+        ),
+        (
+          'series_auto_pin_on_play',
+          true,
+          false,
+          StorageService.getSeriesAutoPinOnPlay,
+          (v) => StorageService.setSeriesAutoPinOnPlay(v as bool),
+        ),
+        (
+          'quick_play_search_timeout',
+          5,
+          -7,
+          StorageService.getQuickPlaySearchTimeout,
+          (v) => StorageService.setQuickPlaySearchTimeout(v as int),
+        ),
+        (
+          'stremio_sources_timeout',
+          15,
+          999,
+          StorageService.getStremioSourcesTimeout,
+          (v) => StorageService.setStremioSourcesTimeout(v as int),
+        ),
+      ];
+  for (final (key, fallback, value, read, write) in scalars) {
+    test(
+      '$key default and exact raw value are independent of rule mirrors',
+      () async {
+        await install({});
+        expect(await read(), fallback);
+        expect(backend.attempts, isEmpty);
+        await write(value);
+        expect(await read(), value);
+        expect(backend.attempts, ['flutter.$key']);
+        expect(await backend.getAll(), {'flutter.$key': value});
+        await StorageService.setQuickPlayRules(selected, isMovie: false);
+        if (key != retryKey) expect(await read(), value);
+      },
+    );
+    for (final throwing in [false, true]) {
+      test(
+        '$key failed write retains SDK cache but not durable state ($throwing)',
+        () async {
+          await install({});
+          if (throwing) {
+            backend.failAt = 0;
+            await expectLater(write(value), throwsStateError);
+          } else {
+            backend.falseAt = 0;
+            await write(value);
+          }
+          expect(await read(), value);
+          expect(await backend.getAll(), isEmpty);
+        },
+      );
+    }
+  }
+
+  test(
+    'model one-attempt rule stays distinct from scalar retry minimum',
+    () async {
+      await StorageService.setQuickPlayRules(
+        selected.copyWith(maxAttempts: 1),
+        isMovie: true,
+      );
+      expect(
+        (await StorageService.getQuickPlayRules(isMovie: true)).maxAttempts,
+        1,
+      );
+      expect(await StorageService.getQuickPlayMaxRetries(), 1);
+      await StorageService.setQuickPlayMaxRetries(1);
+      expect(await StorageService.getQuickPlayMaxRetries(), 2);
+      expect(
+        (await StorageService.getQuickPlayRules(isMovie: true)).maxAttempts,
+        1,
+      );
+    },
+  );
+  for (var failure = 0; failure <= 4; failure++) {
+    test(
+      'clear ordered prefix failure $failure preserves nonmembers',
+      () async {
+        await install({
+          ...legacy,
+          ...sentinels,
+          movieKey: '{}',
+          seriesKey: '{}',
+        });
+        backend.failAt = failure < 4 ? failure : null;
+        if (failure < 4) {
+          await expectLater(
+            StorageService.clearQuickPlayCacheFallbackSettings(),
+            throwsStateError,
+          );
+        } else {
+          await StorageService.clearQuickPlayCacheFallbackSettings();
+        }
+        expect(
+          backend.attempts,
+          clearKeys
+              .take(failure < 4 ? failure + 1 : 4)
+              .map((k) => 'flutter.$k'),
+        );
+        final raw = await backend.getAll();
+        for (var i = 0; i < 4; i++) {
+          expect(raw.containsKey('flutter.${clearKeys[i]}'), i >= failure);
+        }
+        for (final e in {
+          ...sentinels,
+          honorsKey: false,
+          packsKey: false,
+          modeKey: 'smart',
+        }.entries) {
+          expect(raw['flutter.${e.key}'], e.value);
+        }
+      },
+    );
+  }
+  test(
+    'legacy scalar clamps differ from rules and mode read does not normalize',
+    () async {
+      await install({maxKey: 99, modeKey: 'future-mode'});
+      expect(await StorageService.getQuickPlayMaxRetries(), 99);
+      expect(
+        (await StorageService.getQuickPlayRules(isMovie: true)).maxAttempts,
+        10,
+      );
+      await StorageService.setQuickPlayMaxRetries(1);
+      expect(await StorageService.getQuickPlayMaxRetries(), 2);
+      await StorageService.setQuickPlayMaxRetries(99);
+      expect(await StorageService.getQuickPlayMaxRetries(), 10);
+      await StorageService.setPlayButtonMode('future-mode');
+      expect(await StorageService.getPlayButtonMode(), 'quick');
+      expect(
+        (await SharedPreferences.getInstance()).getString(modeKey),
+        'future-mode',
+      );
+    },
+  );
+}


### PR DESCRIPTION
Moves Quick Play preference encoding and compatibility policy into a focused owner while keeping all 18 public StorageService APIs. Movie/series sibling snapshots, legacy retry mirrors, write ordering and original profile-capture boundaries remain unchanged. The existing QuickPlayRules model is retained.

Validated independently against `webdav-sync` at `75b53ef3`: 62 public characterization tests pass before and after extraction; the final Quick Play selection passes all 124 tests, including settings and remote navigation. Three mutations targeting sibling timing, auto-pin independence and profile reacquisition were caught. Scoped analysis reports no diagnostics; independent review found no confirmed regression.

The broader selection has 167 passes and one identical upstream subtitle save-receipt failure before and after extraction. No settings reorganization, new playback policy, failover feature or cache changes. This independent draft replaces only Quick Play preference storage from retired #61.
