### PR TITLE
Extract the skip-segment request session

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -50,6 +50,8 @@ right code instead of re-discovering it. Flutter app; code under `lib/{screens,s
 - WebDAV: `services/webdav_service.dart` (read/browse only — no upload yet).
 
 ## Players
+- Skip provider request/cache lifetime: `services/playback/skip_segment_session.dart`;
+  current-content guards, published segments, button and seek remain in the player host.
 - In-app player: `screens/video_player_screen.dart` 🔴 (subtitles via media_kit
   `subtitleViewConfiguration`; `_restoreTrackPreferences`/`_applyDefault*Language`; per-key D-pad
   handlers arrowUp/Down/Left/Right; duplicated Trakt+Simkl scrobble state machines). Controls overlay:

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -21,6 +21,7 @@ import '../services/resume_write_guard.dart';
 import '../models/profiles/profile_policy.dart';
 import '../services/profiles/profile_policy_guard.dart';
 import '../services/skip_segment_service.dart';
+import '../services/playback/skip_segment_session.dart';
 import '../services/analytics_service.dart';
 import '../services/pip_service.dart';
 import '../services/audio_effect_session_service.dart';
@@ -227,6 +228,13 @@ class IptvCatchupRequestGate {
 /// - Resume playback from last position
 /// - Series-aware episode ordering and tracking
 class VideoPlayerScreen extends StatefulWidget {
+  // Only native construction is substituted by host integration tests.
+  @visibleForTesting
+  static mk.Player Function(mk.PlayerConfiguration)? debugPlayerFactory;
+  @visibleForTesting
+  static mkv.VideoController Function(mk.Player, mkv.VideoControllerConfiguration)?
+      debugVideoControllerFactory;
+
   final String videoUrl;
 
   /// Optional separate audio track played alongside [videoUrl] via mpv's
@@ -1126,12 +1134,14 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   bool _skipSegmentSettingsLoaded = false;
   bool _skipSegmentsEnabled = false;
   String _skipSegmentProviderId = SkipSegmentProviders.auto;
-  SkipSegmentProvider? _skipSegmentProvider;
+  late final SkipSegmentSession _skipSegmentSession = SkipSegmentSession(
+    currentRequest: _currentSkipSegmentRequest,
+    isMounted: () => mounted,
+    loadedKey: () => _loadedSkipSegmentsKey,
+    publish: _publishSkipSegments,
+  );
   SkipSegments _skipSegments = SkipSegments.empty;
   String? _loadedSkipSegmentsKey;
-  String? _loadingSkipSegmentsKey;
-  int _skipSegmentsFetchGeneration = 0;
-  final Map<String, SkipSegments> _skipSegmentsCache = <String, SkipSegments>{};
 
   /// Whether _position/_duration describe the item currently selected, rather
   /// than the one being switched away from. The native player's equivalent is
@@ -1505,7 +1515,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     unawaited(_loadTrackingPolicy());
     unawaited(_loadSkipSegmentSettings());
     unawaited(_loadLocalCompletionThresholds());
-    MediaKitInit.ensureInitialized();
+    if (VideoPlayerScreen.debugPlayerFactory == null) {
+      MediaKitInit.ensureInitialized();
+    }
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
     // The player opens landscape — a video wants the long edge — unless the
     // user asked it to open upright, in which case the Portrait/Landscape
@@ -1562,10 +1574,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         ? storedProvider
         : SkipSegmentProviders.auto;
 
-    _skipSegmentProvider?.close();
-    _skipSegmentProvider = enabled
-        ? SkipSegmentProviders.create(providerId)
-        : null;
+    _skipSegmentSession.configure(enabled, providerId);
     _skipSegmentsEnabled = enabled;
     _skipSegmentProviderId = providerId;
     _skipSegmentSettingsLoaded = true;
@@ -1683,66 +1692,15 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   }
 
   void _syncSkipSegmentsForCurrentContent() {
-    final request = _currentSkipSegmentRequest();
-    final provider = _skipSegmentProvider;
-    if (request == null || provider == null) return;
-    if (_loadedSkipSegmentsKey == request.key ||
-        _loadingSkipSegmentsKey == request.key) {
-      return;
-    }
+    _skipSegmentSession.sync();
+  }
 
-    if (_skipSegmentsCache.containsKey(request.key)) {
-      final cached = _skipSegmentsCache[request.key]!;
-      if (mounted) {
-        setState(() {
-          _skipSegments = cached;
-          _loadedSkipSegmentsKey = request.key;
-        });
-        _syncActiveSkipSegmentUi();
-      }
-      return;
-    }
-
-    final generation = ++_skipSegmentsFetchGeneration;
-    _loadingSkipSegmentsKey = request.key;
-    provider
-        .fetch(
-          imdbId: request.imdbId,
-          season: request.season,
-          episode: request.episode,
-          duration: request.duration,
-        )
-        .then((segments) {
-          _skipSegmentsCache[request.key] = segments;
-          if (!mounted || generation != _skipSegmentsFetchGeneration) return;
-          if (_currentSkipSegmentRequest()?.key != request.key) return;
-          setState(() {
-            _skipSegments = segments;
-            _loadedSkipSegmentsKey = request.key;
-          });
-          _syncActiveSkipSegmentUi();
-        })
-        .catchError((Object error) {
-          // Missing skip data must never affect playback. Cache the miss for
-          // this session so an offline API cannot be retried on every position
-          // tick.
-          _skipSegmentsCache[request.key] = SkipSegments.empty;
-          debugPrint(
-            'SkipSegments: ${provider.displayName} fetch failed: $error',
-          );
-          if (!mounted || generation != _skipSegmentsFetchGeneration) return;
-          if (_currentSkipSegmentRequest()?.key != request.key) return;
-          setState(() {
-            _skipSegments = SkipSegments.empty;
-            _loadedSkipSegmentsKey = request.key;
-          });
-          _syncActiveSkipSegmentUi();
-        })
-        .whenComplete(() {
-          if (_loadingSkipSegmentsKey == request.key) {
-            _loadingSkipSegmentsKey = null;
-          }
-        });
+  void _publishSkipSegments(SkipSegments segments, String key) {
+    setState(() {
+      _skipSegments = segments;
+      _loadedSkipSegmentsKey = key;
+    });
+    _syncActiveSkipSegmentUi();
   }
 
   /// Forget the outgoing item's skip segments when switching playlist entries,
@@ -1752,8 +1710,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   /// The fetch cache survives on purpose: it's keyed per episode, so going
   /// back to one already looked up is instant.
   void _resetSkipSegmentState() {
-    _skipSegmentsFetchGeneration++;
-    _loadingSkipSegmentsKey = null;
+    _skipSegmentSession.reset();
     _loadedSkipSegmentsKey = null;
     _skipSegments = SkipSegments.empty;
     _skipSegmentsMediaReady = false;
@@ -2631,25 +2588,25 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   void _createPlayerInstance(AndroidVideoRendererMode rendererMode) {
     final instanceGeneration = ++_playerInstanceGeneration;
     _isReady = false;
-    final player = mk.Player(
-      configuration: mk.PlayerConfiguration(
-        logLevel: mk.MPVLogLevel.error,
-        ready: () => _onPlayerInstanceReady(instanceGeneration),
-      ),
+    final playerConfiguration = mk.PlayerConfiguration(
+      logLevel: mk.MPVLogLevel.error,
+      ready: () => _onPlayerInstanceReady(instanceGeneration),
     );
+    final player = VideoPlayerScreen.debugPlayerFactory?.call(playerConfiguration)
+        ?? mk.Player(configuration: playerConfiguration);
     _player = player;
     _playerCreated = true;
-    _videoController = mkv.VideoController(
-      player,
-      configuration: mkv.VideoControllerConfiguration(
-        vo: rendererMode.videoOutput,
-        // The tvOS escape hatch outranks the renderer mode (which is an
-        // Android concept; its decoder string is null off-Android anyway).
-        hwdec: PlatformUtil.isTvOS && _tvosForceSoftwareDecode
-            ? 'no'
-            : rendererMode.hardwareDecoder,
-      ),
+    final videoConfiguration = mkv.VideoControllerConfiguration(
+      vo: rendererMode.videoOutput,
+      // The tvOS escape hatch outranks the renderer mode (which is an
+      // Android concept; its decoder string is null off-Android anyway).
+      hwdec: PlatformUtil.isTvOS && _tvosForceSoftwareDecode
+          ? 'no'
+          : rendererMode.hardwareDecoder,
     );
+    _videoController = VideoPlayerScreen.debugVideoControllerFactory
+        ?.call(player, videoConfiguration)
+        ?? mkv.VideoController(player, configuration: videoConfiguration);
     _installTvosDecodeRemedy(player);
     _bindPlayerInstanceSubscriptions(instanceGeneration, player);
     unawaited(_installDecoderObservers(instanceGeneration, player));
@@ -10782,9 +10739,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _pikPakRetryMessage = null;
 
     _cleanupTempSubtitleFilesSync();
-    _skipSegmentsFetchGeneration++;
-    _skipSegmentProvider?.close();
-    _skipSegmentProvider = null;
+    _skipSegmentSession.close();
     _hideTimer?.cancel();
     _autosaveTimer?.cancel();
     _manualSelectionResetTimer?.cancel();

--- a/lib/services/playback/skip_segment_session.dart
+++ b/lib/services/playback/skip_segment_session.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/foundation.dart';
+
+import '../skip_segment_service.dart';
+
+typedef SkipSegmentRequest = ({
+  String imdbId,
+  int season,
+  int episode,
+  Duration duration,
+  String key,
+});
+
+/// Owns provider, pending request key, generation and session fetch cache.
+/// Published segments and their key remain owned by the player host.
+class SkipSegmentSession {
+  SkipSegmentSession({
+    required SkipSegmentRequest? Function() currentRequest,
+    required bool Function() isMounted,
+    required String? Function() loadedKey,
+    required void Function(SkipSegments, String) publish,
+  }) : _currentRequest = currentRequest,
+       _isMounted = isMounted,
+       _loadedKey = loadedKey,
+       _publish = publish;
+
+  final SkipSegmentRequest? Function() _currentRequest;
+  final bool Function() _isMounted;
+  final String? Function() _loadedKey;
+  final void Function(SkipSegments, String) _publish;
+
+  SkipSegmentProvider? _skipSegmentProvider;
+  String? _loadingSkipSegmentsKey;
+  int _skipSegmentsFetchGeneration = 0;
+  final Map<String, SkipSegments> _skipSegmentsCache = <String, SkipSegments>{};
+
+  void configure(bool enabled, String providerId) {
+    _skipSegmentProvider?.close();
+    _skipSegmentProvider = enabled
+        ? SkipSegmentProviders.create(providerId)
+        : null;
+  }
+
+  void sync() {
+    final request = _currentRequest();
+    final provider = _skipSegmentProvider;
+    if (request == null || provider == null) return;
+    if (_loadedKey() == request.key || _loadingSkipSegmentsKey == request.key) {
+      return;
+    }
+
+    if (_skipSegmentsCache.containsKey(request.key)) {
+      final cached = _skipSegmentsCache[request.key]!;
+      if (_isMounted()) {
+        _publish(cached, request.key);
+      }
+      return;
+    }
+
+    final generation = ++_skipSegmentsFetchGeneration;
+    _loadingSkipSegmentsKey = request.key;
+    provider
+        .fetch(
+          imdbId: request.imdbId,
+          season: request.season,
+          episode: request.episode,
+          duration: request.duration,
+        )
+        .then((segments) {
+          _skipSegmentsCache[request.key] = segments;
+          if (!_isMounted() || generation != _skipSegmentsFetchGeneration) {
+            return;
+          }
+          if (_currentRequest()?.key != request.key) return;
+          _publish(segments, request.key);
+        })
+        .catchError((Object error) {
+          // Missing skip data must never affect playback. Cache the miss for
+          // this session so an offline API cannot be retried on every position
+          // tick.
+          _skipSegmentsCache[request.key] = SkipSegments.empty;
+          debugPrint(
+            'SkipSegments: ${provider.displayName} fetch failed: $error',
+          );
+          if (!_isMounted() || generation != _skipSegmentsFetchGeneration) {
+            return;
+          }
+          if (_currentRequest()?.key != request.key) return;
+          _publish(SkipSegments.empty, request.key);
+        })
+        .whenComplete(() {
+          if (_loadingSkipSegmentsKey == request.key) {
+            _loadingSkipSegmentsKey = null;
+          }
+        });
+  }
+
+  void reset() {
+    _skipSegmentsFetchGeneration++;
+    _loadingSkipSegmentsKey = null;
+  }
+
+  void close() {
+    _skipSegmentsFetchGeneration++;
+    _skipSegmentProvider?.close();
+    _skipSegmentProvider = null;
+  }
+}

--- a/test/player_skip_segment_session_origin_test.dart
+++ b/test/player_skip_segment_session_origin_test.dart
@@ -1,0 +1,854 @@
+import 'dart:convert';
+import 'dart:async';
+import 'dart:io';
+import 'package:collection/collection.dart';
+import 'package:http/http.dart' as http;
+import 'package:debrify/screens/video_player/widgets/controls.dart';
+import 'package:debrify/screens/video_player_screen.dart';
+import 'package:debrify/services/mdblist/mdblist_service.dart';
+import 'package:debrify/services/debrify_tv_database.dart';
+import 'package:debrify/services/iptv_media_store.dart';
+import 'package:debrify/services/profiles/profile_runtime.dart';
+import 'package:debrify/services/secret_vault.dart';
+import 'package:debrify/services/storage_service.dart';
+import 'package:debrify/theme/app_theme.dart';
+import 'package:debrify/theme/app_theme_scope.dart';
+import 'package:debrify/utils/app_storage.dart';
+import 'package:debrify/widgets/video_output_lease.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart'
+    show DebugPrintCallback, debugPrintSynchronously;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:media_kit/media_kit.dart' as mk;
+import 'package:media_kit_video/media_kit_video.dart' as mkv;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:debrify/services/tracking_source_policy.dart';
+import 'package:debrify/services/stremio_service.dart';
+import 'package:debrify/services/stremio_subtitle_service.dart';
+import 'package:debrify/screens/video_player/widgets/skip_segment_button.dart';
+
+// Actual current-host pin: only native construction and HTTP transport are
+// substituted. Real provider parsing, position events, rendered Skip intro
+// action and seek callback execute. No private State access or fork owners.
+class _Streams extends mk.PlatformPlayer {
+  _Streams(mk.PlayerConfiguration config, this.unexpected)
+    : super(configuration: config);
+  final List<String> unexpected;
+  final events = <String>[];
+  final seeks = <(String, Duration)>[];
+  final disposalEntered = Completer<void>();
+  Future<void>? disposal;
+  bool closed = false;
+  bool readySent = false;
+  Future<void> Function(String uri)? beforeOpen;
+
+  Future<void> openMedia(mk.Playable playable, {required bool play}) async {
+    if (playable is! mk.Media) throw StateError('Expected one external media');
+    if (closed) {
+      unexpected.add('open-after-dispose:${playable.uri}');
+      throw StateError('External open after actual disposal');
+    }
+    final observer = beforeOpen;
+    if (observer != null) await observer(playable.uri);
+    events.add('open:${playable.uri}:play=$play');
+    state = state.copyWith(
+      playlist: mk.Playlist([playable]),
+      playing: play,
+      completed: false,
+      position: const Duration(seconds: 1),
+      duration: const Duration(seconds: 60),
+      width: 1280,
+      height: 720,
+      tracks: const mk.Tracks(),
+    );
+    if (!readySent) {
+      readySent = true;
+      configuration.ready!();
+    }
+    playlistController.add(state.playlist);
+    durationController.add(state.duration);
+    tracksController.add(state.tracks);
+    widthController.add(state.width);
+    heightController.add(state.height);
+    positionController.add(state.position);
+    playingController.add(play);
+  }
+
+  // External backend events, not a copy of host admission/selection policy.
+  void reportPosition(Duration value) {
+    state = state.copyWith(position: value);
+    positionController.add(value);
+  }
+
+  Future<void> attachAudio(mk.AudioTrack track) async {
+    events.add('audio:${track.id}');
+    state = state.copyWith(track: state.track.copyWith(audio: track));
+    trackController.add(state.track);
+  }
+
+  Future<void> selectSubtitle(mk.SubtitleTrack track) async {
+    events.add('subtitle:${track.id}');
+    state = state.copyWith(track: state.track.copyWith(subtitle: track));
+    trackController.add(state.track);
+  }
+
+  Future<void> changePlaying(bool playing) async {
+    events.add(playing ? 'play' : 'pause');
+    state = state.copyWith(playing: playing);
+    playingController.add(playing);
+  }
+
+  Future<void> seekTo(Duration target) async {
+    final uri = state.playlist.medias.single.uri;
+    events.add('seek:$uri:${target.inMilliseconds}');
+    seeks.add((uri, target));
+    state = state.copyWith(position: target);
+    positionController.add(target);
+  }
+
+  @override
+  Future<void> dispose() {
+    if (disposal != null) return disposal!;
+    events.add('dispose-enter');
+    disposalEntered.complete();
+    return disposal = (() async {
+      await super.dispose();
+      closed = true;
+      events.add('dispose-complete');
+    })();
+  }
+
+  Future<void> changeRate(double value) async {
+    events.add('rate:$value');
+    state = state.copyWith(rate: value);
+    rateController.add(value);
+  }
+}
+
+class _Player implements mk.Player {
+  _Player(this.backend);
+  final _Streams backend;
+  @override
+  mk.PlatformPlayer get platform => backend;
+  @override
+  set platform(mk.PlatformPlayer? value) =>
+      throw StateError('Unexpected replacement');
+  @override
+  mk.PlayerState get state => backend.state;
+  @override
+  mk.PlayerStream get stream => backend.stream;
+  @override
+  Future<void> open(mk.Playable playable, {bool play = true}) =>
+      backend.openMedia(playable, play: play);
+  @override
+  Future<void> play() => backend.changePlaying(true);
+  @override
+  Future<void> pause() => backend.changePlaying(false);
+  @override
+  Future<void> seek(Duration target) => backend.seekTo(target);
+  @override
+  Future<void> setRate(double value) => backend.changeRate(value);
+  @override
+  Future<void> dispose() => backend.dispose();
+  @override
+  Future<void> setAudioTrack(mk.AudioTrack track) => backend.attachAudio(track);
+  @override
+  Future<void> setSubtitleTrack(mk.SubtitleTrack track) =>
+      backend.selectSubtitle(track);
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    backend.unexpected.add('player:${invocation.memberName}');
+    throw StateError('Unexpected player API ${invocation.memberName}');
+  }
+}
+
+class _TexturelessVideo implements mkv.VideoController {
+  _TexturelessVideo(this.player, this.unexpected);
+  @override
+  final mk.Player player;
+  final List<String> unexpected;
+  @override
+  final platform = Completer<mkv.PlatformVideoController>();
+  @override
+  final notifier = ValueNotifier<mkv.PlatformVideoController?>(null);
+  @override
+  final id = ValueNotifier<int?>(null);
+  @override
+  final rect = ValueNotifier<Rect?>(null);
+
+  void close() {
+    notifier.dispose();
+    id.dispose();
+    rect.dispose();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    unexpected.add('video:${invocation.memberName}');
+    throw StateError('Unexpected video API ${invocation.memberName}');
+  }
+}
+
+class _Terminal {
+  final construction = <String>[];
+  final unexpected = <String>[];
+  _Streams? properties;
+  _Player? player;
+  _TexturelessVideo? video;
+
+  mk.Player createPlayer(mk.PlayerConfiguration configuration) {
+    construction.add('player');
+    expect(configuration.logLevel, mk.MPVLogLevel.error);
+    expect(configuration.ready, isNotNull);
+    if (properties != null) {
+      unexpected.add('duplicate-player-construction');
+      throw StateError('Second player outside this fixture contract');
+    }
+    properties = _Streams(configuration, unexpected);
+    return player = _Player(properties!);
+  }
+
+  mkv.VideoController createVideoController(
+    mk.Player player,
+    mkv.VideoControllerConfiguration configuration,
+  ) {
+    construction.add('video');
+    expect(player, same(this.player));
+    if (video != null) {
+      unexpected.add('duplicate-video-construction');
+      throw StateError('Second video outside this fixture contract');
+    }
+    return video = _TexturelessVideo(player, unexpected);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Canned dart:io HTTP. package:http's IOClient goes through HttpClient(), which
+// honours HttpOverrides, so this answers the host's real TVMaze service calls.
+// ---------------------------------------------------------------------------
+
+// MdblistService.instance owns this for the fresh test isolate. Unlike the
+// request-scoped TVMaze clients it is not disposed by a player/case. No IO,
+// timers, delegation or permissive responses exist behind this sentinel.
+class _IsolateRejectingClient extends http.BaseClient {
+  int requests = 0;
+  int closeCalls = 0;
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    requests++;
+    throw StateError(
+      'Unexpected disabled MDBList request ${request.method} ${request.url}',
+    );
+  }
+
+  @override
+  void close() {
+    closeCalls++;
+    throw StateError('Unexpected close of isolate-owned MDBList sentinel');
+  }
+}
+
+// External HTTP transport only. Send completion and response-body consumption
+// are separate observations; neither is a host Future or disposal join.
+class _TrackedClient extends http.BaseClient {
+  _TrackedClient(this.unexpected, this.requests, this.ordinal, this.release);
+  final List<String> unexpected;
+  final List<String> requests;
+  final int ordinal;
+  final Completer<void> release;
+  int sent = 0;
+  int closeCalls = 0;
+  bool failResponse = false;
+  int bodyStarted = 0;
+  int bodyDone = 0;
+  bool get closed => closeCalls == 1;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    sent++;
+    requests.add('${request.method} ${request.url}');
+    final uri = request.url;
+    final valid =
+        closeCalls == 0 &&
+        request.method == 'GET' &&
+        uri.scheme == 'https' &&
+        uri.host == 'api.skipdb.tv' &&
+        uri.port == 443 &&
+        uri.userInfo.isEmpty &&
+        uri.fragment.isEmpty &&
+        uri.path == '/api/segments' &&
+        const MapEquality<String, String>().equals(uri.queryParameters, {
+          'imdb_id': 'tt1234567',
+          'season': '1',
+          'episode': '1',
+          'duration': '60',
+        }) &&
+        uri.queryParametersAll.values.every((v) => v.length == 1) &&
+        request.headers.length == 1 &&
+        request.headers['accept'] == 'application/json';
+    if (!valid) {
+      unexpected.add('http:${request.method} $uri headers=${request.headers}');
+      throw StateError('Unexpected skip fixture request');
+    }
+    final requestBytes = await request.finalize().toBytes();
+    if (requestBytes.isNotEmpty) {
+      unexpected.add('nonempty-get-body');
+      throw StateError('Unexpected GET request payload');
+    }
+    await release.future;
+    return http.StreamedResponse(
+      _responseBody(),
+      200,
+      headers: {'content-type': 'application/json'},
+    );
+  }
+
+  Stream<List<int>> _responseBody() async* {
+    bodyStarted++;
+    try {
+      if (failResponse) {
+        throw const FormatException('fixture invalid response');
+      }
+      yield utf8.encode(
+        '{"segments":{"intro":{"start_ms":10000,"end_ms":20000,"match":"exact"}}}',
+      );
+    } finally {
+      bodyDone++;
+    }
+  }
+
+  @override
+  void close() {
+    closeCalls++;
+    if (closeCalls != 1) unexpected.add('duplicate-http-close');
+  }
+}
+
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+  final previousFactory = databaseFactoryOrNull;
+  Directory? fixtureRoot;
+  const window = MethodChannel('window_manager');
+  const brightness = MethodChannel('github.com/aaassseee/screen_brightness');
+  const wake =
+      'dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.toggle';
+  late _Terminal terminal;
+  late DebugPrintCallback originalPrint;
+  final observed = <String>[];
+  var phase = 'setup';
+  final requests = <String>[];
+  Object? primary;
+  StackTrace? primaryStack;
+  bool cleanupSafe = false;
+  bool contaminated = false;
+  final clients = <_TrackedClient>[];
+  final mdblistSentinel = _IsolateRejectingClient();
+  int mdblistClientConstructions = 0;
+
+  void expectIsolateClientUntouched() {
+    expect(mdblistClientConstructions, 1);
+    expect(mdblistSentinel.requests, 0);
+    expect(mdblistSentinel.closeCalls, 0);
+  }
+
+  void reportClients(String label) {
+    debugPrintSynchronously(
+      'SKIP_CLIENTS ${jsonEncode({
+        'label': label,
+        'phase': phase,
+        'mdblistFactory': mdblistClientConstructions,
+        'mdblistRequests': mdblistSentinel.requests,
+        'mdblistCloses': mdblistSentinel.closeCalls,
+        'clients': clients.map((client) => {'ordinal': client.ordinal, 'sent': client.sent, 'closes': client.closeCalls, 'bodyStarted': client.bodyStarted, 'bodyDone': client.bodyDone}).toList(),
+      })}',
+    );
+  }
+
+  int addonStarts() => observed
+      .where(
+        (s) => s == 'VideoPlayer: Fetching addon subtitles (IMDB: tt1234567)',
+      )
+      .length;
+  int addonCached() => observed
+      .where((s) => s == 'VideoPlayer: Fetched and cached 0 addon subtitles')
+      .length;
+  int addonDone() => observed
+      .where((s) => s == 'SubAuto: SKIP — zero addon subtitles fetched')
+      .length;
+  int restoredTracks() =>
+      observed.where((s) => s.startsWith('SubAuto: restore done')).length;
+
+  setUpAll(() {
+    // Public lazy singleton construction only, before per-case HTTP zones.
+    // A preinitialized/non-fresh isolate fails the exactly-one factory check.
+    http.runWithClient(
+      () {
+        expect(MdblistService.instance, same(MdblistService.instance));
+      },
+      () {
+        mdblistClientConstructions++;
+        return mdblistSentinel;
+      },
+    );
+    expectIsolateClientUntouched();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfiNoIsolate;
+  });
+  tearDownAll(() {
+    expectIsolateClientUntouched();
+    if (!contaminated) databaseFactoryOrNull = previousFactory;
+  });
+  setUp(() async {
+    if (contaminated) {
+      throw StateError('Previous fixture unsettled; process must stop');
+    }
+    expectIsolateClientUntouched();
+    cleanupSafe = false;
+    clients.clear();
+    terminal = _Terminal();
+    originalPrint = debugPrint;
+    observed.clear();
+    phase = 'setup';
+    primary = null;
+    primaryStack = null;
+    requests.clear();
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) observed.add(message);
+      originalPrint(message, wrapWidth: wrapWidth);
+    };
+    SharedPreferences.setMockInitialValues({});
+    ProfileRuntime.debugReset();
+    ProfileRuntime.initializeLegacy();
+    SecretVault.debugReset(deviceIdOverride: 'skip-terminal-origin');
+    StorageService.resetProfileCaches();
+    final root = await Directory(
+      '.dart_tool',
+    ).absolute.createTemp('skip-terminal-');
+    fixtureRoot = root;
+    AppStorage.debugOverride(documents: root, support: root, cache: root);
+    await DebrifyTvDatabase.instance.debugResetScopeState();
+    IptvMediaStore.debugResetMigration();
+    await DebrifyTvDatabase.instance.database;
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(window, (
+      call,
+    ) async {
+      switch (call.method) {
+        case 'setFullScreen':
+        case 'setBounds':
+          return null;
+        case 'getBounds':
+          return {'x': 0.0, 'y': 0.0, 'width': 1280.0, 'height': 720.0};
+        case 'isFullScreen':
+          return false;
+        default:
+          terminal.unexpected.add('window:${call.method}');
+          throw StateError('Unexpected window call ${call.method}');
+      }
+    });
+    binding.defaultBinaryMessenger.setMockMessageHandler(
+      wake,
+      (_) async => const StandardMessageCodec().encodeMessage([null]),
+    );
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(brightness, (
+      call,
+    ) async {
+      if (call.method == 'resetApplicationScreenBrightness') return null;
+      terminal.unexpected.add('brightness:${call.method}');
+      throw StateError('Unexpected brightness ${call.method}');
+    });
+    VideoPlayerScreen.debugPlayerFactory = terminal.createPlayer;
+    VideoPlayerScreen.debugVideoControllerFactory =
+        terminal.createVideoController;
+  });
+  tearDown(() async {
+    if (!cleanupSafe) {
+      contaminated = true;
+      debugPrint = originalPrint;
+      debugPrintSynchronously(
+        'SKIP_UNSETTLED resources retained at $fixtureRoot',
+      );
+      // Do not reset globals/close DB/delete files beneath unresolved work.
+      // Subsequent setUp fails before changing any of these resources.
+      return;
+    }
+    var resourcesClosed = false;
+    try {
+      // A failed close must NOT fall through to global/profile/factory reset.
+      await DebrifyTvDatabase.instance.debugResetScopeState();
+      terminal.video?.close();
+      final root = fixtureRoot;
+      if (root != null) {
+        final parent = await root.parent.resolveSymbolicLinks();
+        expect(parent, await Directory('.dart_tool').resolveSymbolicLinks());
+        await root.delete(recursive: true);
+        fixtureRoot = null;
+      }
+      expect(VideoPlayerScreen.debugPlayerFactory, terminal.createPlayer);
+      expectIsolateClientUntouched();
+      resourcesClosed = true;
+    } catch (error, stack) {
+      contaminated = true;
+      cleanupSafe = false;
+      debugPrintSynchronously(
+        'SKIP_RESOURCE_CLOSE_FAILURE $error\n$stack root=$fixtureRoot',
+      );
+      if (primary != null) Error.throwWithStackTrace(primary!, primaryStack!);
+      rethrow;
+    } finally {
+      debugPrint = originalPrint;
+      if (resourcesClosed) {
+        IptvMediaStore.debugResetMigration();
+        VideoPlayerScreen.debugPlayerFactory = null;
+        VideoPlayerScreen.debugVideoControllerFactory = null;
+        binding.defaultBinaryMessenger.setMockMethodCallHandler(window, null);
+        binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          brightness,
+          null,
+        );
+        binding.defaultBinaryMessenger.setMockMessageHandler(wake, null);
+        StorageService.resetProfileCaches();
+        AppStorage.debugReset();
+        ProfileRuntime.debugReset();
+        SecretVault.debugReset();
+      }
+    }
+  });
+
+  // Fixed feasibility bound: 80 frame/event turns per phase, 50ms per frame.
+  // The root event turn permits real SQLite/file Futures, with no sleep.
+  Future<void> reach(WidgetTester tester, bool Function() predicate) async {
+    for (var i = 0; i < 80 && !predicate(); i++) {
+      await tester.runAsync(() => Future<void>(() {}));
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    expect(predicate(), isTrue, reason: 'Phase did not complete: $phase');
+  }
+
+  for (final outcome in ['success', 'failure', 'dispose']) {
+    testWidgets(
+      'actual SkipDB held request: $outcome',
+      (tester) async {
+        const mediaUrl = 'https://skip-fixture.invalid/Example.S01E01.mp4';
+        final release = Completer<void>();
+        var mountStarted = false;
+        tester.view.physicalSize = const Size(1280, 720);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        Controls controls() =>
+            tester.widget<Controls>(find.byType(Controls).first);
+        bool addonTail() =>
+            addonStarts() == 1 &&
+            addonCached() == 1 &&
+            addonDone() == 1 &&
+            restoredTracks() == 1;
+        void expectNoErrorLogs() {
+          expect(
+            observed.where(
+              (s) =>
+                  s.startsWith('SubAuto: ABORT') ||
+                  outcome != 'failure' &&
+                      s.startsWith('SkipSegments:') &&
+                      s.contains('fetch failed') ||
+                  s.startsWith('SubAuto: auto-select FAILED with exception:') ||
+                  s.contains('Error fetching addon subtitles'),
+            ),
+            isEmpty,
+          );
+        }
+
+        await http.runWithClient(
+          () async {
+            try {
+              phase = 'public preference and authorized empty-addon setup';
+              final policy = await tester.runAsync(() async {
+                await StorageService.setSkipSegmentsEnabled(true);
+                await StorageService.setSkipSegmentProvider('skipdb');
+                await StorageService.setTrackingScrobbleTargets({});
+                await StorageService.setWatchProgressSource(
+                  WatchProgressSource.local,
+                );
+                await StorageService.setHomeTickSources({});
+                await StremioService.instance.clearAllAddons();
+                expect(
+                  await StremioService.instance.getEnabledAddons(),
+                  isEmpty,
+                );
+                expect(
+                  await StremioSubtitleService.instance.getSubtitleAddons(),
+                  isEmpty,
+                );
+                expect(await StorageService.getSkipSegmentsEnabled(), isTrue);
+                expect(await StorageService.getSkipSegmentProvider(), 'skipdb');
+                return TrackingSourcePolicy.load();
+              });
+              expect(policy, isNotNull);
+              expect(policy!.scrobbleTargets, {TrackingSource.local});
+              expect(policy.progressSource, WatchProgressSource.local);
+              phase = 'direct positive IMDb ready video; held skip HTTP';
+              mountStarted = true;
+              await tester.pumpWidget(
+                MaterialApp(
+                  builder: (_, child) => AppThemeScope(
+                    theme: AppThemes.byId('spotlight'),
+                    child: child!,
+                  ),
+                  home: const VideoPlayerScreen(
+                    videoUrl: mediaUrl,
+                    title: 'Example.S01E01.mp4',
+                    contentType: 'series',
+                    contentTitle: 'Example',
+                    contentImdbId: 'tt1234567',
+                    contentSeason: 1,
+                    contentEpisode: 1,
+                    traktScrobble: false,
+                    simklScrobble: false,
+                    mdblistScrobble: false,
+                  ),
+                ),
+              );
+              await reach(
+                tester,
+                () =>
+                    clients.length == 1 &&
+                    clients.single.sent == 1 &&
+                    find.byType(mkv.Video).evaluate().length == 1,
+              );
+              expect(
+                tester.widget<mkv.Video>(find.byType(mkv.Video)).controller,
+                same(terminal.video),
+              );
+              expect(terminal.construction, ['player', 'video']);
+              expect(
+                terminal.properties!.events.where((e) => e.startsWith('open:')),
+                ['open:$mediaUrl:play=true'],
+              );
+              expect(clients.single.bodyStarted, 0);
+              expect(clients.single.bodyDone, 0);
+              expect(find.byType(SkipSegmentButton), findsNothing);
+
+              phase =
+                  'same public position events while provider producer held';
+              // Controls is gated during startup restoration. These are delivered
+              // public stream events, NOT per-event Controls-clock assertions.
+              terminal.properties!.reportPosition(const Duration(seconds: 15));
+              await tester.runAsync(() => Future<void>(() {}));
+              await tester.pump(const Duration(milliseconds: 50));
+              terminal.properties!.reportPosition(const Duration(seconds: 16));
+              await tester.runAsync(() => Future<void>(() {}));
+              await tester.pump(const Duration(milliseconds: 50));
+              terminal.properties!.reportPosition(const Duration(seconds: 15));
+              await tester.runAsync(() => Future<void>(() {}));
+              await tester.pump(const Duration(milliseconds: 50));
+              expect(clients, hasLength(1));
+              expect(clients.single.sent, 1);
+              expect(clients.single.bodyStarted, 0);
+              expect(requests, hasLength(1));
+              expect(find.byType(SkipSegmentButton), findsNothing);
+
+              if (outcome == 'success') {
+                phase =
+                    'release actual HTTP body; real parser and rendered action';
+                release.complete();
+                await reach(
+                  tester,
+                  () =>
+                      clients.single.bodyDone == 1 &&
+                      find.byType(SkipSegmentButton).evaluate().length == 1,
+                );
+                expect(find.text('Skip intro »'), findsOneWidget);
+                expect(clients.single.bodyStarted, 1);
+                expect(terminal.properties!.seeks, isEmpty);
+                await tester.tap(find.text('Skip intro »'));
+                await reach(
+                  tester,
+                  () => terminal.properties!.seeks.contains((
+                    mediaUrl,
+                    const Duration(seconds: 20),
+                  )),
+                );
+                expect(terminal.properties!.seeks, [
+                  (mediaUrl, const Duration(seconds: 20)),
+                ]);
+                expect(requests, hasLength(1));
+                phase =
+                    'explicit empty-track timer frontier after HTTP and skip proof';
+                expect(
+                  observed.where(
+                    (s) => s.startsWith(
+                      'SubAuto: _restoreTrackPreferences entered (token=',
+                    ),
+                  ),
+                  hasLength(1),
+                );
+                expect(clients.single.bodyDone, 1);
+                final subtitleClockBefore = binding.clock.now();
+                // Source: waitForSubtitleTracks is 50 chained 100ms fake-zone delays.
+                // Pinned fake_async elapse executes due timers and their microtasks.
+                // This advances that timer frontier, not real prefs/DB Future work.
+                await tester.pump(const Duration(seconds: 5));
+                final subtitleClockAfter = binding.clock.now();
+                expect(
+                  subtitleClockAfter.difference(subtitleClockBefore),
+                  const Duration(seconds: 5),
+                );
+                debugPrintSynchronously(
+                  'SKIP_SUBTITLE_PHASE '
+                  'before=$subtitleClockBefore after=$subtitleClockAfter',
+                );
+                // Existing bounded root/event turns observe the real positive tail.
+                await reach(
+                  tester,
+                  () =>
+                      addonTail() &&
+                      find.byType(Controls).evaluate().isNotEmpty &&
+                      controls().isReady &&
+                      controls().clock.value.position ==
+                          const Duration(seconds: 20),
+                );
+                expectNoErrorLogs();
+              } else {
+                phase = 'settle independent subtitle tail before held response';
+                await tester.pump(const Duration(seconds: 5));
+                await reach(
+                  tester,
+                  () =>
+                      addonTail() &&
+                      find.byType(Controls).evaluate().isNotEmpty,
+                );
+                if (outcome == 'dispose') {
+                  await tester.pumpWidget(const SizedBox.shrink());
+                  await tester.pump(const Duration(milliseconds: 250));
+                  expect(clients.single.closed, isTrue);
+                }
+                release.complete();
+                await reach(tester, () => clients.single.bodyDone == 1);
+                await tester.runAsync(() => Future<void>(() {}));
+                await tester.pump(const Duration(milliseconds: 50));
+                expect(find.byType(SkipSegmentButton), findsNothing);
+                expect(terminal.properties!.seeks, isEmpty);
+                if (outcome == 'failure') {
+                  expect(
+                    observed.where(
+                      (line) =>
+                          line.startsWith('SkipSegments:') &&
+                          line.contains('fetch failed'),
+                    ),
+                    hasLength(1),
+                  );
+                  for (var position = 15; position < 19; position++) {
+                    terminal.properties!.reportPosition(
+                      Duration(seconds: position),
+                    );
+                    await tester.runAsync(() => Future<void>(() {}));
+                    await tester.pump(const Duration(milliseconds: 50));
+                  }
+                  expect(requests, hasLength(1));
+                  expect(find.byType(SkipSegmentButton), findsNothing);
+                  expect(find.byType(Controls), findsOneWidget);
+                } else {
+                  expect(find.byType(VideoPlayerScreen), findsNothing);
+                }
+                expectNoErrorLogs();
+              }
+            } catch (error, stack) {
+              primary = error;
+              primaryStack = stack;
+              reportClients('primary');
+              rethrow;
+            } finally {
+              try {
+                phase = 'unmount, real terminal disposal, owned HTTP body tail';
+                if (mountStarted) {
+                  await tester.pumpWidget(const SizedBox.shrink());
+                  await tester.pump(const Duration(milliseconds: 250));
+                }
+                // Always release our producer, including failed held assertions. Do
+                // not equate this completion with the host fetch chain settling.
+                if (!release.isCompleted) release.complete();
+                final backend = terminal.properties;
+                if (backend != null) {
+                  await tester.runAsync(() async {
+                    await backend.disposalEntered.future.timeout(
+                      const Duration(seconds: 5),
+                    );
+                    await backend.disposal!.timeout(const Duration(seconds: 5));
+                  });
+                  expect(backend.closed, isTrue);
+                }
+                await reach(
+                  tester,
+                  () =>
+                      clients.length == 1 &&
+                      clients.single.sent == 1 &&
+                      clients.single.bodyDone == 1 &&
+                      clients.single.closed &&
+                      addonTail(),
+                );
+                final counts = (
+                  clients.length,
+                  requests.length,
+                  clients.single.sent,
+                  clients.single.bodyStarted,
+                  clients.single.bodyDone,
+                  clients.single.closeCalls,
+                  addonStarts(),
+                  addonCached(),
+                  addonDone(),
+                  restoredTracks(),
+                );
+                final seeks = List.of(backend!.seeks);
+                await tester.pump(const Duration(milliseconds: 800));
+                expect((
+                  clients.length,
+                  requests.length,
+                  clients.single.sent,
+                  clients.single.bodyStarted,
+                  clients.single.bodyDone,
+                  clients.single.closeCalls,
+                  addonStarts(),
+                  addonCached(),
+                  addonDone(),
+                  restoredTracks(),
+                ), counts);
+                expect(backend.seeks, seeks);
+                expect(backend.closed, isTrue);
+                expect(VideoOutputLease.isHeld, isFalse);
+                expect(terminal.unexpected, isEmpty);
+                expectNoErrorLogs();
+                expectIsolateClientUntouched();
+                reportClients('finite-successful-cleanup');
+                cleanupSafe = true;
+              } catch (error, stack) {
+                reportClients('cleanup-failure');
+                debugPrintSynchronously('SKIP_CLEANUP $error\n$stack');
+                if (primary != null) {
+                  Error.throwWithStackTrace(primary!, primaryStack!);
+                }
+                rethrow;
+              } finally {
+                debugPrint = originalPrint;
+              }
+            }
+          },
+          () {
+            final client = _TrackedClient(
+              terminal.unexpected,
+              requests,
+              clients.length,
+              release,
+            );
+            client.failResponse = outcome == 'failure';
+            clients.add(client);
+            return client;
+          },
+        );
+      },
+      timeout: const Timeout(Duration(seconds: 45)),
+    );
+  }
+}

--- a/test/skip_segment_session_test.dart
+++ b/test/skip_segment_session_test.dart
@@ -1,0 +1,317 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:debrify/services/playback/skip_segment_session.dart';
+import 'package:debrify/services/skip_segment_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+// Transport boundary only: the production provider constructs requests and
+// parses response bodies. The fixture never copies session selection logic.
+class _Transport extends http.BaseClient {
+  final requests = <http.BaseRequest>[];
+  final replies = <Completer<http.StreamedResponse>>[];
+  int closes = 0;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    requests.add(request);
+    final reply = Completer<http.StreamedResponse>();
+    replies.add(reply);
+    return reply.future;
+  }
+
+  void complete(int index, {int endSeconds = 20}) {
+    replies[index].complete(
+      http.StreamedResponse(
+        Stream.value(
+          utf8.encode(
+            jsonEncode({
+              'segments': {
+                'intro': {'start_ms': 10000, 'end_ms': endSeconds * 1000},
+              },
+            }),
+          ),
+        ),
+        200,
+      ),
+    );
+  }
+
+  @override
+  void close() {
+    closes++;
+  }
+}
+
+SkipSegmentRequest request(int episode) => (
+  imdbId: 'tt1234567',
+  season: 1,
+  episode: episode,
+  duration: const Duration(seconds: 60),
+  key: 'skipdb:tt1234567:1:$episode:60',
+);
+
+void main() {
+  late SkipSegmentSession session;
+  late _Transport transport;
+  SkipSegmentRequest? current;
+  String? loaded;
+  bool mounted = true;
+  final publications = <(String, SkipSegments)>[];
+
+  // An event turn settles the real provider's response stream and the session
+  // callback chain. No native time, sleeps, or copied completion algorithm.
+  Future<void> drain() async {
+    for (var i = 0; i < 10; i++) {
+      await Future<void>(() {});
+    }
+  }
+
+  void configure(bool enabled, {_Transport? client}) {
+    http.runWithClient(
+      () => session.configure(enabled, 'skipdb'),
+      () => client ?? transport,
+    );
+  }
+
+  setUp(() {
+    transport = _Transport();
+    current = request(1);
+    loaded = null;
+    mounted = true;
+    publications.clear();
+    session = SkipSegmentSession(
+      currentRequest: () => current,
+      isMounted: () => mounted,
+      loadedKey: () => loaded,
+      publish: (segments, key) {
+        loaded = key;
+        publications.add((key, segments));
+      },
+    );
+  });
+  tearDown(() async {
+    mounted = false;
+    session.close();
+    for (final reply in transport.replies) {
+      if (!reply.isCompleted) {
+        reply.complete(http.StreamedResponse(const Stream.empty(), 404));
+      }
+    }
+    await drain();
+  });
+
+  test('missing provider or current identity starts no transport', () {
+    session.sync();
+    configure(true);
+    current = null;
+    session.sync();
+    expect(transport.requests, isEmpty);
+    expect(publications, isEmpty);
+  });
+
+  test(
+    'pending and loaded requests deduplicate real provider traffic',
+    () async {
+      configure(true);
+      session.sync();
+      session.sync();
+      expect(transport.requests, hasLength(1));
+      expect(transport.requests.single.url.queryParameters, {
+        'imdb_id': 'tt1234567',
+        'season': '1',
+        'episode': '1',
+        'duration': '60',
+      });
+      transport.complete(0);
+      await drain();
+      expect(publications.single.$2.intro!.end, const Duration(seconds: 20));
+      session.sync();
+      expect(transport.requests, hasLength(1));
+      expect(publications, hasLength(1));
+    },
+  );
+
+  test(
+    'reset retains cache for synchronous revisit without another fetch',
+    () async {
+      configure(true);
+      session.sync();
+      transport.complete(0);
+      await drain();
+      session.reset();
+      loaded = null;
+      session.sync();
+      expect(transport.requests, hasLength(1));
+      expect(publications, hasLength(2));
+      expect(publications.last.$2, same(publications.first.$2));
+    },
+  );
+
+  test(
+    'out-of-order old success caches but does not replace newer episode',
+    () async {
+      configure(true);
+      session.sync();
+      current = request(2);
+      session.sync();
+      transport.complete(1, endSeconds: 30);
+      await drain();
+      transport.complete(0);
+      await drain();
+      expect(publications, hasLength(1));
+      expect(publications.single.$1, request(2).key);
+      expect(publications.single.$2.intro!.end, const Duration(seconds: 30));
+      current = request(1);
+      loaded = null;
+      session.sync();
+      expect(publications.last.$2.intro!.end, const Duration(seconds: 20));
+      expect(transport.requests, hasLength(2));
+    },
+  );
+
+  test(
+    'live identity guard rejects completion even without another fetch',
+    () async {
+      configure(true);
+      session.sync();
+      current = request(2);
+      transport.complete(0);
+      await drain();
+      expect(publications, isEmpty);
+      current = request(1);
+      session.sync();
+      expect(publications.single.$1, request(1).key);
+      expect(transport.requests, hasLength(1));
+    },
+  );
+
+  test(
+    'reset invalidates held same-key success but still caches its result',
+    () async {
+      configure(true);
+      session.sync();
+      session.reset();
+      transport.complete(0);
+      await drain();
+      expect(publications, isEmpty);
+      session.sync();
+      expect(publications.single.$2.intro!.end, const Duration(seconds: 20));
+      expect(transport.requests, hasLength(1));
+    },
+  );
+
+  test(
+    'transport failure publishes an empty result and caches the miss',
+    () async {
+      configure(true);
+      session.sync();
+      transport.replies.single.completeError(
+        const FormatException('invalid JSON'),
+      );
+      await drain();
+      expect(publications.single.$2, same(SkipSegments.empty));
+      session.reset();
+      loaded = null;
+      session.sync();
+      expect(publications, hasLength(2));
+      expect(publications.last.$2, same(SkipSegments.empty));
+      expect(transport.requests, hasLength(1));
+    },
+  );
+
+  test(
+    'reset invalidates held error and retains the empty cache entry',
+    () async {
+      configure(true);
+      session.sync();
+      session.reset();
+      transport.replies.single.completeError(
+        const FormatException('invalid JSON'),
+      );
+      await drain();
+      expect(publications, isEmpty);
+      session.sync();
+      expect(publications.single.$2, same(SkipSegments.empty));
+      expect(transport.requests, hasLength(1));
+    },
+  );
+
+  for (final failure in [false, true]) {
+    test(
+      'unmounted host receives no late ${failure ? 'failure' : 'success'} publication',
+      () async {
+        configure(true);
+        session.sync();
+        mounted = false;
+        if (failure) {
+          transport.replies.single.completeError(
+            const FormatException('invalid JSON'),
+          );
+        } else {
+          transport.complete(0);
+        }
+        await drain();
+        session.sync();
+        expect(publications, isEmpty);
+        expect(transport.requests, hasLength(1));
+      },
+    );
+  }
+
+  test(
+    'close invalidates in-flight result and releases provider once',
+    () async {
+      configure(true);
+      session.sync();
+      session.close();
+      expect(transport.closes, 1);
+      transport.complete(0);
+      await drain();
+      session.sync();
+      session.close();
+      expect(publications, isEmpty);
+      expect(transport.requests, hasLength(1));
+      expect(transport.closes, 1);
+    },
+  );
+
+  test(
+    'reconfigure closes previous provider and disabled mode starts no fetch',
+    () async {
+      configure(true);
+      final replacement = _Transport();
+      configure(true, client: replacement);
+      expect(transport.closes, 1);
+      configure(false);
+      expect(replacement.closes, 1);
+      session.sync();
+      expect(transport.requests, isEmpty);
+      expect(replacement.requests, isEmpty);
+    },
+  );
+
+  test(
+    'legacy same-key cleanup exposes old cached result while replacement is pending',
+    () async {
+      configure(true);
+      session.sync();
+      session.reset();
+      session.sync();
+      expect(transport.requests, hasLength(2));
+      transport.complete(0);
+      await drain();
+      expect(publications, isEmpty);
+      // Preserve the current host's key-only whenComplete quirk: completion of
+      // the old request clears the same-key loading marker for its replacement.
+      session.sync();
+      expect(publications.single.$2.intro!.end, const Duration(seconds: 20));
+      expect(transport.requests, hasLength(2));
+      transport.complete(1, endSeconds: 30);
+      await drain();
+      expect(publications, hasLength(2));
+      expect(publications.last.$2.intro!.end, const Duration(seconds: 30));
+    },
+  );
+}


### PR DESCRIPTION
Extracts skip-segment provider requests, cache and generation state into a small session owner. The player still builds current-content requests, publishes visible segments and handles the Skip button and seek action. Existing deduplication, failure-as-empty caching, stale completion and reset behavior are preserved.

The original host/provider/UI baseline passes 22 tests. The extracted selection passes 35 tests, independently rerun and green after mutation restoration. Worker and reviewer each rejected four compiled behavioral mutations covering invalidation, cache retention, provider disposal and the rendered Skip action. Analysis retains 65 existing host diagnostics with no new findings or errors.

Independent slice of retired #61, with no transport/resume/controller foundation dependency. Native construction is substituted in host tests; native decoding/device verification is not claimed. The pre-existing same-key cleanup quirk is characterized and retained.
